### PR TITLE
Add libp2p implementation-level textbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+.playwright-mcp/

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -1,0 +1,179 @@
+# Chapter 1: Overview
+
+## What is libp2p?
+
+libp2p is a modular networking stack for peer-to-peer applications. Originally
+extracted from IPFS, it provides a framework of composable protocols that handle
+peer discovery, transport, security, multiplexing, and application-level routing
+without relying on centralized infrastructure.
+
+Unlike traditional client-server networking where a server has a fixed address
+and clients connect to it, libp2p peers are equal participants that can both
+initiate and accept connections. Each peer is identified by a cryptographic key
+pair rather than an IP address, enabling identity to persist across network
+changes.
+
+## Design Principles
+
+### 1. Transport Agnosticism
+
+libp2p abstracts the underlying transport mechanism. A peer can communicate over
+TCP, QUIC, WebSocket, WebRTC, or WebTransport — all using the same application
+code. Transports are selected at runtime based on the addresses of the remote
+peer.
+
+### 2. Encryption by Default
+
+Every libp2p connection is encrypted and authenticated. There is no unencrypted
+mode. The security protocol (Noise or TLS 1.3) is negotiated during connection
+establishment, and the remote peer's identity is cryptographically verified.
+
+### 3. Peer Identity over Network Identity
+
+Peers are identified by their Peer ID (a hash of their public key), not by
+their IP address or port. This means a peer's identity is stable even as it
+moves between networks, changes IP addresses, or listens on different ports.
+
+### 4. Protocol Multiplexing
+
+Multiple application protocols can share a single connection through stream
+multiplexing. Each protocol negotiation happens at the stream level, allowing
+a single TCP connection to carry DHT queries, pubsub messages, and file
+transfers simultaneously.
+
+### 5. Modular and Composable
+
+Each layer of the stack is a replaceable module:
+- Transports: TCP, QUIC, WebSocket, WebRTC, WebTransport
+- Security: Noise, TLS 1.3
+- Multiplexing: Yamux, mplex
+- Discovery: mDNS, DHT, Rendezvous
+- Routing: Kademlia DHT
+- Messaging: GossipSub
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Application Layer                        │
+│        (GossipSub, DHT, Identify, Ping, Custom, ...)        │
+├─────────────────────────────────────────────────────────────┤
+│                     Protocol Negotiation                     │
+│                   (multistream-select)                        │
+├─────────────────────────────────────────────────────────────┤
+│                    Stream Multiplexing                        │
+│                   (Yamux / mplex)                             │
+├─────────────────────────────────────────────────────────────┤
+│                     Protocol Negotiation                     │
+│                   (multistream-select)                        │
+├─────────────────────────────────────────────────────────────┤
+│                     Secure Channel                           │
+│                   (Noise / TLS 1.3)                          │
+├─────────────────────────────────────────────────────────────┤
+│                     Protocol Negotiation                     │
+│                   (multistream-select)                        │
+├─────────────────────────────────────────────────────────────┤
+│                       Transport                              │
+│              (TCP / QUIC / WebSocket / WebRTC)                │
+├─────────────────────────────────────────────────────────────┤
+│                       Network                                │
+│                    (IP / UDP / etc.)                          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Layer Stack: Connection Upgrade Pipeline
+
+When a TCP connection is established, it goes through a series of upgrades:
+
+```
+Raw TCP connection
+    │
+    ▼
+multistream-select  ──►  Negotiate security protocol
+    │
+    ▼
+Secure Channel (Noise XX handshake)
+    │
+    ▼
+multistream-select  ──►  Negotiate muxer protocol
+    │
+    ▼
+Stream Multiplexer (Yamux)
+    │
+    ▼
+Individual streams opened
+    │
+    ▼
+multistream-select  ──►  Negotiate application protocol per stream
+    │
+    ▼
+Application data exchange
+```
+
+QUIC is different — it has built-in encryption (TLS 1.3) and multiplexing, so
+no negotiation for security or muxer is needed. Streams are opened directly.
+
+## Key Abstractions
+
+### Connection
+
+A connection represents a secure, multiplexed link between two peers. It may
+wrap a TCP socket, a QUIC connection, or any other transport. Once established,
+it provides the ability to open and accept streams.
+
+### Stream
+
+A stream is a bidirectional byte channel within a connection. Streams are
+lightweight (a single connection may carry thousands) and are the unit at which
+protocol negotiation occurs. Each stream carries exactly one protocol's data.
+
+### Switch / Swarm
+
+The Switch (also called Swarm in some implementations) is the central component.
+It manages:
+- Transport listeners (accepting incoming connections)
+- Dialing out to remote peers
+- Connection upgrading (security + muxing)
+- Connection reuse (sharing a connection across multiple protocol interactions)
+- Protocol routing (dispatching incoming streams to handlers)
+
+### Peer Store
+
+The Peer Store maintains metadata about known peers:
+- Peer ID → public key mapping
+- Peer ID → known multiaddrs
+- Peer ID → supported protocols
+- Connection status and metadata
+
+## Comparison with Traditional Networking
+
+| Aspect | Client-Server | libp2p |
+|--------|--------------|--------|
+| Identity | IP address + port | Cryptographic Peer ID |
+| Discovery | DNS / hardcoded | DHT, mDNS, Rendezvous |
+| NAT | Port forwarding | Hole punching, Circuit Relay |
+| Security | Optional (TLS) | Mandatory (Noise/TLS) |
+| Multiplexing | HTTP/2 or custom | Yamux (built-in) |
+| Addressing | `host:port` | Multiaddr (composable) |
+| Topology | Star / hub-spoke | Mesh / arbitrary |
+
+## Reference Implementations
+
+| Language | Repository | Maturity |
+|----------|------------|----------|
+| Go | [go-libp2p](https://github.com/libp2p/go-libp2p) | Most mature, reference impl |
+| Rust | [rust-libp2p](https://github.com/libp2p/rust-libp2p) | Production-ready, strong types |
+| JavaScript | [js-libp2p](https://github.com/libp2p/js-libp2p) | Browser-compatible |
+| Nim | [nim-libp2p](https://github.com/vacp2p/nim-libp2p) | Smaller, readable |
+| **Haskell** | **libp2p-hs** (this project) | **In development** |
+
+The Go and Rust implementations are the primary references for understanding
+behavior not fully specified in the written specs. When the spec is ambiguous,
+these implementations define the de facto standard.
+
+## Spec References
+
+- libp2p specs repository: https://github.com/libp2p/specs
+- Introduction: https://docs.libp2p.io/concepts/introduction/
+- Transports: https://docs.libp2p.io/concepts/transports/overview/
+- Protocols: https://docs.libp2p.io/concepts/fundamentals/protocols/

--- a/docs/02-peer-identity.md
+++ b/docs/02-peer-identity.md
@@ -1,0 +1,281 @@
+# Chapter 2: Peer Identity
+
+Peer identity is the foundation of libp2p. Every peer has a cryptographic key
+pair. The public key is encoded in protobuf, hashed, and the result is the
+peer's unique identity (Peer ID). This chapter covers every detail needed to
+implement key serialization, Peer ID derivation, and signing.
+
+## Protobuf Definitions
+
+```protobuf
+syntax = "proto2";
+
+enum KeyType {
+    RSA = 0;
+    Ed25519 = 1;
+    Secp256k1 = 2;
+    ECDSA = 3;
+}
+
+message PublicKey {
+    required KeyType Type = 1;
+    required bytes Data = 2;
+}
+
+message PrivateKey {
+    required KeyType Type = 1;
+    required bytes Data = 2;
+}
+```
+
+Source: https://github.com/libp2p/go-libp2p/blob/master/core/crypto/pb/crypto.proto
+
+**Critical:** `PrivateKey` messages are **never transmitted over the wire**. They
+are only used for on-disk storage. `PublicKey` messages are transmitted during
+Noise handshakes and in Identify messages.
+
+## Deterministic Protobuf Encoding
+
+libp2p requires **deterministic encoding** of the `PublicKey` message. Standard
+protobuf allows non-deterministic serialization, so implementations must enforce:
+
+1. **Minimal varint encoding**: Use the fewest bytes possible for each varint.
+2. **Tag order**: Fields must be serialized in field number order (Type=1 first,
+   then Data=2).
+3. **All fields present**: Both `Type` and `Data` must be included.
+4. **No extra fields**: No unknown fields or extensions.
+
+This is critical because the serialized bytes are hashed to produce the Peer ID.
+Non-deterministic encoding would produce different Peer IDs for the same key.
+
+### Encoding Walkthrough
+
+For an Ed25519 public key (32 bytes), the protobuf encoding is:
+
+```
+Field 1 (Type), varint, value 1 (Ed25519):
+  Tag:  0x08  (field 1, wire type 0 = varint)
+  Data: 0x01  (KeyType.Ed25519 = 1)
+
+Field 2 (Data), bytes, 32-byte key:
+  Tag:  0x12  (field 2, wire type 2 = length-delimited)
+  Len:  0x20  (32 in varint)
+  Data: <32 bytes of Ed25519 public key>
+
+Total: 2 + 2 + 32 = 36 bytes
+```
+
+## Key Types
+
+### Ed25519 (KeyType = 1) — Recommended
+
+Implementations MUST support Ed25519. This is the default key type for new peers.
+
+**Public key encoding (`Data` field):**
+- Raw 32-byte Ed25519 public key
+- No additional wrapping or encoding
+
+**Private key encoding (`Data` field):**
+- Preferred (64 bytes): `[32-byte private key seed][32-byte public key]`
+- Legacy (96 bytes): `[32-byte private key seed][32-byte public key][32-byte public key]`
+  - If encountered, verify both copies of the public key match; error if they differ
+
+**Signing:**
+- Standard Ed25519 signature as per [RFC 8032 §5.1](https://tools.ietf.org/html/rfc8032#section-5.1)
+- Sign the raw message (no pre-hashing)
+- Signature is 64 bytes
+
+### RSA (KeyType = 0)
+
+Implementations SHOULD support RSA for interoperability with the IPFS DHT and
+bootstrap nodes.
+
+**Public key encoding (`Data` field):**
+- DER-encoded PKIX (SubjectPublicKeyInfo) format
+- This is the standard ASN.1 DER encoding of an RSA public key
+
+**Private key encoding (`Data` field):**
+- PKCS#1 ASN.1 DER encoding
+
+**Signing:**
+1. Hash the message with SHA-256
+2. Sign with RSASSA-PKCS1-v1_5 ([RFC 3447 §8.2](https://tools.ietf.org/html/rfc3447#section-8.2))
+
+**Note:** RSA keys are large. A 2048-bit RSA public key serializes to ~294 bytes
+in protobuf, which means the Peer ID will use SHA-256 multihash (not identity).
+
+### Secp256k1 (KeyType = 2) — Optional
+
+**Public key encoding (`Data` field):**
+- Standard Bitcoin compressed EC point encoding (33 bytes)
+- Format: `0x02` or `0x03` prefix + 32-byte X coordinate
+
+**Private key encoding (`Data` field):**
+- Raw 32-byte scalar
+
+**Signing:**
+1. Hash the message with SHA-256
+2. Sign using ECDSA with the secp256k1 curve
+3. Encode signature in DER format per [BIP-0062](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki)
+
+### ECDSA (KeyType = 3) — Optional
+
+Uses the NIST P-256 curve.
+
+**Public key encoding (`Data` field):**
+- ASN.1 DER encoding (SubjectPublicKeyInfo)
+
+**Private key encoding (`Data` field):**
+- DER-encoded PKIX format
+
+**Signing:**
+1. Hash the message with SHA-256
+2. Sign with deterministic ECDSA ([RFC 6979](https://tools.ietf.org/html/rfc6979))
+3. Encode signature in DER-encoded ASN.1
+
+## Peer ID Derivation
+
+A Peer ID is a [multihash](https://github.com/multiformats/multihash) of the
+serialized `PublicKey` protobuf message.
+
+### Algorithm
+
+```
+1. Serialize the PublicKey message to bytes (deterministic encoding)
+2. If len(serialized) <= 42:
+     peer_id = multihash(identity, serialized)
+     // identity multihash = 0x00 <varint length> <raw bytes>
+3. If len(serialized) > 42:
+     digest = SHA-256(serialized)
+     peer_id = multihash(sha2-256, digest)
+     // sha2-256 multihash = 0x12 0x20 <32-byte digest>
+```
+
+### Which Keys Use Identity vs SHA-256?
+
+| Key Type | Serialized Size | Multihash |
+|----------|----------------|-----------|
+| Ed25519 | 36 bytes | **Identity** (key embedded in Peer ID) |
+| RSA 2048 | ~294 bytes | SHA-256 |
+| RSA 4096 | ~550 bytes | SHA-256 |
+| Secp256k1 | 37 bytes | **Identity** (key embedded in Peer ID) |
+| ECDSA P-256 | ~93 bytes | SHA-256 |
+
+Ed25519 keys serialize to 36 bytes (2 bytes tag+type + 2 bytes tag+length + 32
+bytes key), which is ≤ 42, so the identity multihash is used. This means the
+full public key is embedded directly in the Peer ID — no hash lookup needed to
+recover the key.
+
+### Multihash Format
+
+```
+Multihash = <hash-function-code><digest-size><digest>
+```
+
+All values are unsigned varints (LEB128), except the digest which is raw bytes.
+
+**Identity multihash** (code = 0x00):
+```
+0x00 <length as varint> <raw serialized PublicKey bytes>
+```
+
+**SHA-256 multihash** (code = 0x12):
+```
+0x12 0x20 <32-byte SHA-256 digest>
+```
+
+### Worked Example: Ed25519
+
+Given an Ed25519 public key (32 bytes, hex):
+```
+1ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e
+```
+
+Step 1 — Protobuf encode:
+```
+08 01 12 20 1ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e
+```
+(36 bytes)
+
+Step 2 — 36 ≤ 42, so use identity multihash:
+```
+00 24 08 01 12 20 1ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e
+```
+(38 bytes: 0x00 = identity, 0x24 = 36, then 36 bytes of protobuf)
+
+This 38-byte multihash is the Peer ID.
+
+## String Representation
+
+### Legacy Format (base58btc)
+
+Encode the raw multihash bytes with base58btc (Bitcoin alphabet).
+
+- Ed25519 Peer IDs start with `12D3KooW...` (because the identity multihash
+  prefix `0x00 0x24 0x08 0x01...` maps to those characters)
+- SHA-256 Peer IDs start with `Qm...` or `16Uiu2HA...`
+
+Example: `12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA`
+
+### New Format (CIDv1)
+
+Encode as a CIDv1 with the `libp2p-key` multicodec (0x72):
+
+```
+CIDv1 = <multibase-prefix><cid-version><multicodec><multihash>
+       = <base32-prefix><0x01><0x72><peer-id-multihash>
+```
+
+Default multibase is base32 (lowercase, no padding), prefix `b`.
+
+Example: `bafzbeie5745rpv2m6tjyuugywy4d5ewrqgqqhfnf445he3omzpjbx5xqxe`
+
+### Decoding Rules
+
+1. If the string starts with `1` or `Qm` → base58btc-encoded multihash
+2. If the string starts with a multibase prefix → CIDv1
+   - Decode multibase
+   - Verify CID version = 1
+   - Verify multicodec = 0x72 (`libp2p-key`)
+   - Extract multihash = Peer ID
+3. Otherwise → invalid
+
+Implementations MUST support parsing both formats.
+Implementations SHOULD display using the legacy format (base58btc) until the
+CIDv1 format is widely adopted.
+
+## Test Vectors
+
+From the official spec (hex-encoded protobuf bytes):
+
+| Key | Hex Bytes |
+|-----|-----------|
+| Ed25519 private | `080112407e0830617c4a7de83925dfb2694556b12936c477a0e1feb2e148ec9da60fee7d1ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e` |
+| Ed25519 public | `080112201ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e` |
+| Secp256k1 private | `0802122053DADF1D5A164D6B4ACDB15E24AA4C5B1D3461BDBD42ABEDB0A4404D56CED8FB` |
+| Secp256k1 public | `08021221037777e994e452c21604f91de093ce415f5432f701dd8cd1a7a6fea0e630bfca99` |
+| ECDSA private | `08031279307702010104203E5B1FE9...` (see spec for full) |
+| ECDSA public | `0803125b3059301306072a8648ce3d...` (see spec for full) |
+
+For each test vector, implementations should verify:
+1. The private key can derive the corresponding public key
+2. The public key protobuf encoding matches the expected hex
+3. The Peer ID derived from the public key is correct
+
+## Haskell Implementation Notes
+
+For the Haskell implementation, consider:
+
+- **Ed25519**: Use the `crypton` or `cryptonite` library (`Crypto.PubKey.Ed25519`)
+- **RSA**: Use `crypton` (`Crypto.PubKey.RSA`) with ASN.1 via `asn1-encoding`
+- **Protobuf**: Use `proto-lens` or manual encoding (only 2 fields, manual may be simpler)
+- **Multihash**: Use or implement a small multihash library
+- **Base58**: Use the `base58-bytestring` package
+
+The protobuf encoding is simple enough (2 fields, both required) that a manual
+encoder/decoder may be preferable to a full protobuf library dependency. The
+key constraint is deterministic encoding.
+
+## Spec Reference
+
+- https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md

--- a/docs/03-addressing.md
+++ b/docs/03-addressing.md
@@ -1,0 +1,283 @@
+# Chapter 3: Addressing
+
+libp2p uses **multiaddr** (multiaddress), a self-describing network address
+format that supports composing multiple protocol layers into a single address.
+This chapter covers the binary encoding, protocol codes, and practical usage
+patterns needed for implementation.
+
+## What is Multiaddr?
+
+A multiaddr is a binary-encoded, composable network address. Unlike traditional
+`host:port` pairs, a multiaddr describes the entire protocol stack needed to
+reach a peer.
+
+Example (human-readable form):
+```
+/ip4/198.51.100.0/tcp/4001/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N
+```
+
+This says: "Connect via IPv4 address 198.51.100.0, TCP port 4001, to peer with
+the given Peer ID."
+
+## Binary Format
+
+A multiaddr is encoded as a concatenation of protocol segments:
+
+```
+<multiaddr> = (<protocol-segment>)+
+<protocol-segment> = <protocol-code> <address-bytes>
+<protocol-code> = unsigned varint
+<address-bytes> = depends on protocol (fixed-length or varint-length-prefixed)
+```
+
+### Varint Encoding
+
+Protocol codes and length prefixes use **unsigned varint** (LEB128) encoding,
+as defined by the [multiformats unsigned-varint spec](https://github.com/multiformats/unsigned-varint).
+
+```
+Value < 128:    1 byte   (value as-is, high bit = 0)
+Value < 16384:  2 bytes  (7 bits per byte, high bit = continuation flag)
+...and so on
+```
+
+Examples:
+| Value | Varint Bytes |
+|-------|-------------|
+| 4 (ip4) | `0x04` |
+| 6 (tcp) | `0x06` |
+| 421 (p2p) | `0xa5 0x03` |
+| 273 (udp) | `0x91 0x02` |
+| 460 (quic-v1) | `0xcc 0x03` |
+
+## Protocol Table
+
+Key protocols and their multiaddr encoding rules:
+
+| Protocol | Code | Code (varint) | Address Format |
+|----------|------|---------------|----------------|
+| ip4 | 4 | `04` | 4 bytes (big-endian IPv4) |
+| tcp | 6 | `06` | 2 bytes (big-endian port) |
+| udp | 273 | `91 02` | 2 bytes (big-endian port) |
+| ip6 | 41 | `29` | 16 bytes (big-endian IPv6) |
+| dns | 53 | `35` | varint-length-prefixed UTF-8 |
+| dns4 | 54 | `36` | varint-length-prefixed UTF-8 |
+| dns6 | 55 | `37` | varint-length-prefixed UTF-8 |
+| dnsaddr | 56 | `38` | varint-length-prefixed UTF-8 |
+| p2p | 421 | `a5 03` | varint-length-prefixed multihash |
+| quic-v1 | 460 | `cc 03` | 0 bytes (no address) |
+| ws | 477 | `dd 03` | 0 bytes (no address) |
+| wss | 478 | `de 03` | 0 bytes (no address) |
+| webtransport | 465 | `d1 03` | 0 bytes (no address) |
+| p2p-circuit | 290 | `a2 02` | 0 bytes (no address) |
+| noise | 454 | `c6 03` | 0 bytes (no address) |
+| yamux | 467 | `d3 03` | 0 bytes (no address) |
+
+The full registry is at: https://github.com/multiformats/multicodec/blob/master/table.csv
+
+## Address Encoding Examples
+
+### Example 1: `/ip4/127.0.0.1/tcp/4001`
+
+```
+Protocol: ip4 (code 4)
+  Code:    04
+  Address: 7f 00 00 01          (127.0.0.1 as 4 bytes)
+
+Protocol: tcp (code 6)
+  Code:    06
+  Address: 0f a1                (4001 as big-endian uint16)
+
+Binary:  04 7f000001 06 0fa1
+         (9 bytes total)
+```
+
+### Example 2: `/ip4/198.51.100.0/udp/9090/quic-v1`
+
+```
+Protocol: ip4 (code 4)
+  Code:    04
+  Address: c6 33 64 00          (198.51.100.0)
+
+Protocol: udp (code 273)
+  Code:    91 02
+  Address: 23 82                (9090 as big-endian uint16)
+
+Protocol: quic-v1 (code 460)
+  Code:    cc 03
+  Address: (none — zero-length address)
+
+Binary:  04 c6336400 9102 2382 cc03
+         (11 bytes total)
+```
+
+### Example 3: `/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW...`
+
+The `/p2p` component contains a Peer ID as a varint-length-prefixed multihash:
+
+```
+Protocol: ip4 → 04 7f000001
+Protocol: tcp → 06 0fa1
+Protocol: p2p (code 421)
+  Code:    a5 03
+  Address: <varint length of multihash><multihash bytes>
+```
+
+For an Ed25519 peer, the multihash is 38 bytes (identity multihash), so:
+```
+  Length:  26                    (38 as varint)
+  Data:    00 24 0801 1220 <32-byte Ed25519 public key>
+```
+
+### Example 4: Circuit Relay Address
+
+```
+/ip4/198.51.100.0/tcp/4001/p2p/<relay-peer-id>/p2p-circuit/p2p/<target-peer-id>
+```
+
+This means: connect to the relay peer, establish a circuit relay, then reach
+the target peer through the relay. The `/p2p-circuit` component has no address
+bytes — it acts as a marker separating the relay address from the target.
+
+## Encapsulation and Decapsulation
+
+Multiaddrs compose through **encapsulation**. A transport address can be
+encapsulated with additional protocol layers:
+
+```haskell
+-- Conceptual Haskell representation
+data Multiaddr = Multiaddr [Component]
+data Component = Component ProtocolCode ByteString
+
+-- Encapsulation = appending components
+encapsulate :: Multiaddr -> Multiaddr -> Multiaddr
+encapsulate (Multiaddr a) (Multiaddr b) = Multiaddr (a ++ b)
+
+-- Decapsulation = removing the last occurrence of a protocol and everything after it
+decapsulate :: Multiaddr -> ProtocolCode -> Multiaddr
+```
+
+## String Parsing Rules
+
+The human-readable string format follows these rules:
+
+1. Each component starts with `/`
+2. Protocol name follows (lowercase, e.g., `ip4`, `tcp`, `p2p`)
+3. If the protocol has an address, it follows after another `/`
+4. Components are concatenated
+
+```
+/ip4/127.0.0.1/tcp/4001
+ ─┬─ ─────┬─── ─┬─ ──┬─
+  │       │      │    │
+  proto   addr   proto addr
+```
+
+Parsing algorithm:
+1. Split on `/` (ignoring leading empty string)
+2. Read protocol name → look up code and address format
+3. If protocol has an address, read the next token and parse it
+4. Repeat until end of string
+5. Encode each component to binary
+
+## Address Patterns in libp2p
+
+### TCP Transport
+```
+/ip4/<ipv4-addr>/tcp/<port>
+/ip6/<ipv6-addr>/tcp/<port>
+/dns4/<hostname>/tcp/<port>
+/dns6/<hostname>/tcp/<port>
+```
+
+### QUIC Transport (v1)
+```
+/ip4/<ipv4-addr>/udp/<port>/quic-v1
+/ip6/<ipv6-addr>/udp/<port>/quic-v1
+```
+
+### WebSocket
+```
+/ip4/<ipv4-addr>/tcp/<port>/ws
+/dns4/<hostname>/tcp/<port>/wss
+```
+
+### WebTransport
+```
+/ip4/<ipv4-addr>/udp/<port>/quic-v1/webtransport
+```
+
+### Circuit Relay
+```
+/p2p/<relay-id>/p2p-circuit/p2p/<target-id>
+/<relay-transport-addr>/p2p/<relay-id>/p2p-circuit/p2p/<target-id>
+```
+
+### With Peer ID
+Any transport address can be suffixed with `/p2p/<peer-id>`:
+```
+/ip4/198.51.100.0/tcp/4001/p2p/<peer-id>
+/ip4/198.51.100.0/udp/4001/quic-v1/p2p/<peer-id>
+```
+
+## `dnsaddr` Resolution
+
+The `dnsaddr` protocol uses DNS TXT records to resolve multiaddrs:
+
+```
+/dnsaddr/bootstrap.libp2p.io
+```
+
+Resolution:
+1. Query TXT records for `_dnsaddr.bootstrap.libp2p.io`
+2. Each TXT record contains `dnsaddr=<multiaddr>`
+3. Replace the `/dnsaddr/...` component with the resolved multiaddr
+
+This enables bootstrap nodes to change their addresses without updating
+hardcoded configurations.
+
+## Haskell Implementation Notes
+
+For the Haskell implementation, consider:
+
+- **Data representation**: A multiaddr as a newtype over `ByteString` with
+  smart constructors for each protocol, or as a list of typed components.
+- **Varint**: Implement unsigned varint encoding/decoding (LEB128) as a
+  foundational utility — it's used throughout libp2p.
+- **Protocol registry**: A map from protocol code to parsing/formatting
+  functions.
+- **Existing libraries**: Check Hackage for `multiformats` or `multiaddr`
+  packages, though a custom implementation may be necessary.
+
+Key type sketch:
+```haskell
+newtype Multiaddr = Multiaddr ByteString
+  deriving (Eq, Ord)
+
+data Protocol
+  = IP4 Word32
+  | IP6 (Word64, Word64)
+  | TCP Word16
+  | UDP Word16
+  | P2P PeerId
+  | QuicV1
+  | WS
+  | WSS
+  | P2PCircuit
+  | DNS Text
+  | DNS4 Text
+  | DNS6 Text
+  | DNSAddr Text
+  deriving (Eq, Show)
+
+parseMultiaddr :: ByteString -> Either String [Protocol]
+encodeMultiaddr :: [Protocol] -> ByteString
+toText :: [Protocol] -> Text
+fromText :: Text -> Either String [Protocol]
+```
+
+## Spec References
+
+- Multiaddr spec: https://github.com/multiformats/multiaddr
+- Protocol table: https://github.com/multiformats/multicodec/blob/master/table.csv
+- Unsigned varint: https://github.com/multiformats/unsigned-varint

--- a/docs/04-transports.md
+++ b/docs/04-transports.md
@@ -1,0 +1,192 @@
+# Chapter 4: Transports
+
+A transport in libp2p provides the ability to establish connections (dial) and
+accept connections (listen) over a network protocol. This chapter covers the
+transport abstraction and the key transport implementations.
+
+## Transport Interface
+
+Every transport implements two core operations:
+
+```
+Dial   : Multiaddr → IO Connection
+Listen : Multiaddr → IO Listener
+```
+
+A `Listener` yields incoming connections. A `Connection` provides a reliable,
+bidirectional byte stream (before upgrade) or a multiplexed stream provider
+(after upgrade).
+
+### Which Transports Need Upgrading?
+
+| Transport | Needs Security Upgrade | Needs Muxer Upgrade |
+|-----------|----------------------|-------------------- |
+| TCP | Yes (Noise/TLS) | Yes (Yamux) |
+| WebSocket | Yes (Noise/TLS) | Yes (Yamux) |
+| QUIC v1 | No (built-in TLS 1.3) | No (built-in) |
+| WebRTC | No (built-in DTLS) | No (built-in SCTP) |
+| WebTransport | No (built-in TLS 1.3) | No (built-in) |
+
+TCP and WebSocket connections are raw byte streams that must go through the full
+connection upgrade pipeline (multistream-select → security → multistream-select
+→ muxer). QUIC, WebRTC, and WebTransport have encryption and multiplexing
+built into the transport itself.
+
+## TCP Transport
+
+TCP is the most widely supported transport and the recommended starting point
+for a new implementation.
+
+### Multiaddr Format
+```
+/ip4/<addr>/tcp/<port>
+/ip6/<addr>/tcp/<port>
+/dns4/<hostname>/tcp/<port>
+/dns6/<hostname>/tcp/<port>
+```
+
+### Connection Lifecycle
+
+**Dialing:**
+1. Resolve the multiaddr to an IP address and port
+2. Open a TCP socket connection (standard `connect()`)
+3. Upgrade the connection:
+   a. multistream-select → negotiate security (e.g., `/noise`)
+   b. Perform security handshake (e.g., Noise XX)
+   c. multistream-select → negotiate muxer (e.g., `/yamux/1.0.0`)
+   d. Initialize stream multiplexer
+4. Connection is now ready for application streams
+
+**Listening:**
+1. Bind to IP:port and listen for connections
+2. On accept, perform the upgrade process (same as dialing, but as responder)
+3. After upgrade, yield the connection to the Switch
+
+### TCP-Specific Considerations
+
+- **Keepalives**: Enable TCP keepalives to detect dead connections
+- **Nodelay**: Disable Nagle's algorithm (`TCP_NODELAY`) for low latency
+- **Reuse port**: Consider `SO_REUSEPORT` for hole punching scenarios
+- **Connection timeout**: Implement dial timeout (typical: 5-10 seconds)
+
+## QUIC Transport (v1)
+
+QUIC provides encryption (TLS 1.3) and multiplexing natively. It runs over UDP
+and offers significant advantages: 1-RTT connection establishment, no head-of-
+line blocking across streams, built-in connection migration.
+
+### Multiaddr Format
+```
+/ip4/<addr>/udp/<port>/quic-v1
+/ip6/<addr>/udp/<port>/quic-v1
+```
+
+### Key Properties
+
+- **No upgrade needed**: TLS 1.3 and stream multiplexing are part of the QUIC
+  protocol itself. No multistream-select negotiation for security or muxer.
+- **1-RTT handshake**: Security and transport are established simultaneously.
+- **Peer authentication**: The libp2p peer's identity key is embedded in a
+  self-signed TLS certificate. The remote peer's Peer ID is verified from this
+  certificate during the TLS handshake.
+- **Streams**: QUIC streams map directly to libp2p streams. Each stream is
+  bidirectional and independently flow-controlled.
+- **Protocol negotiation**: multistream-select is still used per-stream for
+  application protocol negotiation.
+
+### QUIC Connection Flow
+```
+Client                                      Server
+  │                                            │
+  │─────── QUIC Initial (TLS ClientHello) ────►│
+  │                                            │
+  │◄────── QUIC Handshake (TLS ServerHello) ───│
+  │        (includes server cert with          │
+  │         libp2p identity key)               │
+  │                                            │
+  │─────── QUIC Handshake Complete ───────────►│
+  │        (TLS Finished + client cert)        │
+  │                                            │
+  │  Connection established (1-RTT)            │
+  │                                            │
+  │─── Open QUIC stream ──────────────────────►│
+  │─── multistream-select for protocol ───────►│
+  │◄── protocol data exchange ────────────────►│
+```
+
+### ALPN
+
+libp2p over QUIC uses the ALPN (Application-Layer Protocol Negotiation)
+extension in TLS to identify itself. The ALPN protocol ID is `libp2p`.
+
+## WebSocket Transport
+
+WebSocket provides a bidirectional byte stream over HTTP, useful for
+browser-based peers.
+
+### Multiaddr Format
+```
+/ip4/<addr>/tcp/<port>/ws          (unencrypted WebSocket)
+/ip4/<addr>/tcp/<port>/wss         (TLS-encrypted WebSocket)
+/dns4/<hostname>/tcp/<port>/wss    (typical production setup)
+```
+
+### Properties
+
+- Raw WebSocket connections need security and muxer upgrades (same as TCP)
+- WSS (WebSocket Secure) provides TLS at the transport level, but libp2p still
+  requires its own security negotiation (Noise/TLS) on top
+- Primarily used for browser interoperability
+
+## WebRTC Transport
+
+WebRTC enables browser-to-browser and browser-to-server connections using
+DTLS for security and SCTP for multiplexing.
+
+### Multiaddr Format
+```
+/ip4/<addr>/udp/<port>/webrtc-direct
+```
+
+### Properties
+
+- Built-in security (DTLS) and multiplexing (SCTP data channels)
+- No upgrade needed
+- Supports NAT traversal through ICE (Interactive Connectivity Establishment)
+- Two variants: `webrtc-direct` (signaling over HTTP) and `webrtc` (signaling
+  over a relay)
+
+## WebTransport
+
+WebTransport is based on HTTP/3 (QUIC) and provides a modern alternative for
+browser connectivity.
+
+### Multiaddr Format
+```
+/ip4/<addr>/udp/<port>/quic-v1/webtransport/certhash/<hash>
+```
+
+### Properties
+
+- Built on QUIC — inherits all QUIC benefits
+- Certificate hashes in the multiaddr allow browsers to connect to
+  self-signed servers
+- No upgrade needed (security and muxing from QUIC)
+
+## Implementation Priority for libp2p-hs
+
+For the Haskell implementation, the recommended order:
+
+1. **TCP** — Start here. Most widely supported, easiest to debug (use Wireshark).
+   Requires implementing the full upgrade pipeline.
+2. **QUIC** — Second priority. Significant performance benefits. Use an existing
+   Haskell QUIC library (e.g., `quic` package from Kazu Yamamoto).
+3. **WebSocket** — If browser interop is needed.
+4. **WebRTC/WebTransport** — Lower priority.
+
+## Spec References
+
+- Transport interface: https://github.com/libp2p/specs/blob/master/connections/README.md
+- QUIC transport: https://github.com/libp2p/specs/tree/master/quic
+- WebRTC: https://github.com/libp2p/specs/tree/master/webrtc
+- WebTransport: https://github.com/libp2p/specs/tree/master/webtransport

--- a/docs/05-secure-channels.md
+++ b/docs/05-secure-channels.md
@@ -1,0 +1,285 @@
+# Chapter 5: Secure Channels
+
+Every libp2p connection must be encrypted and authenticated. This chapter covers
+the two supported security protocols: Noise (recommended) and TLS 1.3.
+
+## Noise Protocol
+
+The Noise protocol is the recommended security channel for libp2p. It uses a
+single, fixed cipher suite with no negotiation.
+
+### Protocol ID
+
+```
+/noise
+```
+
+### Noise Protocol Name
+
+```
+Noise_XX_25519_ChaChaPoly_SHA256
+```
+
+This name fully specifies:
+- **XX**: Handshake pattern (mutual authentication, both parties transmit static keys)
+- **25519**: X25519 Diffie-Hellman key exchange
+- **ChaChaPoly**: ChaCha20-Poly1305 AEAD cipher
+- **SHA256**: SHA-256 hash function
+
+There is **no cipher negotiation**. All libp2p Noise implementations use exactly
+this cipher suite.
+
+### Key Architecture
+
+libp2p Noise uses **two distinct key pairs**:
+
+1. **Identity key pair**: The peer's long-term libp2p identity key (Ed25519, RSA,
+   etc.). Used to derive the Peer ID.
+2. **Noise static key pair**: An X25519 key pair used specifically for the Noise
+   handshake. This is separate from the identity key because:
+   - Not all identity key types are compatible with Noise DH operations
+   - Separation prevents static key reuse across protocols
+
+Implementations MAY generate a new Noise static key pair per session or reuse
+one across sessions. Implementations SHOULD NOT persist the Noise static key
+to disk.
+
+### XX Handshake Pattern
+
+```
+XX:
+  -> e
+  <- e, ee, s, es
+  -> s, se
+```
+
+Three messages are exchanged:
+
+| Message | Direction | Tokens | Content |
+|---------|-----------|--------|---------|
+| 1 | Initiator → Responder | `e` | Initiator's ephemeral public key |
+| 2 | Responder → Initiator | `e, ee, s, es` | Responder's ephemeral key + DH + responder's static key (encrypted) + DH |
+| 3 | Initiator → Responder | `s, se` | Initiator's static key (encrypted) + DH |
+
+**Token meanings:**
+- `e`: Send ephemeral public key
+- `s`: Send static public key (encrypted after first DH)
+- `ee`: DH(ephemeral_initiator, ephemeral_responder)
+- `es`: DH(ephemeral_initiator, static_responder)
+- `se`: DH(static_initiator, ephemeral_responder)
+
+### Handshake Sequence Diagram
+
+```
+Initiator (Alice)                          Responder (Bob)
+     │                                          │
+     │  ── Message 1: [e] ──────────────────►   │
+     │     (Alice's ephemeral pubkey,            │
+     │      plaintext, no payload)               │
+     │                                          │
+     │  ◄── Message 2: [e, ee, s, es] ────────  │
+     │     (Bob's ephemeral pubkey,              │
+     │      Bob's static pubkey (encrypted),     │
+     │      handshake payload (encrypted):       │
+     │        - Bob's libp2p identity key        │
+     │        - signature over Noise static key  │
+     │        - optional extensions)             │
+     │                                          │
+     │  ── Message 3: [s, se] ──────────────►   │
+     │     (Alice's static pubkey (encrypted),   │
+     │      handshake payload (encrypted):       │
+     │        - Alice's libp2p identity key      │
+     │        - signature over Noise static key  │
+     │        - optional extensions)             │
+     │                                          │
+     │  ══ Secure channel established ══════     │
+     │  (Two CipherState objects for             │
+     │   bidirectional encryption)               │
+```
+
+### Static Key Authentication
+
+The Noise static key is authenticated by signing it with the libp2p identity
+private key. This proves the Noise participant possesses the claimed identity.
+
+**Signature data:**
+```
+"noise-libp2p-static-key:" || noise_static_public_key
+```
+
+The prefix is the literal UTF-8 string `noise-libp2p-static-key:` (including
+the colon), followed by the Noise static public key encoded per
+[RFC 7748 §5](https://tools.ietf.org/html/rfc7748#section-5) (32 bytes for
+X25519).
+
+The signature is produced using the identity private key's signing algorithm
+(e.g., Ed25519 signature for Ed25519 identity keys, RSASSA-PKCS1-v1_5 for RSA).
+
+### Handshake Payload
+
+Messages 2 and 3 contain an encrypted payload with the following protobuf:
+
+```protobuf
+syntax = "proto2";
+
+message NoiseExtensions {
+    repeated bytes webtransport_certhashes = 1;
+    repeated string stream_muxers = 2;
+}
+
+message NoiseHandshakePayload {
+    optional bytes identity_key = 1;
+    optional bytes identity_sig = 2;
+    optional NoiseExtensions extensions = 4;
+}
+```
+
+**Fields:**
+- `identity_key`: Serialized `PublicKey` protobuf (as defined in Chapter 2)
+- `identity_sig`: Signature of `"noise-libp2p-static-key:" || noise_static_pubkey`
+  using the identity private key
+- `extensions`: Optional. The `stream_muxers` field can be used to negotiate the
+  muxer during the handshake (avoiding a round-trip for multistream-select muxer
+  negotiation)
+
+**Message 1 (initiator's first message):** The initiator MUST NOT send extensions
+in message 1 (it is not encrypted and has no secrecy guarantee).
+
+**Message 2 (responder):** Has forward secrecy but the sender has NOT yet
+authenticated the responder. The payload might be sent to an active attacker.
+
+**Message 3 (initiator):** Has forward secrecy and the initiator has verified
+the responder.
+
+### Payload Validation
+
+Upon receiving a handshake payload, the recipient MUST:
+
+1. Decode `identity_key` into a usable public key
+2. Validate `identity_sig` against the Noise static public key received in the
+   handshake
+3. If the signature is invalid → terminate the connection immediately
+4. Derive the remote Peer ID from `identity_key` and verify it matches
+   expectations (if dialing a specific peer)
+
+### Wire Format
+
+All Noise messages (handshake and transport) are framed as:
+
+```
+┌──────────────────────┬──────────────────────────────┐
+│  noise_message_len   │       noise_message          │
+│   (2 bytes, BE)      │     (variable length)        │
+└──────────────────────┴──────────────────────────────┘
+```
+
+- `noise_message_len`: 2-byte **big-endian** unsigned integer, length of
+  `noise_message` in bytes
+- `noise_message`: A Noise message (max 65535 bytes)
+
+### Handshake Phase
+
+During the handshake, each `noise_message` is a Noise handshake message as
+defined in the [Noise spec](https://noiseprotocol.org/noise.html#message-format).
+
+### Transport Phase (Post-Handshake)
+
+After the handshake completes, each peer has two `CipherState` objects:
+- One for **encrypting** outgoing data
+- One for **decrypting** incoming data
+
+Each `noise_message` is now an AEAD ciphertext:
+
+```
+noise_message = encrypted_payload || authentication_tag
+                                     (16 bytes)
+```
+
+The plaintext payload is encrypted with ChaCha20-Poly1305. The 16-byte
+authentication tag provides integrity and authenticity.
+
+**Maximum message size:** 65535 bytes (limited by the 2-byte length prefix).
+The maximum plaintext per message is 65535 - 16 = 65519 bytes.
+
+**Nonce exhaustion:** If more than 2^64 - 1 messages are exchanged, the
+connection MUST be terminated (nonce reuse would break security).
+
+### Complete Handshake Byte Flow Example
+
+```
+Initiator → Responder:
+  [2 bytes: length] [32 bytes: ephemeral pubkey]
+
+Responder → Initiator:
+  [2 bytes: length] [32 bytes: ephemeral pubkey]
+                     [encrypted: static pubkey (32+16 bytes)]
+                     [encrypted: payload protobuf + 16 byte tag]
+
+Initiator → Responder:
+  [2 bytes: length] [encrypted: static pubkey (32+16 bytes)]
+                     [encrypted: payload protobuf + 16 byte tag]
+```
+
+Message 1 size: 2 + 32 = 34 bytes
+Message 2 size: 2 + 32 + 48 + (payload_len + 16) bytes
+Message 3 size: 2 + 48 + (payload_len + 16) bytes
+
+## TLS 1.3
+
+TLS 1.3 is an alternative security protocol, primarily used by QUIC.
+
+### Protocol ID
+
+```
+/tls/1.0.0
+```
+
+### How It Works in libp2p
+
+libp2p uses TLS 1.3 with a special twist: instead of relying on a certificate
+authority (CA), each peer generates a **self-signed certificate** that embeds
+its libp2p identity public key.
+
+The certificate contains a custom extension (OID `1.3.6.1.4.1.53594.1.1`) with
+a signed payload that binds the TLS certificate key to the libp2p identity key.
+
+### ALPN
+
+When used with QUIC, the ALPN (Application-Layer Protocol Negotiation) protocol
+ID is `libp2p`.
+
+### Peer ID Verification
+
+After the TLS handshake:
+1. Extract the libp2p public key from the remote peer's certificate extension
+2. Verify the signature binding the TLS key to the identity key
+3. Derive the Peer ID from the extracted public key
+4. Verify it matches the expected Peer ID (if known)
+
+### When to Use TLS vs Noise
+
+| Aspect | Noise | TLS 1.3 |
+|--------|-------|---------|
+| Protocol ID | `/noise` | `/tls/1.0.0` |
+| Used with TCP | Yes (primary) | Yes |
+| Used with QUIC | No (QUIC has built-in TLS) | Yes (built into QUIC) |
+| Cipher negotiation | None (fixed suite) | Standard TLS negotiation |
+| Implementation complexity | Moderate | Uses existing TLS libraries |
+| Handshake messages | 3 (1.5 RTT) | 2 (1 RTT) |
+
+For a Haskell implementation starting with TCP, **implement Noise first**.
+TLS 1.3 becomes relevant when adding QUIC support.
+
+## Haskell Implementation Notes
+
+- **Noise framework**: The `cacophony` Haskell package implements the Noise
+  Protocol Framework. It supports XX pattern and the required cipher suite.
+- **X25519**: Available in `crypton` (`Crypto.PubKey.Curve25519`)
+- **ChaCha20-Poly1305**: Available in `crypton` (`Crypto.Cipher.ChaChaPoly1305`)
+- **TLS 1.3**: The `tls` package by Vincent Hanquez supports TLS 1.3
+
+## Spec References
+
+- Noise spec: https://github.com/libp2p/specs/tree/master/noise
+- TLS spec: https://github.com/libp2p/specs/tree/master/tls
+- Noise Protocol Framework: https://noiseprotocol.org/noise.html

--- a/docs/06-multiplexing.md
+++ b/docs/06-multiplexing.md
@@ -1,0 +1,272 @@
+# Chapter 6: Stream Multiplexing
+
+Stream multiplexing allows multiple independent, bidirectional streams to share
+a single connection. This chapter covers Yamux (recommended) and mplex
+(deprecated).
+
+## Yamux
+
+Yamux ("Yet another Multiplexer") is the recommended stream multiplexer for
+libp2p.
+
+### Protocol ID
+
+```
+/yamux/1.0.0
+```
+
+### Frame Format
+
+Every Yamux message has a fixed 12-byte header:
+
+```
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+├─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┤
+│    Version    │      Type     │           Flags             │
+├─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┤
+│                         Stream ID                           │
+├─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┤
+│                          Length                              │
+└─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┼─┘
+```
+
+| Field | Offset | Size | Encoding | Description |
+|-------|--------|------|----------|-------------|
+| Version | 0 | 1 byte | uint8 | Protocol version (always 0) |
+| Type | 1 | 1 byte | uint8 | Frame type |
+| Flags | 2 | 2 bytes | big-endian uint16 | Bitfield of flags |
+| Stream ID | 4 | 4 bytes | big-endian uint32 | Stream identifier |
+| Length | 8 | 4 bytes | big-endian uint32 | Type-dependent length/value |
+
+Total header: **12 bytes**, always. No variable-length encoding.
+
+### Frame Types
+
+| Type | Value | Length Field Meaning |
+|------|-------|---------------------|
+| Data | 0x00 | Number of payload bytes following the header |
+| Window Update | 0x01 | Window size increment (delta) in bytes |
+| Ping | 0x02 | Opaque ping value (echoed back in response) |
+| Go Away | 0x03 | Error code |
+
+### Flags
+
+| Flag | Value | Description |
+|------|-------|-------------|
+| SYN | 0x0001 | Open a new stream |
+| ACK | 0x0002 | Acknowledge a new stream |
+| FIN | 0x0004 | Half-close the stream (no more data from sender) |
+| RST | 0x0008 | Reset the stream (abrupt termination) |
+
+Flags apply to specific frame types:
+- **SYN, ACK**: May be sent with Data, Window Update, or Ping frames
+- **FIN, RST**: May be sent with Data or Window Update frames only
+
+For example, a Data frame with SYN flag opens a new stream and sends data in
+the same frame.
+
+### Stream Lifecycle
+
+```
+Initiator                               Responder
+    │                                       │
+    │── Data/WndUpdate [SYN, StreamID=1] ──►│  Stream opened
+    │                                       │
+    │◄── Data/WndUpdate [ACK, StreamID=1] ──│  Stream acknowledged
+    │                                       │
+    │◄──────── Data [StreamID=1] ──────────►│  Bidirectional data
+    │◄──────── Data [StreamID=1] ──────────►│
+    │                                       │
+    │── Data [FIN, StreamID=1] ────────────►│  Half-close (initiator done sending)
+    │                                       │
+    │◄── Data [FIN, StreamID=1] ────────────│  Half-close (responder done sending)
+    │                                       │
+    │         Stream fully closed            │
+```
+
+**Stream rejection:** The responder may reject a stream by replying with the
+RST flag instead of ACK. The initiator should be prepared to handle this.
+
+**Optimistic sending:** Because Yamux runs over a reliable transport, data can
+be sent immediately after the SYN flag without waiting for the ACK. However,
+the stream may be rejected (RST) after data has already been sent — senders
+must handle this case.
+
+### Stream ID Assignment
+
+- Stream IDs are 32-bit unsigned integers
+- The **client** (connection initiator) uses **odd** stream IDs: 1, 3, 5, ...
+- The **server** (connection responder) uses **even** stream IDs: 2, 4, 6, ...
+- Stream ID 0 is reserved for session-level messages (Ping, Go Away)
+
+### Flow Control
+
+Yamux uses a **credit-based** flow control mechanism at the **stream level only**
+(there is no session-level flow control):
+
+- **Initial window size**: 256 KiB (262144 bytes) per stream
+- Each stream maintains a **send window** and **receive window**
+- Only **Data frames** count toward the window size. Window Update, Ping, and
+  Go Away frames are not tracked.
+- When data is read from a stream, the receiver sends a **Window Update** frame
+  to increase the sender's available window
+- The Length field of a Window Update frame is the **delta** (increment), not
+  the absolute window size
+- Senders MUST NOT send more data than the current window allows
+- If the window reaches 0, the sender blocks until a Window Update is received
+- Both sides can send a Window Update with the SYN/ACK to indicate a larger
+  initial window than the default 256 KiB
+
+### Session-Level Messages
+
+**Ping (Type = 0x02):**
+- Stream ID = 0
+- The Length field contains an opaque 32-bit value
+- Responder echoes back a Ping frame with the same value
+- Used for keepalive and latency measurement
+- SYN flag on request, ACK flag on response
+
+**Go Away (Type = 0x03):**
+- Stream ID = 0
+- Signals session termination
+- Length field contains an error code:
+  - 0x00: Normal termination
+  - 0x01: Protocol error
+  - 0x02: Internal error
+- After sending Go Away, no new streams may be opened
+- Existing streams are allowed to complete
+
+### Data Frame
+
+```
+[12-byte header: Version=0, Type=0x00, Flags, StreamID, Length=N]
+[N bytes of payload]
+```
+
+The Length field specifies how many bytes of payload follow the header.
+
+### Wire Example: Opening a Stream and Sending Data
+
+Opening stream 1 with 5 bytes of data ("hello"):
+
+```hex
+00       Version: 0
+00       Type: Data (0x00)
+00 01    Flags: SYN (0x0001)
+00 00 00 01  StreamID: 1
+00 00 00 05  Length: 5
+68 65 6c 6c 6f  Payload: "hello"
+```
+
+Total: 12 + 5 = 17 bytes.
+
+Acknowledging stream 1 with a window update:
+
+```hex
+00       Version: 0
+01       Type: Window Update (0x01)
+00 02    Flags: ACK (0x0002)
+00 00 00 01  StreamID: 1
+00 04 00 00  Length: 262144 (256 KiB window delta)
+```
+
+Total: 12 bytes (no payload for Window Update).
+
+## mplex (Deprecated)
+
+mplex is an older, simpler multiplexer. It is deprecated in favor of Yamux but
+documented here for reference and interoperability.
+
+### Protocol ID
+
+```
+/mplex/6.7.0
+```
+
+### Frame Format
+
+```
+┌──────────────────────┬──────────────────┬──────────────────────┐
+│   header (varint)    │  length (varint) │   data (bytes)       │
+└──────────────────────┴──────────────────┴──────────────────────┘
+```
+
+The header varint encodes both the stream ID and the message type:
+
+```
+header = (stream_id << 3) | flag
+```
+
+- **Lower 3 bits**: message type (flag)
+- **Upper bits**: stream ID
+
+### Message Types
+
+| Flag | Name | Description |
+|------|------|-------------|
+| 0 | NewStream | Open a new stream (data = stream name as UTF-8) |
+| 1 | MessageReceiver | Data from stream initiator to receiver |
+| 2 | MessageInitiator | Data from stream receiver to initiator |
+| 3 | CloseReceiver | Half-close from initiator's side |
+| 4 | CloseInitiator | Half-close from receiver's side |
+| 5 | ResetReceiver | Reset from initiator's side |
+| 6 | ResetInitiator | Reset from receiver's side |
+
+Note: The "Receiver"/"Initiator" in flag names refers to the **sender's role**,
+not the recipient. Flag 1 (MessageReceiver) means "message sent by the stream
+receiver" — this is confusing and is one reason mplex is deprecated.
+
+### Key Differences from Yamux
+
+| Feature | Yamux | mplex |
+|---------|-------|-------|
+| Header size | Fixed 12 bytes | Variable (varints) |
+| Flow control | Yes (window-based) | **No** |
+| Max frame payload | ~4 GiB (32-bit Length) | 1 MiB |
+| Status | Recommended | Deprecated |
+| Ping/keepalive | Built-in | No |
+| Graceful shutdown | Go Away frame | No |
+
+The lack of flow control in mplex means a fast sender can overwhelm a slow
+receiver, which is a significant limitation for production use.
+
+## Haskell Implementation Notes
+
+- Yamux is the implementation priority. The 12-byte fixed header is easy to
+  parse with `Data.Binary` or manual `ByteString` manipulation.
+- Flow control state per stream: track send window and receive window as
+  `IORef Int` or `TVar Int`.
+- Use STM (`TVar`, `TQueue`) for managing concurrent stream state.
+- Consider `async` for spawning per-stream read/write tasks.
+
+Key data types sketch:
+
+```haskell
+data FrameType = Data | WindowUpdate | Ping | GoAway
+  deriving (Eq, Show)
+
+data Flags = Flags
+  { flagSYN :: Bool
+  , flagACK :: Bool
+  , flagFIN :: Bool
+  , flagRST :: Bool
+  } deriving (Eq, Show)
+
+data YamuxHeader = YamuxHeader
+  { yhVersion  :: Word8       -- always 0
+  , yhType     :: FrameType
+  , yhFlags    :: Flags
+  , yhStreamId :: Word32
+  , yhLength   :: Word32
+  } deriving (Eq, Show)
+
+-- 12 bytes, big-endian, no variable-length encoding
+encodeHeader :: YamuxHeader -> ByteString
+decodeHeader :: ByteString -> Either String YamuxHeader
+```
+
+## Spec References
+
+- Yamux: https://github.com/hashicorp/yamux/blob/master/spec.md
+- mplex: https://github.com/libp2p/specs/tree/master/mplex

--- a/docs/07-protocols.md
+++ b/docs/07-protocols.md
@@ -1,0 +1,757 @@
+# Chapter 7: Protocol Negotiation
+
+Protocol negotiation is the mechanism by which two libp2p peers agree on which
+protocol to use for a given connection or stream. This chapter covers
+multistream-select (the universal negotiation protocol), the Identify protocol
+(for exchanging peer metadata after connection establishment), and the Ping
+protocol (for liveness checking). Together, these three protocols form the
+foundation layer that every higher-level libp2p protocol depends on.
+
+## multistream-select
+
+multistream-select is used everywhere in libp2p: to negotiate the security
+protocol on a raw connection, to negotiate the stream multiplexer, and to
+negotiate application protocols on each new stream. It is the first thing
+spoken on every new channel.
+
+### Protocol ID
+
+```
+/multistream/1.0.0
+```
+
+### Wire Format
+
+Every multistream-select message is a UTF-8 encoded string with the following
+framing:
+
+```
+┌──────────────────────┬──────────────────────────────┬─────┐
+│  length (uvarint)    │   message (UTF-8 bytes)      │ \n  │
+└──────────────────────┴──────────────────────────────┴─────┘
+```
+
+- **length**: An unsigned varint (LEB128) encoding the total byte count of the
+  message content **including** the trailing newline `\n` (0x0a).
+- **message**: The UTF-8 encoded protocol ID or command.
+- **`\n`**: A single newline byte (0x0a) that terminates every message.
+
+The newline is part of the message and is counted in the length prefix.
+
+### Unsigned Varint (LEB128) Encoding
+
+The length prefix uses the multiformats unsigned varint format, which is a
+variant of unsigned LEB128:
+
+- Unsigned integers are serialized 7 bits at a time, starting with the **least
+  significant bits**.
+- The **most significant bit** (MSB, bit 7) of each byte is a continuation flag:
+  `1` means more bytes follow, `0` means this is the last byte.
+- Integers MUST be minimally encoded (no leading zero bytes except for the
+  value 0 itself).
+- Implementations MUST restrict varint size to a maximum of 9 bytes (63 bits).
+
+| Value | Hex | Varint Bytes |
+|-------|-----|--------------|
+| 0 | 0x00 | `00` |
+| 1 | 0x01 | `01` |
+| 127 | 0x7f | `7f` |
+| 128 | 0x80 | `80 01` |
+| 255 | 0xff | `ff 01` |
+| 300 | 0x012c | `ac 02` |
+| 16384 | 0x4000 | `80 80 01` |
+
+Encoding algorithm:
+
+```
+while value >= 0x80:
+    emit (value & 0x7F) | 0x80
+    value >>= 7
+emit value & 0x7F
+```
+
+Decoding algorithm:
+
+```
+result = 0
+shift  = 0
+loop:
+    byte = read_next_byte()
+    result |= (byte & 0x7F) << shift
+    if (byte & 0x80) == 0:
+        return result
+    shift += 7
+    if shift >= 63:
+        error("varint too long")
+```
+
+### Protocol ID Conventions
+
+Protocol IDs follow a path-like convention:
+
+```
+/<organization-or-project>/<protocol-name>/<version>
+```
+
+Examples:
+
+| Protocol ID | Description |
+|-------------|-------------|
+| `/multistream/1.0.0` | multistream-select itself |
+| `/noise` | Noise security protocol |
+| `/tls/1.0.0` | TLS 1.3 security protocol |
+| `/yamux/1.0.0` | Yamux stream multiplexer |
+| `/mplex/6.7.0` | mplex stream multiplexer (deprecated) |
+| `/ipfs/id/1.0.0` | Identify protocol |
+| `/ipfs/id/push/1.0.0` | Identify Push protocol |
+| `/ipfs/ping/1.0.0` | Ping protocol |
+| `/ipfs/kad/1.0.0` | Kademlia DHT |
+
+Protocol IDs are compared using **exact string matching** by default.
+Implementations MAY support custom match functions for more flexible routing.
+
+### Handshake Flow
+
+Both sides begin by sending the multistream-select protocol ID. Both sides MAY
+send this initial message simultaneously, without waiting for the other side.
+If either side receives anything other than `/multistream/1.0.0\n` as the first
+message, the negotiation is aborted.
+
+After the multistream header exchange, the **Initiator** proposes a protocol by
+sending its protocol ID. The **Responder** either:
+- **Accepts**: Echoes back the same protocol ID.
+- **Rejects**: Sends `na\n`.
+
+If rejected, the Initiator may propose a different protocol or close the channel.
+
+### Sequence Diagram
+
+```
+Initiator                                          Responder
+    │                                                   │
+    │  ── /multistream/1.0.0\n ──────────────────────►  │
+    │  ◄── /multistream/1.0.0\n ──────────────────────  │
+    │     (both sides may send simultaneously)          │
+    │                                                   │
+    │  ── /noise\n ──────────────────────────────────►  │
+    │                                                   │
+    │  ◄── na\n ─────────────────────────────────────── │
+    │     (Responder does not support /noise)           │
+    │                                                   │
+    │  ── /tls/1.0.0\n ─────────────────────────────►  │
+    │                                                   │
+    │  ◄── /tls/1.0.0\n ────────────────────────────── │
+    │     (Responder echoes back = accepted)            │
+    │                                                   │
+    │  ═══ Protocol agreed: /tls/1.0.0 ═══════════     │
+    │  (subsequent bytes are TLS handshake data)        │
+```
+
+### Optimistic Pipelining
+
+Implementations SHOULD pipeline the multistream header and the first protocol
+proposal into a single write to avoid an extra round trip:
+
+```
+Initiator                                          Responder
+    │                                                   │
+    │  ── /multistream/1.0.0\n + /noise\n ──────────►  │
+    │                                                   │
+    │  ◄── /multistream/1.0.0\n + /noise\n ──────────  │
+    │                                                   │
+    │  ═══ Negotiation complete in 1 RTT ═══════════   │
+```
+
+Both the multistream header and the protocol proposal are sent as separate
+length-prefixed messages concatenated in the same TCP segment. The responder
+similarly pipelines its multistream header with its response.
+
+### The `ls` Command
+
+A peer may request the list of protocols supported by the remote side by
+sending `ls\n`:
+
+```
+ls\n
+```
+
+On the wire:
+
+```
+0x03 0x6c 0x73 0x0a
+ │    │    │    └── newline '\n'
+ │    │    └─────── 's' (0x73)
+ │    └──────────── 'l' (0x6c)
+ └───────────────── varint length: 3 (includes 'l', 's', '\n')
+```
+
+The response is a single length-prefixed block containing all supported
+protocol IDs, each individually length-prefixed:
+
+```
+<varint-total-response-size>
+  <varint-protocol-length><protocol>\n
+  <varint-protocol-length><protocol>\n
+  ...
+  \n
+```
+
+The outer varint gives the total byte count of the entire response payload
+(all inner protocol entries plus the trailing newline). Each inner protocol
+entry has its own varint length prefix and `\n` suffix. The response ends
+with a bare `\n` unless there are zero protocols.
+
+Support for `ls` is OPTIONAL. Implementations MUST NOT depend on a remote peer
+supporting `ls`.
+
+### The `na` Response
+
+When a proposed protocol is not supported, the responder sends `na\n`:
+
+```
+0x03 0x6e 0x61 0x0a
+ │    │    │    └── newline '\n'
+ │    │    └─────── 'a' (0x61)
+ │    └──────────── 'n' (0x6e)
+ └───────────────── varint length: 3
+```
+
+### Simultaneous Open (Deprecated)
+
+In NAT hole-punching scenarios, both peers may act as initiators simultaneously.
+The simultaneous open extension used the protocol ID
+`/libp2p/simultaneous-connect` to resolve this by having both sides generate
+a random 64-bit integer and exchanging it prefixed with `select:`. The peer
+with the higher integer becomes the initiator.
+
+This extension is **deprecated** as of 2023-09-05 (see
+[specs#573](https://github.com/libp2p/specs/issues/573)).
+
+### Complete Wire Example: Negotiating Noise
+
+Below is a complete hex dump of a successful multistream-select negotiation
+for the Noise protocol. Each message shows the varint length prefix, the
+UTF-8 payload, and the trailing newline.
+
+**Step 1: Initiator sends multistream header**
+
+The string `/multistream/1.0.0\n` is 20 bytes (19 characters + newline):
+
+```hex
+Bytes: 14 2f 6d 75 6c 74 69 73 74 72 65 61 6d 2f 31 2e 30 2e 30 0a
+       ││ └─────────────────────────────────────────────────────────┘
+       ││   "/multistream/1.0.0" + '\n' (19 + 1 = 20 bytes)
+       │└── varint length: 0x14 = 20
+       └─── (part of varint)
+```
+
+Breakdown:
+```
+14          varint: 20 (0x14)
+2f          '/'
+6d 75 6c 74 69 73 74 72 65 61 6d   "multistream"
+2f          '/'
+31 2e 30 2e 30   "1.0.0"
+0a          '\n'
+```
+
+**Step 2: Responder sends multistream header**
+
+Identical to Step 1:
+```hex
+14 2f 6d 75 6c 74 69 73 74 72 65 61 6d 2f 31 2e 30 2e 30 0a
+```
+
+**Step 3: Initiator proposes Noise**
+
+The string `/noise\n` is 7 bytes (6 characters + newline):
+
+```hex
+Bytes: 07 2f 6e 6f 69 73 65 0a
+       │  └─────────────────────┘
+       │   "/noise" + '\n' (6 + 1 = 7 bytes)
+       └── varint: 7 (0x07)
+```
+
+**Step 4: Responder accepts (echoes back)**
+
+```hex
+07 2f 6e 6f 69 73 65 0a
+```
+
+**Complete exchange on the wire (initiator's perspective):**
+
+```hex
+SEND: 14 2f6d756c746973747265616d2f312e302e30 0a   /multistream/1.0.0\n
+RECV: 14 2f6d756c746973747265616d2f312e302e30 0a   /multistream/1.0.0\n
+SEND: 07 2f6e6f697365 0a                            /noise\n
+RECV: 07 2f6e6f697365 0a                            /noise\n
+--- Noise handshake begins ---
+```
+
+**Example with rejection (Initiator proposes TLS, rejected, then Noise):**
+
+```hex
+SEND: 14 2f6d756c746973747265616d2f312e302e30 0a   /multistream/1.0.0\n
+RECV: 14 2f6d756c746973747265616d2f312e302e30 0a   /multistream/1.0.0\n
+SEND: 0b 2f746c732f312e302e30 0a                    /tls/1.0.0\n
+RECV: 03 6e61 0a                                     na\n
+SEND: 07 2f6e6f697365 0a                            /noise\n
+RECV: 07 2f6e6f697365 0a                            /noise\n
+--- Noise handshake begins ---
+```
+
+### Where multistream-select Is Used
+
+multistream-select is used at multiple points during connection establishment:
+
+```
+Raw TCP Connection
+    │
+    ├── multistream-select: negotiate security protocol
+    │   (e.g., /noise or /tls/1.0.0)
+    │
+    ├── Security handshake (Noise XX or TLS 1.3)
+    │
+    ├── multistream-select: negotiate stream multiplexer
+    │   (e.g., /yamux/1.0.0)
+    │
+    ├── Multiplexer setup
+    │
+    └── For each new stream:
+        └── multistream-select: negotiate application protocol
+            (e.g., /ipfs/id/1.0.0, /ipfs/kad/1.0.0, etc.)
+```
+
+## Identify Protocol (`/ipfs/id/1.0.0`)
+
+The Identify protocol allows peers to exchange basic information after a
+connection is established: public keys, listen addresses, observed address,
+supported protocols, and software version.
+
+### Protocol IDs
+
+| Variant | Protocol ID | Direction |
+|---------|-------------|-----------|
+| Identify | `/ipfs/id/1.0.0` | Queried peer sends info, then closes stream |
+| Identify Push | `/ipfs/id/push/1.0.0` | Initiating peer sends info, then closes stream |
+
+### How Identify Works
+
+1. After a new connection is fully established (security + multiplexing), a
+   peer opens a new stream using multistream-select with `/ipfs/id/1.0.0`.
+2. The **responder** (the peer being identified) sends a single `Identify`
+   protobuf message and closes the stream.
+3. The **initiator** reads the message and updates its local metadata store.
+
+The Identify exchange typically happens immediately after connection setup. It
+is the mechanism by which peers learn each other's listen addresses, supported
+protocols, and observed addresses (useful for NAT detection).
+
+### Identify Sequence Diagram
+
+```
+Peer A (Initiator)                             Peer B (Responder)
+    │                                               │
+    │  ── Open stream ─────────────────────────────►│
+    │  ── multistream: /ipfs/id/1.0.0\n ──────────►│
+    │  ◄── multistream: /ipfs/id/1.0.0\n ──────────│
+    │                                               │
+    │  ◄── Identify protobuf message ───────────────│
+    │  ◄── (stream closed by Peer B) ───────────────│
+    │                                               │
+    │  Peer A now knows:                            │
+    │   - Peer B's public key                       │
+    │   - Peer B's listen addresses                 │
+    │   - Peer A's observed address (NAT detection) │
+    │   - Peer B's supported protocols              │
+    │   - Peer B's agent version                    │
+```
+
+### Identify Push
+
+When a peer's information changes at runtime (e.g., new listen address
+obtained), it uses Identify Push to notify connected peers:
+
+```
+Peer A (Pushes update)                         Peer B (Receives update)
+    │                                               │
+    │  ── Open stream ─────────────────────────────►│
+    │  ── multistream: /ipfs/id/push/1.0.0\n ─────►│
+    │  ◄── multistream: /ipfs/id/push/1.0.0\n ─────│
+    │                                               │
+    │  ── Identify protobuf message ───────────────►│
+    │  ── (stream closed by Peer A) ───────────────►│
+    │                                               │
+    │  Peer B updates its local metadata for Peer A │
+```
+
+Note the reversed data flow: with Identify, the responder sends the message;
+with Identify Push, the initiator sends the message.
+
+For Identify Push, missing fields should be ignored. Peers MAY send partial
+updates containing only the fields whose values have changed.
+
+### Protobuf Definition
+
+```protobuf
+syntax = "proto2";
+
+message Identify {
+    optional string protocolVersion = 5;
+    optional string agentVersion = 6;
+    optional bytes publicKey = 1;
+    repeated bytes listenAddrs = 2;
+    optional bytes observedAddr = 4;
+    repeated string protocols = 3;
+    optional bytes signedPeerRecord = 8;
+}
+```
+
+Note: The `signedPeerRecord` field (tag 8) is not in the original spec document
+but is present in production implementations (go-libp2p, rust-libp2p). It
+contains a serialized `SignedEnvelope` holding a `PeerRecord` signed by the
+sending peer. It provides the same address information as `listenAddrs` but in
+a cryptographically signed form.
+
+### Field Descriptions
+
+| Field | Tag | Type | Description |
+|-------|-----|------|-------------|
+| `publicKey` | 1 | `optional bytes` | Peer's public key, marshalled as the `PublicKey` protobuf (see Chapter 2). Used to derive the remote Peer ID. |
+| `listenAddrs` | 2 | `repeated bytes` | Multiaddrs on which the peer is listening, each encoded as raw binary multiaddr bytes. |
+| `protocols` | 3 | `repeated string` | List of protocol IDs the peer supports (e.g., `/ipfs/kad/1.0.0`). A peer SHOULD only advertise protocols for which it accepts inbound streams. |
+| `observedAddr` | 4 | `optional bytes` | The multiaddr of the **initiator** as observed by the responder. Binary-encoded multiaddr. Useful for NAT detection. |
+| `protocolVersion` | 5 | `optional string` | Protocol family version string. Example: `ipfs/0.1.0`. Optional but recommended. |
+| `agentVersion` | 6 | `optional string` | Free-form implementation identifier. Format: `agent-name/version`. Example: `go-libp2p/0.35.0`. |
+| `signedPeerRecord` | 8 | `optional bytes` | Serialized `SignedEnvelope` containing a `PeerRecord`. Provides signed, authenticated address information. |
+
+### Protobuf Field Encoding Reference
+
+Protobuf uses varint-encoded field tags where `tag = (field_number << 3) | wire_type`:
+
+| Field | Field Number | Wire Type | Tag Byte(s) |
+|-------|-------------|-----------|-------------|
+| `publicKey` | 1 | 2 (length-delimited) | `0x0a` |
+| `listenAddrs` | 2 | 2 (length-delimited) | `0x12` |
+| `protocols` | 3 | 2 (length-delimited) | `0x1a` |
+| `observedAddr` | 4 | 2 (length-delimited) | `0x22` |
+| `protocolVersion` | 5 | 2 (length-delimited) | `0x2a` |
+| `agentVersion` | 6 | 2 (length-delimited) | `0x32` |
+| `signedPeerRecord` | 8 | 2 (length-delimited) | `0x42` |
+
+### Identify Message Wire Format
+
+The Identify message is sent as a raw protobuf (no additional framing beyond
+what the stream provides). The stream is closed after the message is sent,
+which signals the end of the message to the receiver.
+
+Example partial wire dump of an Identify message:
+
+```hex
+2a 09 69 70 66 73 2f 30 2e 31 2e 30
+│  │  └──────────────────────────────── "ipfs/0.1.0" (9 bytes)
+│  └─────────────────────────────────── varint length: 9
+└────────────────────────────────────── tag: field 5, wire type 2 (0x2a)
+
+32 10 67 6f 2d 6c 69 62 70 32 70 2f 30 2e 33 35 2e 30
+│  │  └──────────────────────────────────────────────── "go-libp2p/0.35.0" (16 bytes)
+│  └─────────────────────────────────────────────────── varint length: 16
+└────────────────────────────────────────────────────── tag: field 6, wire type 2 (0x32)
+
+0a 24 08 01 12 20 <32 bytes of Ed25519 public key>
+│  │  │  │  │  │
+│  │  │  │  │  └── varint length: 32 (the raw key)
+│  │  │  │  └───── tag for PublicKey.data: field 2, wire type 2
+│  │  │  └──────── varint value: 1 (Ed25519 key type)
+│  │  └─────────── tag for PublicKey.type: field 1, wire type 0
+│  └────────────── varint length: 36 (2 + 2 + 32)
+└───────────────── tag: field 1 (publicKey), wire type 2 (0x0a)
+
+1a 0f 2f 69 70 66 73 2f 6b 61 64 2f 31 2e 30 2e 30
+│  │  └──────────────────────────────────────────── "/ipfs/kad/1.0.0" (15 bytes)
+│  └─────────────────────────────────────────────── varint length: 15
+└────────────────────────────────────────────────── tag: field 3 (protocols), wire type 2 (0x1a)
+```
+
+## Ping Protocol (`/ipfs/ping/1.0.0`)
+
+The Ping protocol is a simple liveness check used to verify connectivity and
+measure round-trip time (RTT) between two peers. It operates over an already
+established libp2p connection.
+
+### Protocol ID
+
+```
+/ipfs/ping/1.0.0
+```
+
+### Wire Format
+
+The ping protocol has no framing beyond the raw bytes:
+
+1. The **dialing peer** sends exactly **32 bytes** of random binary data.
+2. The **listening peer** echoes back the same **32 bytes**.
+3. The dialing peer measures the RTT from when it sent the bytes to when it
+   received them.
+
+```
+┌────────────────────────────────────────────┐
+│            32 bytes of random data         │
+└────────────────────────────────────────────┘
+```
+
+No length prefix. No framing. No protobuf. Just 32 raw bytes sent and 32 raw
+bytes echoed back.
+
+### Sequence Diagram
+
+```
+Dialer                                         Listener
+    │                                               │
+    │  ── Open stream ─────────────────────────────►│
+    │  ── multistream: /ipfs/ping/1.0.0\n ────────►│
+    │  ◄── multistream: /ipfs/ping/1.0.0\n ────────│
+    │                                               │
+    │  ── 32 random bytes ─────────────────────────►│
+    │  ◄── 32 bytes (echo) ────────────────────────│  RTT measured
+    │                                               │
+    │  ── 32 random bytes ─────────────────────────►│  (optional repeat)
+    │  ◄── 32 bytes (echo) ────────────────────────│
+    │                                               │
+    │  ── close write ─────────────────────────────►│
+    │  ◄── close stream ───────────────────────────│
+```
+
+### Behavioral Rules
+
+- The dialing peer MAY repeat the ping by sending another 32 bytes of random
+  data on the same stream. The listening peer SHOULD loop and echo each
+  payload.
+- The dialing peer SHOULD close the write side of the stream after sending the
+  last payload.
+- The listening peer SHOULD finish writing the echoed payload, then close the
+  stream.
+- The dialing peer MUST NOT keep more than **one** outbound ping stream per
+  peer.
+- The listening peer SHOULD accept at most **two** streams per peer, because
+  cross-stream behavior is non-linear and stream writes occur asynchronously
+  (the listener may perceive the dialer closing and opening the wrong streams).
+
+### Wire Example
+
+```hex
+SEND (32 bytes, random):
+a1 b2 c3 d4 e5 f6 07 18 29 3a 4b 5c 6d 7e 8f 90
+01 12 23 34 45 56 67 78 89 9a ab bc cd de ef f0
+
+RECV (32 bytes, identical echo):
+a1 b2 c3 d4 e5 f6 07 18 29 3a 4b 5c 6d 7e 8f 90
+01 12 23 34 45 56 67 78 89 9a ab bc cd de ef f0
+```
+
+### Timeout Behavior
+
+The spec does not prescribe a specific timeout. In practice:
+
+| Implementation | Default Ping Timeout |
+|----------------|---------------------|
+| go-libp2p | 60 seconds |
+| rust-libp2p | 20 seconds |
+| js-libp2p | 10 seconds |
+
+Implementations SHOULD enforce a reasonable timeout and consider the peer
+unreachable if the echo is not received within it.
+
+## Length-Prefixed Protobuf Encoding
+
+Many libp2p protocols use a common pattern for sending protobuf messages over
+streams: a **varint length prefix** followed by the **protobuf payload**.
+
+```
+┌──────────────────────┬──────────────────────────────┐
+│  length (uvarint)    │   protobuf message (bytes)   │
+└──────────────────────┴──────────────────────────────┘
+```
+
+- **length**: Unsigned varint (same LEB128 format as multistream-select)
+  encoding the byte length of the protobuf message.
+- **protobuf message**: The serialized protobuf bytes.
+
+This pattern is used by:
+
+| Protocol | Message Type |
+|----------|-------------|
+| Kademlia DHT | `Message` (requests and responses) |
+| Circuit Relay v2 | `HopMessage`, `StopMessage` |
+| AutoNAT | `Message` |
+| GossipSub | `RPC` |
+| DCUtR | `HolePunch` |
+
+The Identify protocol is a notable **exception**: it sends the protobuf
+message without a length prefix, relying on stream closure to delimit the
+message.
+
+### Reading Length-Prefixed Messages
+
+```
+1. Read varint from stream → message_length
+2. Read exactly message_length bytes from stream → raw_bytes
+3. Deserialize raw_bytes as the expected protobuf message type
+```
+
+### Writing Length-Prefixed Messages
+
+```
+1. Serialize protobuf message → raw_bytes
+2. Encode len(raw_bytes) as unsigned varint → length_prefix
+3. Write length_prefix ++ raw_bytes to stream
+```
+
+### Maximum Message Sizes
+
+Protocols typically enforce a maximum message size to prevent memory exhaustion.
+Common limits:
+
+| Protocol | Max Message Size |
+|----------|-----------------|
+| Identify | ~64 KiB (practical limit) |
+| Kademlia DHT | ~1 MiB |
+| GossipSub | ~1 MiB |
+| Circuit Relay v2 | ~4 KiB |
+
+Implementations SHOULD validate the varint length before allocating memory and
+reject messages exceeding the protocol's maximum size.
+
+## Haskell Implementation Notes
+
+### multistream-select
+
+- Varint encoding/decoding can use the `Data.Binary.Get` and
+  `Data.Binary.Put` monads from the `binary` package, or manual
+  `ByteString` manipulation.
+- The `bytestring` package provides efficient byte-level operations.
+- Consider using `Data.ByteString.Builder` for efficient construction of
+  outgoing messages (varint + payload + newline).
+
+Key data type sketch:
+
+```haskell
+import Data.ByteString (ByteString)
+import Data.Word (Word8)
+
+-- | A protocol identifier, e.g., "/noise" or "/yamux/1.0.0"
+newtype ProtocolId = ProtocolId { unProtocolId :: ByteString }
+  deriving (Eq, Ord, Show)
+
+-- | Result of a multistream-select negotiation
+data NegotiationResult
+  = Accepted ProtocolId
+  | Rejected
+  | NegotiationError String
+  deriving (Eq, Show)
+
+-- | Encode a varint (unsigned LEB128)
+encodeUvarint :: Word -> ByteString
+
+-- | Decode a varint from a stream, returning the value and remaining bytes
+decodeUvarint :: ByteString -> Either String (Word, ByteString)
+
+-- | Encode a multistream-select message (varint-length + payload + newline)
+encodeMssMessage :: ByteString -> ByteString
+
+-- | Negotiate a protocol as the initiator
+negotiateInitiator
+  :: (ByteString -> IO ())    -- ^ send function
+  -> IO ByteString            -- ^ receive function
+  -> [ProtocolId]             -- ^ protocols to try, in preference order
+  -> IO NegotiationResult
+
+-- | Handle negotiation as the responder
+negotiateResponder
+  :: (ByteString -> IO ())    -- ^ send function
+  -> IO ByteString            -- ^ receive function
+  -> [ProtocolId]             -- ^ locally supported protocols
+  -> IO NegotiationResult
+```
+
+### Identify
+
+- Use the `proto-lens` or `proto3-wire` package for protobuf
+  encoding/decoding.
+- The `Identify` message is straightforward proto2 with all optional or
+  repeated fields.
+- Multiaddr values in `listenAddrs` and `observedAddr` are raw binary
+  multiaddr bytes (see Chapter 3).
+
+```haskell
+data IdentifyMessage = IdentifyMessage
+  { idProtocolVersion  :: Maybe Text
+  , idAgentVersion     :: Maybe Text
+  , idPublicKey        :: Maybe ByteString   -- serialized PublicKey protobuf
+  , idListenAddrs      :: [ByteString]       -- binary multiaddrs
+  , idObservedAddr     :: Maybe ByteString   -- binary multiaddr
+  , idProtocols        :: [Text]             -- supported protocol IDs
+  , idSignedPeerRecord :: Maybe ByteString   -- serialized SignedEnvelope
+  } deriving (Eq, Show)
+
+-- | Run the Identify protocol as the querying peer
+runIdentify :: Stream -> IO IdentifyMessage
+
+-- | Handle an incoming Identify request
+handleIdentify :: Stream -> IdentifyMessage -> IO ()
+
+-- | Send an Identify Push to a remote peer
+pushIdentify :: Stream -> IdentifyMessage -> IO ()
+```
+
+### Ping
+
+- Ping is the simplest protocol to implement. It needs a CSPRNG for the
+  32-byte payload.
+- Use `Crypto.Random` from the `crypton` package (or `entropy` package)
+  for generating random bytes.
+
+```haskell
+import Data.ByteString (ByteString)
+
+pingPayloadSize :: Int
+pingPayloadSize = 32
+
+-- | Send a ping and measure RTT
+sendPing :: Stream -> IO (Either PingError NominalDiffTime)
+
+-- | Handle incoming pings (echo loop)
+handlePing :: Stream -> IO ()
+
+data PingError
+  = PingTimeout
+  | PingMismatch       -- echoed bytes differ from sent bytes
+  | PingStreamError String
+  deriving (Eq, Show)
+```
+
+### Relevant Haskell Packages
+
+| Package | Purpose |
+|---------|---------|
+| `binary` | Varint encoding/decoding, binary serialization |
+| `bytestring` | Efficient byte-level operations |
+| `proto-lens` | Protobuf code generation and serialization |
+| `proto3-wire` | Low-level protobuf wire format encoding |
+| `crypton` | CSPRNG for ping payloads |
+| `stm` | Concurrent state management for protocol handlers |
+| `async` | Spawning concurrent protocol handler tasks |
+| `network` | Low-level socket operations |
+| `text` | UTF-8 text handling for protocol IDs |
+| `time` | RTT measurement for Ping |
+
+## Spec References
+
+- multistream-select: https://github.com/multiformats/multistream-select
+- Unsigned varint: https://github.com/multiformats/unsigned-varint
+- Connections (multistream-select in context): https://github.com/libp2p/specs/blob/master/connections/README.md
+- Identify: https://github.com/libp2p/specs/blob/master/identify/README.md
+- Ping: https://github.com/libp2p/specs/blob/master/ping/ping.md
+- Simultaneous open (deprecated): https://github.com/libp2p/specs/blob/master/connections/simopen.md
+- go-libp2p Identify protobuf: https://github.com/libp2p/go-libp2p/blob/master/p2p/protocol/identify/pb/identify.proto

--- a/docs/08-switch.md
+++ b/docs/08-switch.md
@@ -1,0 +1,1015 @@
+# Chapter 8: Switch / Swarm
+
+The Switch (called Swarm in Go implementations) is the central coordinator of
+the libp2p networking stack. It owns all transports, manages connections to
+peers, drives the connection upgrade pipeline, dispatches incoming streams to
+protocol handlers, and enforces resource limits. Every outbound dial and every
+inbound accept flows through the Switch. This chapter specifies its
+responsibilities, internal state, and the algorithms that govern connection
+establishment, reuse, and teardown.
+
+## Switch as Central Coordinator
+
+The Switch sits between the transport layer below and the application protocols
+above. It is the single entry point for all network operations.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   Application Protocols                      │
+│          (Identify, Ping, Kademlia, GossipSub, ...)          │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│                         Switch                               │
+│                                                              │
+│  ┌──────────┐ ┌──────────┐ ┌───────────┐ ┌──────────────┐  │
+│  │ Transport│ │Connection│ │  Stream    │ │  Protocol    │  │
+│  │ Manager  │ │  Pool    │ │  Manager   │ │  Registry    │  │
+│  └──────────┘ └──────────┘ └───────────┘ └──────────────┘  │
+│  ┌──────────┐ ┌──────────┐ ┌───────────┐                   │
+│  │  Dialer  │ │ Listener │ │  Resource  │                   │
+│  │          │ │ Manager  │ │  Manager   │                   │
+│  └──────────┘ └──────────┘ └───────────┘                   │
+│                                                              │
+├─────────────────────────────────────────────────────────────┤
+│              Transports (TCP, QUIC, WebSocket, ...)           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Responsibilities
+
+| Responsibility | Description |
+|----------------|-------------|
+| Transport management | Register transports, select the correct transport for a given multiaddr |
+| Dialing | Resolve addresses, dial peers, handle parallel attempts, manage backoff |
+| Listening | Bind transports to listen addresses, accept inbound connections |
+| Connection upgrading | Drive the upgrade pipeline: security negotiation then muxer negotiation |
+| Connection pool | Track active connections per peer, reuse existing connections |
+| Stream management | Open new streams on existing connections, accept inbound streams |
+| Protocol dispatch | Route inbound streams to registered protocol handlers via multistream-select |
+| Resource management | Enforce limits on connections, streams, file descriptors, and memory |
+| Connection gating | Allow or deny connections based on policy (IP, Peer ID, etc.) |
+| Event notification | Emit events for connection open/close, stream open/close |
+
+### Naming: Switch vs Swarm
+
+The terms "Switch" and "Swarm" refer to the same component. The libp2p
+specification uses "Switch." Go's implementation calls it "Swarm." Rust calls
+it "Swarm." JavaScript historically used "Switch" then moved to "Swarm." This
+chapter uses "Switch" to align with the specification, but the terms are
+interchangeable.
+
+## Connection Upgrading Pipeline
+
+When a raw transport connection is established (e.g., a TCP socket), it must be
+upgraded to a secure, multiplexed connection before application protocols can
+use it. The upgrade pipeline transforms a raw byte stream into a fully capable
+libp2p connection.
+
+### Full Upgrade Sequence
+
+```
+ Raw Transport Connection (e.g., TCP socket)
+         │
+         ▼
+ ┌───────────────────────────────────────┐
+ │  Step 1: multistream-select           │
+ │  Negotiate security protocol          │
+ │  Dialer proposes: /noise              │
+ │  Listener responds: /noise (or na)    │
+ └───────────────────────────────────────┘
+         │
+         ▼
+ ┌───────────────────────────────────────┐
+ │  Step 2: Security Handshake           │
+ │  Perform Noise XX (3 messages)        │
+ │  or TLS 1.3 handshake                 │
+ │  Result: encrypted, authenticated     │
+ │          channel + remote Peer ID     │
+ └───────────────────────────────────────┘
+         │
+         ▼
+ ┌───────────────────────────────────────┐
+ │  Step 3: multistream-select           │
+ │  Negotiate muxer protocol             │
+ │  Dialer proposes: /yamux/1.0.0        │
+ │  Listener responds: /yamux/1.0.0      │
+ │  (runs over the encrypted channel)    │
+ └───────────────────────────────────────┘
+         │
+         ▼
+ ┌───────────────────────────────────────┐
+ │  Step 4: Muxer Initialization         │
+ │  Initialize Yamux session             │
+ │  Connection is now multiplexed        │
+ │  Streams can be opened/accepted       │
+ └───────────────────────────────────────┘
+         │
+         ▼
+ Upgraded Connection (secure + multiplexed)
+```
+
+### Step-by-Step Detail
+
+**Step 1: Security Protocol Negotiation (Chapter 7)**
+
+On the raw transport byte stream, both sides run multistream-select. The dialer
+proposes one or more security protocols. The listener selects one it supports.
+
+```
+Dialer                              Listener
+  │                                    │
+  │── "/multistream/1.0.0\n" ────────►│
+  │◄── "/multistream/1.0.0\n" ────────│
+  │                                    │
+  │── "/noise\n" ────────────────────►│
+  │◄── "/noise\n" ────────────────────│  (agreed)
+  │                                    │
+```
+
+If the listener does not support the proposed protocol, it responds with `na`.
+The dialer may propose alternatives. If no agreement is reached, the connection
+is closed.
+
+Supported security protocols:
+
+| Protocol ID | Description |
+|-------------|-------------|
+| `/noise` | Noise XX (recommended for TCP) |
+| `/tls/1.0.0` | TLS 1.3 |
+
+**Step 2: Security Handshake (Chapter 5)**
+
+Once a security protocol is agreed, the handshake proceeds over the raw
+transport stream. For Noise XX, this is a 3-message handshake (1.5 RTT) that
+produces an encrypted, authenticated channel. For TLS 1.3, this is a standard
+TLS handshake (1 RTT).
+
+After the security handshake:
+- Both sides know the remote peer's identity (Peer ID)
+- All subsequent data is encrypted and authenticated
+- The dialer can verify the remote Peer ID matches expectations
+
+**Step 3: Muxer Protocol Negotiation (Chapter 7)**
+
+Over the now-encrypted channel, both sides run multistream-select again. The
+dialer proposes a stream multiplexer. The listener selects one it supports.
+
+```
+Dialer                              Listener
+  │                                    │
+  │── "/multistream/1.0.0\n" ────────►│   (encrypted)
+  │◄── "/multistream/1.0.0\n" ────────│   (encrypted)
+  │                                    │
+  │── "/yamux/1.0.0\n" ──────────────►│   (encrypted)
+  │◄── "/yamux/1.0.0\n" ──────────────│   (encrypted, agreed)
+  │                                    │
+```
+
+Supported muxer protocols:
+
+| Protocol ID | Description |
+|-------------|-------------|
+| `/yamux/1.0.0` | Yamux (recommended) |
+| `/mplex/6.7.0` | mplex (deprecated) |
+
+**Step 4: Muxer Initialization (Chapter 6)**
+
+After muxer agreement, the Yamux session is initialized. The dialer takes the
+client role (odd stream IDs), the listener takes the server role (even stream
+IDs). The connection is now fully upgraded and ready for application streams.
+
+### Early Muxer Negotiation (Noise Extensions Optimization)
+
+The standard upgrade pipeline requires two rounds of multistream-select: one
+for security and one for the muxer. The Noise handshake payload includes an
+optional `extensions` field (see Chapter 5) that can carry muxer preferences,
+eliminating the second multistream-select round-trip.
+
+```
+Standard Pipeline (3 round-trips for negotiation):
+  multistream-select (security)   1 RTT
+  Noise XX handshake              1.5 RTT
+  multistream-select (muxer)      1 RTT
+  ─────────────────────────────
+  Total:                          3.5 RTT
+
+With Early Muxer Negotiation (2 round-trips):
+  multistream-select (security)   1 RTT
+  Noise XX handshake              1.5 RTT  (muxer piggybacked in payload)
+  ─────────────────────────────
+  Total:                          2.5 RTT
+```
+
+**How it works:**
+
+1. During the Noise handshake, each peer includes its supported muxers in the
+   `NoiseExtensions.stream_muxers` field of the handshake payload (messages 2
+   and 3).
+2. The initiator sends its supported muxers in message 3.
+3. The responder sends its supported muxers in message 2.
+4. After the handshake completes, both sides select the muxer using the
+   following rule: pick the first muxer from the **initiator's** list that
+   appears in the **responder's** list.
+5. If a common muxer is found, the muxer is initialized immediately. No
+   multistream-select negotiation for the muxer is needed.
+6. If no common muxer is found (or if either side did not send extensions),
+   fall back to the standard multistream-select muxer negotiation.
+
+**Important:** The initiator MUST NOT include extensions in Noise message 1
+(it is unencrypted). Extensions are only sent in messages 2 and 3, which are
+encrypted.
+
+### Upgrade for Non-Upgrading Transports
+
+QUIC, WebRTC, and WebTransport have built-in encryption and multiplexing. For
+these transports, the Switch skips the upgrade pipeline entirely. The transport
+itself provides the secure, multiplexed connection. Protocol negotiation
+(multistream-select) still occurs per-stream for application protocols.
+
+| Transport | Security Upgrade | Muxer Upgrade | Per-Stream Negotiation |
+|-----------|-----------------|---------------|----------------------|
+| TCP | Yes (Noise/TLS) | Yes (Yamux) | Yes |
+| WebSocket | Yes (Noise/TLS) | Yes (Yamux) | Yes |
+| QUIC v1 | No (built-in TLS 1.3) | No (built-in) | Yes |
+| WebRTC | No (built-in DTLS) | No (built-in SCTP) | Yes |
+| WebTransport | No (built-in TLS 1.3) | No (built-in) | Yes |
+
+## Dialing
+
+The Switch provides a `Dial` operation that, given a Peer ID and optionally a
+set of addresses, establishes an upgraded connection to the remote peer.
+
+### Dial Flow
+
+```
+         Dial(PeerID, [Multiaddr])
+                  │
+                  ▼
+    ┌─────────────────────────────┐
+    │  1. Check connection pool   │──── Existing connection? ──► Return it
+    │     for existing connection │
+    └─────────────────────────────┘
+                  │ (no existing connection)
+                  ▼
+    ┌─────────────────────────────┐
+    │  2. Resolve addresses       │
+    │     - Use provided addrs    │
+    │     - Query peer store      │
+    │     - Query DHT (optional)  │
+    └─────────────────────────────┘
+                  │
+                  ▼
+    ┌─────────────────────────────┐
+    │  3. Check dial backoff      │──── Recently failed? ──► Return error
+    │     for the peer            │
+    └─────────────────────────────┘
+                  │ (no backoff active)
+                  ▼
+    ┌─────────────────────────────┐
+    │  4. Connection gating       │──── Policy denies? ──► Return error
+    │     (optional)              │
+    └─────────────────────────────┘
+                  │ (allowed)
+                  ▼
+    ┌─────────────────────────────┐
+    │  5. Resource check          │──── Over limits? ──► Return error
+    │     (connection limits)     │
+    └─────────────────────────────┘
+                  │ (within limits)
+                  ▼
+    ┌─────────────────────────────┐
+    │  6. Select transport for    │
+    │     each address            │
+    │     (match multiaddr to     │
+    │      registered transport)  │
+    └─────────────────────────────┘
+                  │
+                  ▼
+    ┌─────────────────────────────┐
+    │  7. Parallel dial attempts  │
+    │     (ranked, staggered)     │
+    └─────────────────────────────┘
+                  │
+                  ▼
+    ┌─────────────────────────────┐
+    │  8. First success:          │
+    │     Upgrade connection      │
+    │     Cancel remaining dials  │
+    └─────────────────────────────┘
+                  │
+                  ▼
+    ┌─────────────────────────────┐
+    │  9. Add to connection pool  │
+    │     Emit Connected event    │
+    └─────────────────────────────┘
+                  │
+                  ▼
+          Return Connection
+```
+
+### Parallel Dial Attempts (Happy Eyeballs Style)
+
+When a peer has multiple addresses, the Switch dials them in parallel using a
+staggered approach inspired by the Happy Eyeballs algorithm (RFC 8305). This
+avoids waiting for slow addresses while still preferring certain address types.
+
+**Address ranking:**
+
+1. QUIC addresses are preferred over TCP (lower latency, no upgrade overhead)
+2. IPv6 addresses are preferred over IPv4
+3. Direct addresses are preferred over relayed addresses
+4. Recently successful addresses are preferred
+
+**Staggered dialing:**
+
+Rather than dialing all addresses simultaneously (which wastes resources) or
+sequentially (which is slow), the Switch uses staggered delays:
+
+```
+Time   Action
+─────  ──────────────────────────────────────────
+ 0ms   Dial address 1 (highest ranked)
+250ms  If no success yet, dial address 2
+500ms  If no success yet, dial address 3
+...    Continue with 250ms delay between attempts
+```
+
+The 250ms delay comes from RFC 8305. It provides enough time for fast addresses
+to succeed while not waiting too long before trying alternatives.
+
+**On first success:**
+- Cancel all pending dial attempts
+- Upgrade the successful connection
+- Return the upgraded connection
+
+**On all failures:**
+- Activate dial backoff for the peer
+- Return an error
+
+### Dial Backoff
+
+When all dial attempts to a peer fail, the Switch records a backoff entry to
+avoid hammering unreachable peers.
+
+| Parameter | Typical Value | Description |
+|-----------|---------------|-------------|
+| Backoff duration | 5 seconds | Time before retrying a failed peer |
+| Backoff multiplier | 2x | Exponential increase on repeated failures |
+| Maximum backoff | 5 minutes | Upper bound on backoff duration |
+| Backoff reset | On successful connection | Clears backoff state |
+
+```
+Attempt 1 fails  →  backoff 5s
+Attempt 2 fails  →  backoff 10s
+Attempt 3 fails  →  backoff 20s
+Attempt 4 fails  →  backoff 40s
+...
+Attempt N fails  →  backoff min(5s * 2^(N-1), 300s)
+```
+
+Any dial attempt during the backoff period returns immediately with an error
+without actually attempting the connection. The backoff is per-peer, not
+per-address.
+
+### Dial Deduplication
+
+If multiple goroutines (or threads) attempt to dial the same peer
+simultaneously, the Switch deduplicates these into a single dial operation. All
+callers receive the same connection (or error) when the dial completes.
+
+```
+Thread A: Dial(PeerX)  ──┐
+                          ├──►  Single dial operation  ──►  Connection
+Thread B: Dial(PeerX)  ──┘                                    │
+                                                              ├──► Thread A
+                                                              └──► Thread B
+```
+
+## Listening
+
+The Switch provides a `Listen` operation that binds one or more transports to
+local addresses and accepts inbound connections.
+
+### Listen Flow
+
+```
+         Listen([Multiaddr])
+                  │
+                  ▼
+    ┌─────────────────────────────┐
+    │  1. Select transport for    │
+    │     each listen address     │
+    └─────────────────────────────┘
+                  │
+                  ▼
+    ┌─────────────────────────────┐
+    │  2. Bind transport to       │
+    │     listen address          │
+    │     (e.g., TCP bind+listen) │
+    └─────────────────────────────┘
+                  │
+                  ▼
+    ┌─────────────────────────────┐
+    │  3. Accept loop (per        │
+    │     transport listener)     │
+    └─────────────────────────────┘
+                  │
+                  ▼ (on each accepted connection)
+    ┌─────────────────────────────┐
+    │  4. Connection gating       │──── Policy denies? ──► Close raw conn
+    │     (check IP/PeerID)       │
+    └─────────────────────────────┘
+                  │ (allowed)
+                  ▼
+    ┌─────────────────────────────┐
+    │  5. Resource check          │──── Over limits? ──► Close raw conn
+    └─────────────────────────────┘
+                  │ (within limits)
+                  ▼
+    ┌─────────────────────────────┐
+    │  6. Upgrade connection      │
+    │     (security + muxer)      │
+    │     as responder             │
+    └─────────────────────────────┘
+                  │
+                  ▼
+    ┌─────────────────────────────┐
+    │  7. Verify remote Peer ID   │──── Already connected? ──► Policy decision
+    │     (known after security   │     (allow multiple or reject)
+    │      handshake)             │
+    └─────────────────────────────┘
+                  │
+                  ▼
+    ┌─────────────────────────────┐
+    │  8. Add to connection pool  │
+    │     Emit Connected event    │
+    │     Start stream accept     │
+    │     loop for this conn      │
+    └─────────────────────────────┘
+```
+
+### Inbound Connection Handling
+
+For each accepted connection, the Switch spawns a concurrent task that:
+
+1. **Upgrades the connection** as the responder (the dialing side is the
+   initiator; the listening side is the responder in multistream-select and
+   Noise/TLS).
+2. **Runs the stream accept loop**: continuously accepts new inbound streams
+   from the muxer and dispatches each to the appropriate protocol handler.
+
+```
+Stream Accept Loop (per connection):
+
+    loop {
+        stream ← accept_stream(muxer_session)
+        spawn {
+            protocol ← multistream_select_respond(stream, registered_protocols)
+            handler  ← lookup_handler(protocol)
+            handler(stream)
+        }
+    }
+```
+
+Each inbound stream is handled in its own concurrent task. The
+multistream-select negotiation on the stream determines which protocol handler
+receives it.
+
+### Inbound vs Outbound Roles
+
+| Aspect | Dialer (Outbound) | Listener (Inbound) |
+|--------|-------------------|---------------------|
+| multistream-select role | Proposer | Responder |
+| Noise/TLS role | Initiator | Responder |
+| Yamux role | Client (odd stream IDs) | Server (even stream IDs) |
+| Who opens first stream | Typically the dialer | Either side can |
+
+## Connection Reuse
+
+Stream multiplexing (Chapter 6) enables multiple independent streams over a
+single connection. The Switch exploits this to avoid redundant connections.
+
+### Reuse Policy
+
+When the application requests a new stream to a peer:
+
+1. **Check the connection pool** for an existing connection to that peer.
+2. If a healthy connection exists, open a new stream on it. No new connection
+   is needed.
+3. If no connection exists (or all existing connections are closing), dial a new
+   connection.
+
+```
+Application: OpenStream(PeerID, "/ipfs/kad/1.0.0")
+         │
+         ▼
+    ┌────────────────────────┐
+    │  Connection pool lookup │
+    │  for PeerID             │
+    └────────────────────────┘
+         │                │
+    (found)          (not found)
+         │                │
+         ▼                ▼
+    Open stream      Dial peer
+    on existing      ──► Upgrade
+    connection       ──► Open stream
+```
+
+### When to Open New Connections vs Reuse
+
+In general, a single multiplexed connection per peer is sufficient. However,
+there are cases where multiple connections to the same peer are justified:
+
+| Scenario | Action |
+|----------|--------|
+| No existing connection | Dial new |
+| Existing healthy connection | Reuse (open stream) |
+| Existing connection is closing | Dial new |
+| Simultaneous dial (both peers dial each other) | Keep one, close one (see below) |
+| Transport diversity (e.g., TCP + QUIC) | Implementation-specific |
+
+### Simultaneous Open
+
+When two peers dial each other at the same time, both will establish a
+connection, resulting in two connections between the same pair. The Switch
+resolves this by keeping one and closing the other using a deterministic tie-
+breaking rule:
+
+**Rule:** Compare the two peers' Peer IDs as byte strings. The peer with the
+**larger** Peer ID keeps its initiated (outbound) connection; the peer with
+the **smaller** Peer ID closes its initiated connection and uses the inbound
+connection instead.
+
+This ensures both sides agree on which connection to keep without additional
+coordination.
+
+## Connection Lifecycle
+
+Each connection managed by the Switch progresses through a defined set of
+states.
+
+### Connection States
+
+```
+                  Dial / Accept
+                       │
+                       ▼
+               ┌──────────────┐
+               │  Connecting  │    Raw transport established,
+               │              │    upgrade in progress
+               └──────┬───────┘
+                      │ (upgrade succeeds)
+                      ▼
+               ┌──────────────┐
+               │    Open      │    Fully upgraded, streams
+               │              │    can be opened/accepted
+               └──────┬───────┘
+                      │ (shutdown initiated)
+                      ▼
+               ┌──────────────┐
+               │   Closing    │    Go Away sent/received,
+               │              │    no new streams, existing
+               │              │    streams draining
+               └──────┬───────┘
+                      │ (all streams closed)
+                      ▼
+               ┌──────────────┐
+               │   Closed     │    Transport connection
+               │              │    closed, resources freed
+               └──────────────┘
+```
+
+| State | Description | Allowed Operations |
+|-------|-------------|-------------------|
+| Connecting | Raw connection established, upgrade in progress | None (wait for upgrade) |
+| Open | Secure, multiplexed connection ready | Open streams, accept streams |
+| Closing | Graceful shutdown in progress | Existing streams continue, no new streams |
+| Closed | Connection terminated | None (removed from pool) |
+
+### Connection Events
+
+The Switch emits events that application code can subscribe to:
+
+| Event | When |
+|-------|------|
+| `Connected(PeerID, ConnInfo)` | Connection fully upgraded and added to pool |
+| `Disconnected(PeerID, ConnInfo)` | Connection closed and removed from pool |
+| `StreamOpened(PeerID, StreamInfo)` | New stream opened (inbound or outbound) |
+| `StreamClosed(PeerID, StreamInfo)` | Stream closed |
+
+`ConnInfo` includes: direction (inbound/outbound), remote address, local
+address, security protocol, muxer protocol. `StreamInfo` includes: stream ID,
+protocol ID, direction.
+
+### Graceful Shutdown
+
+Yamux supports graceful shutdown through the Go Away frame (see Chapter 6).
+When the Switch decides to close a connection:
+
+1. **Send Go Away** (error code 0x00 = normal termination) on the Yamux
+   session.
+2. **Stop accepting new streams** on this connection.
+3. **Wait for existing streams to complete** (with a timeout).
+4. **Close the transport connection** (TCP socket, etc.).
+
+The remote side, upon receiving Go Away:
+1. Stops opening new streams on this connection.
+2. Allows existing streams to finish.
+3. May open a new connection if it still needs to communicate.
+
+```
+Peer A                                  Peer B
+  │                                       │
+  │── GoAway [Normal, StreamID=0] ──────►│
+  │                                       │
+  │   (existing streams continue)         │
+  │◄──────── Data [StreamID=3] ──────────│
+  │── Data [StreamID=3, FIN] ───────────►│
+  │◄── Data [StreamID=3, FIN] ──────────│
+  │                                       │
+  │   (all streams closed)                │
+  │── TCP FIN ──────────────────────────►│
+  │◄── TCP FIN ──────────────────────────│
+```
+
+### Abrupt Termination
+
+If a connection must be closed immediately (e.g., protocol error, resource
+exhaustion), the Switch sends a Go Away with an appropriate error code and
+closes the transport connection without waiting for streams to drain.
+
+| Go Away Error Code | Value | Meaning |
+|--------------------|-------|---------|
+| Normal | 0x00 | Graceful shutdown |
+| Protocol Error | 0x01 | Muxer protocol violation |
+| Internal Error | 0x02 | Unrecoverable internal error |
+
+## Resource Management
+
+Without resource limits, a libp2p node is vulnerable to resource exhaustion
+attacks. An adversary could open thousands of connections or streams, consuming
+all available memory and file descriptors. The Switch enforces configurable
+limits at multiple scopes.
+
+### Resource Scopes
+
+Resource limits are applied hierarchically:
+
+```
+┌─────────────────────────────────────────────┐
+│  System Scope                                │
+│  (global limits for the entire node)         │
+│                                              │
+│  ┌────────────────────────────────────────┐  │
+│  │  Service Scope                         │  │
+│  │  (limits per protocol/service)         │  │
+│  │                                        │  │
+│  │  ┌─────────────────────────────────┐   │  │
+│  │  │  Peer Scope                     │   │  │
+│  │  │  (limits per remote peer)       │   │  │
+│  │  │                                 │   │  │
+│  │  │  ┌──────────────────────────┐   │   │  │
+│  │  │  │  Connection Scope       │   │   │  │
+│  │  │  │  (limits per connection) │   │   │  │
+│  │  │  │                         │   │   │  │
+│  │  │  │  ┌───────────────────┐  │   │   │  │
+│  │  │  │  │  Stream Scope    │  │   │   │  │
+│  │  │  │  │  (per stream)    │  │   │   │  │
+│  │  │  │  └───────────────────┘  │   │   │  │
+│  │  │  └──────────────────────────┘   │   │  │
+│  │  └─────────────────────────────────┘   │  │
+│  └────────────────────────────────────────┘  │
+└─────────────────────────────────────────────┘
+```
+
+Every resource reservation must be approved at every enclosing scope. For
+example, opening a new stream requires available capacity at the stream's scope,
+the connection scope, the peer scope, the service scope, and the system scope.
+
+### Tracked Resources
+
+| Resource | Description |
+|----------|-------------|
+| Connections (inbound) | Number of inbound connections |
+| Connections (outbound) | Number of outbound connections |
+| Streams (inbound) | Number of inbound streams |
+| Streams (outbound) | Number of outbound streams |
+| File descriptors | OS file descriptor usage (TCP sockets) |
+| Memory | Bytes of memory reserved for buffers |
+
+### Typical Default Limits
+
+| Scope | Resource | Typical Limit |
+|-------|----------|---------------|
+| System | Total connections | 128 - 256 |
+| System | Total streams | 1024 - 4096 |
+| System | Memory | Proportional to system RAM |
+| System | File descriptors | 256 - 512 |
+| Peer | Connections (inbound) | 4 |
+| Peer | Connections (outbound) | 4 |
+| Peer | Streams (inbound) | 256 |
+| Peer | Streams (outbound) | 256 |
+| Connection | Streams (inbound) | 256 |
+| Connection | Streams (outbound) | 256 |
+| Connection | Memory | 1 MiB - 4 MiB |
+
+These limits are implementation-specific and should be tunable. go-libp2p
+auto-scales limits proportional to available system memory.
+
+### Connection Gating
+
+Connection gating provides policy-based admission control. The Switch consults
+a connection gater at multiple points in the connection lifecycle:
+
+| Gate Point | Input | Decision |
+|------------|-------|----------|
+| Before dialing | Remote multiaddr | Allow / Deny dial |
+| After accepting | Remote IP address | Allow / Deny accept |
+| After security handshake | Remote Peer ID | Allow / Deny upgrade |
+| After muxer upgrade | Fully identified connection | Allow / Deny |
+
+Gating is separate from resource management. A connection may be within
+resource limits but denied by policy (e.g., a blocklisted Peer ID).
+
+### Connection Pruning
+
+When the connection pool approaches its limit, the Switch must decide which
+connections to prune (close). Pruning strategies consider:
+
+| Factor | Preference |
+|--------|------------|
+| Connection age | Older connections pruned first (LRU) |
+| Stream activity | Idle connections (no active streams) pruned first |
+| Direction | Inbound connections pruned before outbound |
+| Peer importance | Connections to peers with active protocols kept longer |
+| Redundancy | If multiple connections to same peer, close extras |
+
+The pruning algorithm runs when a new inbound connection would exceed the
+system connection limit. It selects the least valuable connection and closes it
+gracefully (Go Away) before accepting the new one.
+
+## Protocol Handlers
+
+Application protocols (Identify, Ping, Kademlia, GossipSub, custom protocols)
+register themselves with the Switch. When an inbound stream arrives, the Switch
+uses multistream-select to determine which protocol the remote side wants, then
+dispatches the stream to the registered handler.
+
+### Registering Protocol Handlers
+
+Each handler is registered with a protocol ID and a stream handler function:
+
+```
+Switch.SetStreamHandler("/ipfs/id/1.0.0",    identifyHandler)
+Switch.SetStreamHandler("/ipfs/ping/1.0.0",  pingHandler)
+Switch.SetStreamHandler("/ipfs/kad/1.0.0",   kadHandler)
+Switch.SetStreamHandler("/meshsub/1.1.0",    gossipsubHandler)
+```
+
+The protocol ID is a string that uniquely identifies the protocol. Protocol IDs
+follow the convention `/<name>/<version>`.
+
+### Stream Handler Dispatch
+
+When an inbound stream is accepted from the muxer:
+
+```
+Inbound Stream
+      │
+      ▼
+multistream-select (responder)
+      │
+      │  Remote peer proposes: "/ipfs/kad/1.0.0"
+      │  Check registered handlers
+      │
+      ├── Found? ──► Respond with "/ipfs/kad/1.0.0"
+      │               Dispatch stream to kadHandler
+      │
+      └── Not found? ──► Respond with "na"
+                         Remote may propose another protocol
+                         If no match: close stream
+```
+
+### Protocol Matching
+
+Protocol matching supports two modes:
+
+**Exact match:** The proposed protocol ID must exactly match a registered
+handler.
+
+**Semantic version match (optional):** Some implementations support matching
+based on semantic versioning. For example, a handler registered for
+`/ipfs/kad/1.0.0` could accept `/ipfs/kad/1.1.0` if the major version matches.
+This is implementation-specific and not required by the spec.
+
+### Outbound Streams
+
+To open an outbound stream to a remote peer for a specific protocol:
+
+1. Obtain a connection to the peer (reuse existing or dial new).
+2. Open a new muxer stream on the connection.
+3. Run multistream-select as the proposer, proposing the desired protocol.
+4. If the remote agrees, the stream is ready for application data.
+5. If the remote responds with `na`, the stream is closed with an error.
+
+```
+OpenStream(PeerID, "/ipfs/kad/1.0.0")
+         │
+         ▼
+    Get/Dial connection to PeerID
+         │
+         ▼
+    Open new muxer stream
+         │
+         ▼
+    multistream-select (proposer)
+    Propose "/ipfs/kad/1.0.0"
+         │
+         ├── Agreed ──► Return stream for application use
+         │
+         └── "na" ──► Close stream, return error
+```
+
+## Haskell Implementation Notes
+
+### Architecture Sketch
+
+The Switch can be modeled as a record of operations backed by shared concurrent
+state:
+
+```haskell
+data Switch = Switch
+  { swConfig        :: SwitchConfig
+  , swTransports    :: TVar (Map TransportKey Transport)
+  , swConnPool      :: TVar (Map PeerID [Connection])
+  , swListeners     :: TVar [Listener]
+  , swProtocols     :: TVar (Map ProtocolID StreamHandler)
+  , swDialBackoffs  :: TVar (Map PeerID BackoffState)
+  , swResourceMgr   :: ResourceManager
+  , swConnGater     :: ConnectionGater
+  , swEvents        :: TChan SwitchEvent
+  }
+
+data SwitchConfig = SwitchConfig
+  { scListenAddrs     :: [Multiaddr]
+  , scSecurityProtos  :: [SecurityProtocol]   -- e.g., [Noise, TLS13]
+  , scMuxerProtos     :: [MuxerProtocol]      -- e.g., [Yamux, Mplex]
+  , scDialTimeout     :: NominalDiffTime      -- e.g., 10 seconds
+  , scDialBackoff     :: BackoffConfig
+  , scResourceLimits  :: ResourceLimits
+  }
+
+data Connection = Connection
+  { connPeerID     :: PeerID
+  , connDirection  :: Direction        -- Inbound | Outbound
+  , connLocalAddr  :: Multiaddr
+  , connRemoteAddr :: Multiaddr
+  , connSecurity   :: ProtocolID       -- e.g., "/noise"
+  , connMuxer      :: ProtocolID       -- e.g., "/yamux/1.0.0"
+  , connSession    :: MuxerSession     -- open/accept streams
+  , connState      :: TVar ConnState   -- Connecting | Open | Closing | Closed
+  }
+
+data Direction = Inbound | Outbound
+  deriving (Eq, Show)
+
+data ConnState = Connecting | Open | Closing | Closed
+  deriving (Eq, Show)
+
+type StreamHandler = Stream -> IO ()
+
+data SwitchEvent
+  = Connected    PeerID ConnInfo
+  | Disconnected PeerID ConnInfo
+  | StreamOpened  PeerID StreamInfo
+  | StreamClosed  PeerID StreamInfo
+```
+
+### Key Operations
+
+```haskell
+-- Dial a peer, reusing existing connections when possible
+dial :: Switch -> PeerID -> [Multiaddr] -> IO Connection
+
+-- Open a new stream to a peer for a specific protocol
+openStream :: Switch -> PeerID -> ProtocolID -> IO Stream
+
+-- Register a protocol handler
+setStreamHandler :: Switch -> ProtocolID -> StreamHandler -> IO ()
+
+-- Start listening on configured addresses
+listen :: Switch -> IO ()
+
+-- Close the switch and all connections
+close :: Switch -> IO ()
+```
+
+### Use of STM for Concurrent State
+
+The Switch manages highly concurrent state: multiple connections, streams,
+dial attempts, and protocol handlers accessed from many threads simultaneously.
+STM (Software Transactional Memory) is the natural fit in Haskell.
+
+```haskell
+-- Atomic connection pool lookup and insertion
+dialOrReuse :: Switch -> PeerID -> [Multiaddr] -> IO Connection
+dialOrReuse sw pid addrs = do
+    -- Check pool atomically
+    existing <- atomically $ do
+        pool <- readTVar (swConnPool sw)
+        case Map.lookup pid pool of
+            Just (c:_) -> do
+                st <- readTVar (connState c)
+                if st == Open then return (Just c) else return Nothing
+            _ -> return Nothing
+    case existing of
+        Just c  -> return c
+        Nothing -> dialNew sw pid addrs
+
+-- Atomic resource reservation
+reserveConnection :: ResourceManager -> PeerID -> Direction -> STM (Either ResourceError ())
+```
+
+Key STM patterns:
+- `TVar (Map PeerID [Connection])` for the connection pool
+- `TVar (Map ProtocolID StreamHandler)` for the protocol registry
+- `TVar (Map PeerID BackoffState)` for dial backoffs
+- `TChan SwitchEvent` for event broadcasting
+- Compose multiple reads/writes atomically with `atomically`
+
+### Resource Management with Bracket Patterns
+
+Connection and stream lifecycles are managed with bracket patterns to ensure
+cleanup on exceptions:
+
+```haskell
+withConnection :: Switch -> PeerID -> (Connection -> IO a) -> IO a
+withConnection sw pid action =
+    bracket
+        (dial sw pid [])
+        (\conn -> atomically $ modifyTVar (connState conn) (const Closing))
+        action
+
+withStream :: Connection -> ProtocolID -> (Stream -> IO a) -> IO a
+withStream conn proto action =
+    bracket
+        (openMuxerStream (connSession conn))
+        closeStream
+        (\stream -> do
+            negotiateProtocol stream proto
+            action stream)
+```
+
+Resource cleanup is critical: every opened connection must be closed, every
+opened stream must be closed, every reserved resource must be released. The
+bracket pattern guarantees this even in the presence of asynchronous exceptions.
+
+### Accept Loop with Async
+
+The listener accept loop spawns a new `async` task for each inbound connection:
+
+```haskell
+acceptLoop :: Switch -> Listener -> IO ()
+acceptLoop sw listener = forever $ do
+    rawConn <- accept listener
+    void $ async $ handleInbound sw rawConn
+
+handleInbound :: Switch -> RawConnection -> IO ()
+handleInbound sw rawConn = do
+    -- Gate check, resource check, upgrade, add to pool
+    result <- try $ upgradeInbound sw rawConn
+    case result of
+        Left (e :: SomeException) -> closeRaw rawConn
+        Right conn -> do
+            addToPool sw conn
+            streamAcceptLoop sw conn
+
+streamAcceptLoop :: Switch -> Connection -> IO ()
+streamAcceptLoop sw conn = forever $ do
+    stream <- acceptStream (connSession conn)
+    void $ async $ dispatchStream sw conn stream
+```
+
+### Concurrency Summary
+
+| Component | Concurrency Primitive | Rationale |
+|-----------|----------------------|-----------|
+| Connection pool | `TVar (Map ...)` | Atomic read/modify from many threads |
+| Protocol registry | `TVar (Map ...)` | Handlers may be added/removed at runtime |
+| Dial backoffs | `TVar (Map ...)` | Updated from dial threads, read from any |
+| Connection state | `TVar ConnState` | Transitions observed by multiple threads |
+| Events | `TChan SwitchEvent` | Broadcast to multiple subscribers |
+| Accept loop | `async` per connection | Each connection handled independently |
+| Stream dispatch | `async` per stream | Each stream handled independently |
+| Parallel dialing | `race` / `async` | First success wins |
+| Resource cleanup | `bracket` / `finally` | Exception safety |
+
+## Spec References
+
+- Connections spec: https://github.com/libp2p/specs/blob/master/connections/README.md
+- Switch concept: https://docs.libp2p.io/concepts/multiplex/switch/
+- go-libp2p swarm: https://github.com/libp2p/go-libp2p/tree/master/p2p/net/swarm
+- go-libp2p resource manager: https://github.com/libp2p/go-libp2p/tree/master/p2p/host/resource-manager
+- Noise extensions (early muxer): https://github.com/libp2p/specs/tree/master/noise
+- Happy Eyeballs: https://www.rfc-editor.org/rfc/rfc8305

--- a/docs/09-dht.md
+++ b/docs/09-dht.md
@@ -1,0 +1,1026 @@
+# Chapter 9: Distributed Hash Table (Kademlia)
+
+The libp2p Distributed Hash Table (DHT) is the primary mechanism for peer
+routing and content discovery in decentralized libp2p networks. It is based on
+the Kademlia algorithm, augmented with ideas from S/Kademlia, Coral, and the
+BitTorrent DHT. This chapter covers the wire protocol, routing table mechanics,
+lookup algorithms, and record management in full implementation detail.
+
+## Kademlia Fundamentals
+
+### XOR Distance Metric
+
+Kademlia defines "distance" between two keys using the bitwise XOR operation.
+This is not a physical distance -- it is a mathematical metric over a 256-bit
+keyspace.
+
+Given two keys `a` and `b`, the distance is:
+
+```
+distance(a, b) = XOR(sha256(a), sha256(b))
+```
+
+Both keys are first hashed with SHA-256 to produce 256-bit values, then XORed
+together. The result is interpreted as an unsigned 256-bit integer.
+
+**Worked example:**
+
+```
+Peer A ID (SHA-256):  0010 1100 ...  (256 bits)
+Peer B ID (SHA-256):  0010 0101 ...  (256 bits)
+                      ─────────
+XOR distance:         0000 1001 ...  (256 bits)
+
+Peer A ID (SHA-256):  0010 1100 ...  (256 bits)
+Peer C ID (SHA-256):  1101 0011 ...  (256 bits)
+                      ─────────
+XOR distance:         1111 1111 ...  (256 bits)
+
+distance(A, B) < distance(A, C)
+because 0000 1001... < 1111 1111...
+```
+
+Peer B is "closer" to Peer A than Peer C in XOR space. Note that this has
+nothing to do with network topology or geographic location.
+
+### Properties of XOR Distance
+
+The XOR metric satisfies the properties required for a proper distance function:
+
+1. **Identity**: `d(x, x) = 0` -- a key has zero distance to itself
+2. **Symmetry**: `d(x, y) = d(y, x)` -- if A is close to B, then B is close to A.
+   This is a key advantage over asymmetric metrics: every lookup for a target
+   converges from all directions simultaneously.
+3. **Triangle inequality**: `d(x, z) <= d(x, y) + d(y, z)` -- the direct
+   distance is never longer than going through an intermediate point.
+4. **Non-negativity**: `d(x, y) >= 0` for all x, y.
+5. **Unidirectionality**: For any point `x` and distance `delta > 0`, there is
+   exactly one point `y` such that `d(x, y) = delta`. This means that lookups
+   for the same key from different starting points converge along the same path.
+
+### 256-bit Keyspace
+
+All keys in the libp2p DHT are 256-bit SHA-256 hashes. Peer IDs are hashed
+with SHA-256 to produce their position in the keyspace:
+
+```
+key = SHA-256(peer_id_bytes)
+```
+
+This means the keyspace has 2^256 possible positions. The SHA-256 hash ensures
+a uniform distribution of peers across the keyspace, preventing clustering.
+
+## Routing Table
+
+### k-Buckets
+
+The routing table is organized into **k-buckets**, where each bucket holds up to
+`k` peers at a particular distance range from the local node.
+
+**Replication parameter `k`:** The recommended value is **20** in the libp2p
+DHT. This governs both the bucket size and the replication factor for stored
+records.
+
+### Bucket Structure
+
+An implementation must try to maintain `k` peers with shared key prefix of
+length `L`, for every `L` in `[0..255]`, in its routing table.
+
+There are 256 buckets, one for each bit of distance:
+
+```
+Bucket 0:   Peers with distance in [2^255, 2^256)   — differ in bit 0 (MSB)
+Bucket 1:   Peers with distance in [2^254, 2^255)   — share bit 0, differ in bit 1
+Bucket 2:   Peers with distance in [2^253, 2^254)   — share bits 0-1, differ in bit 2
+  ...
+Bucket 254: Peers with distance in [2^1, 2^2)       — share bits 0-253, differ in bit 254
+Bucket 255: Peers with distance in [2^0, 2^1)       — share bits 0-254, differ in bit 255
+```
+
+Equivalently, bucket `i` contains peers whose key shares a common prefix of
+length `i` with the local node's key and differs at bit `i`.
+
+```
+Local node key:  0010 1100 0111 ...
+
+Bucket 0:  1... .... .... ...   (first bit differs)
+Bucket 1:  01.. .... .... ...   (first bit matches, second differs)
+Bucket 2:  001. .... .... ...   (first 2 bits match, third differs)
+Bucket 3:  0011 .... .... ...   (first 3 bits match, fourth differs)
+Bucket 4:  0010 0... .... ...   (first 4 bits match, fifth differs)
+  ...
+
+Each bucket holds up to k=20 peers.
+```
+
+The bucket for distant peers (bucket 0) covers half the keyspace and is
+easily filled. Buckets for nearby peers (high index) cover exponentially smaller
+portions of the keyspace and may remain partially empty.
+
+### Bucket Refresh and Maintenance
+
+The routing table must be kept fresh to reflect the current state of the
+network. The bootstrap process (described below) refreshes buckets periodically.
+
+On every bootstrap run (default: every 10 minutes):
+1. For every non-empty k-bucket, generate a random peer ID that would fall
+   into that bucket.
+2. Perform a lookup for that random ID via the `FIND_NODE` RPC.
+3. Peers encountered during the lookup are inserted into the routing table.
+
+This ensures that all buckets remain populated with live peers.
+
+### Least-Recently-Seen Eviction
+
+When a new peer is discovered and the appropriate k-bucket is full, the
+implementation must decide whether to keep or evict an existing entry.
+
+The original Kademlia paper specifies pinging the least-recently-seen peer:
+- If it responds, it is moved to the tail (most recently seen) and the new peer
+  is discarded. Long-lived peers are statistically more likely to remain online.
+- If it does not respond, it is evicted and the new peer takes its place.
+
+Note: The libp2p DHT implementation historically deviates from this by evicting
+the least-recently-seen peer without pinging, which causes higher bucket churn.
+Implementations SHOULD follow the standard Kademlia eviction policy (ping first)
+for better routing table stability.
+
+### Routing Table Entry
+
+Each entry in a k-bucket contains:
+
+| Field | Description |
+|-------|-------------|
+| Peer ID | The peer's identity |
+| Addresses | Known multiaddrs for the peer |
+| Last seen | Timestamp of last successful communication |
+| Connection type | Current connection status |
+
+## Protocol ID
+
+```
+/ipfs/kad/1.0.0
+```
+
+This is the protocol identifier used with multistream-select when opening a
+Kademlia DHT stream. Nodes operating in **server mode** advertise this protocol
+via the Identify protocol. Nodes operating in **client mode** do not advertise
+it.
+
+## RPC Messages
+
+### Wire Format
+
+All RPC messages are sent over a dedicated stream:
+
+1. Open a new stream using multistream-select with `/ipfs/kad/1.0.0`.
+2. Send the request message.
+3. Read the response message.
+4. Close the stream.
+
+On any error, the stream is reset.
+
+Each message is prefixed with its length in bytes, encoded as an unsigned
+variable-length integer (unsigned varint, as defined by the multiformats
+unsigned-varint spec).
+
+```
+┌──────────────────────┬──────────────────────────────┐
+│  message_length      │       protobuf_message       │
+│  (uvarint)           │     (variable length)        │
+└──────────────────────┴──────────────────────────────┘
+```
+
+### Protobuf Definitions
+
+The following protobuf definitions are taken verbatim from the spec:
+
+```protobuf
+syntax = "proto2";
+
+// Record represents a dht record that contains a value
+// for a key value pair
+message Record {
+    // The key that references this record
+    bytes key = 1;
+
+    // The actual value this record is storing
+    bytes value = 2;
+
+    // Note: These fields were removed from the Record message
+    //
+    // Hash of the authors public key
+    // optional string author = 3;
+    // A PKI signature for the key+value+author
+    // optional bytes signature = 4;
+
+    // Time the record was received, set by receiver
+    // Formatted according to https://datatracker.ietf.org/doc/html/rfc3339
+    string timeReceived = 5;
+};
+
+message Message {
+    enum MessageType {
+        PUT_VALUE     = 0;
+        GET_VALUE     = 1;
+        ADD_PROVIDER  = 2;
+        GET_PROVIDERS = 3;
+        FIND_NODE     = 4;
+        PING          = 5;
+    }
+
+    enum ConnectionType {
+        // sender does not have a connection to peer, and no extra information
+        // (default)
+        NOT_CONNECTED = 0;
+
+        // sender has a live connection to peer
+        CONNECTED     = 1;
+
+        // sender recently connected to peer
+        CAN_CONNECT   = 2;
+
+        // sender recently tried to connect to peer repeatedly but failed to
+        // connect ("try" here is loose, but this should signal "made strong
+        // effort, failed")
+        CANNOT_CONNECT = 3;
+    }
+
+    message Peer {
+        // ID of a given peer.
+        bytes id = 1;
+
+        // multiaddrs for a given peer
+        repeated bytes addrs = 2;
+
+        // used to signal the sender's connection capabilities to the peer
+        ConnectionType connection = 3;
+    }
+
+    // defines what type of message it is.
+    MessageType type = 1;
+
+    // defines what coral cluster level this query/response belongs to.
+    // in case we want to implement coral's cluster rings in the future.
+    int32 clusterLevelRaw = 10;  // NOT USED
+
+    // Used to specify the key associated with this message.
+    // PUT_VALUE, GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
+    bytes key = 2;
+
+    // Used to return a value
+    // PUT_VALUE, GET_VALUE
+    Record record = 3;
+
+    // Used to return peers closer to a key in a query
+    // GET_VALUE, GET_PROVIDERS, FIND_NODE
+    repeated Peer closerPeers = 8;
+
+    // Used to return Providers
+    // GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
+    repeated Peer providerPeers = 9;
+}
+```
+
+### FIND_NODE
+
+Used for peer routing -- finding the closest peers to a given key.
+
+**Request:**
+| Field | Value |
+|-------|-------|
+| `type` | `FIND_NODE` (4) |
+| `key` | Binary Peer ID of the node to find |
+
+**Response:**
+| Field | Value |
+|-------|-------|
+| `type` | `FIND_NODE` (4) |
+| `closerPeers` | Up to `k` closest `Peer` entries known by the responder |
+
+Each `Peer` in `closerPeers` contains the peer's ID, known multiaddrs, and
+connection type.
+
+**Wire example (conceptual):**
+
+```
+Request:
+  type: FIND_NODE
+  key:  0x12200a1b2c3d...  (peer ID bytes, 34 bytes for Ed25519)
+
+Response:
+  type: FIND_NODE
+  closerPeers: [
+    { id: 0x1220..., addrs: [/ip4/1.2.3.4/tcp/4001], connection: CONNECTED },
+    { id: 0x1220..., addrs: [/ip4/5.6.7.8/tcp/4001], connection: CAN_CONNECT },
+    ...  (up to k=20 peers)
+  ]
+```
+
+### PUT_VALUE / GET_VALUE
+
+Used for storing and retrieving arbitrary records in the DHT.
+
+**PUT_VALUE request:**
+| Field | Value |
+|-------|-------|
+| `type` | `PUT_VALUE` (0) |
+| `key` | Key for the record |
+| `record` | `Record` protobuf with `key` and `value` |
+
+**PUT_VALUE response:**
+The target node validates the record. If valid, it stores the record and echoes
+the request back as the response.
+
+**GET_VALUE request:**
+| Field | Value |
+|-------|-------|
+| `type` | `GET_VALUE` (1) |
+| `key` | Key to look up |
+
+**GET_VALUE response:**
+| Field | Value |
+|-------|-------|
+| `type` | `GET_VALUE` (1) |
+| `record` | The `Record` for the key (if found in the datastore) |
+| `closerPeers` | Up to `k` closest peers to the key |
+
+The response may contain both a record and closer peers. The caller uses the
+closer peers to continue the iterative lookup if needed.
+
+### ADD_PROVIDER / GET_PROVIDERS
+
+Used for content routing -- advertising and discovering content providers.
+
+**ADD_PROVIDER request:**
+| Field | Value |
+|-------|-------|
+| `type` | `ADD_PROVIDER` (2) |
+| `key` | Multihash of the content (not a CID -- see note below) |
+| `providerPeers` | `Peer` entries for the provider (must match sender's Peer ID) |
+
+The target node verifies that the `providerPeers` entries match the sender's
+Peer ID. If they do, the provider record is stored.
+
+**GET_PROVIDERS request:**
+| Field | Value |
+|-------|-------|
+| `type` | `GET_PROVIDERS` (3) |
+| `key` | Multihash of the content |
+
+**GET_PROVIDERS response:**
+| Field | Value |
+|-------|-------|
+| `type` | `GET_PROVIDERS` (3) |
+| `providerPeers` | Known provider `Peer` entries for this key |
+| `closerPeers` | Up to `k` closest peers to the key |
+
+**Why multihash, not CID?** Provider records use multihashes as keys because
+the same content (same multihash) may appear under different CIDs (CIDv0 vs
+CIDv1, different codecs like dag-pb vs raw). The multihash is the minimal
+common denominator that all parties agree on.
+
+### PING (Deprecated)
+
+The `PING` message type (5) is deprecated and replaced by the dedicated ping
+protocol (`/ipfs/ping/1.0.0`). Implementations may handle incoming PING
+requests for backwards compatibility but MUST NOT actively send them.
+
+## Iterative Lookup Algorithm
+
+The core of Kademlia is the iterative lookup -- a process that converges
+towards the `k` closest peers to a target key by querying progressively closer
+peers.
+
+### Alpha Concurrency Parameter
+
+The concurrency of lookups is limited by parameter `alpha` (written as `a`
+below). The libp2p spec sets the default value to **10**, meaning up to 10
+in-flight requests at any time. (Note: The original Kademlia paper uses
+`alpha = 3`.)
+
+### Step-by-Step Algorithm (FIND_NODE)
+
+**Goal:** Find the `k` closest peers to a target key `Key`.
+
+**State:**
+- `Pq`: Set of peers already queried
+- `Pn`: Candidate peers sorted by ascending XOR distance from `Key`
+
+**Initialization:**
+Seed `Pn` with the `k` closest peers to `Key` from the local routing table.
+
+**Loop:**
+
+```
+1. TERMINATION CHECK
+   If we have queried and received responses from the k closest
+   peers we have seen, return those k peers as the result.
+   Also terminate early if Pn is empty and no requests are in flight.
+
+2. SEND QUERIES
+   Pick up to alpha peers from the front of Pn (closest first).
+   Send FIND_NODE(Key) to each.
+   Move them from Pn to Pq (mark as queried).
+
+3. PROCESS RESPONSES
+   For each response:
+   - On success: add the returned closerPeers to Pn
+     (excluding those already in Pq).
+     Re-sort Pn by distance to Key.
+   - On error/timeout: discard and continue.
+
+4. Go to step 1.
+```
+
+### ASCII Diagram: Iterative Lookup
+
+```
+                         Target Key: K
+                              |
+    Local Node                |
+        |                     |
+        |  1. Seed Pn with k closest from routing table
+        |                     |
+        v                     |
+   ┌─────────┐                |
+   │ Pn list │ (sorted by distance to K)
+   │ [A,B,C] │                |
+   └────┬────┘                |
+        |                     |
+        | 2. Query alpha peers in parallel
+        |                     |
+   ┌────┴────────────────┐    |
+   v         v            v   |
+ ┌───┐    ┌───┐       ┌───┐  |
+ │ A │    │ B │       │ C │  |
+ └─┬─┘    └─┬─┘       └─┬─┘  |
+   |        |            |    |
+   | FIND_NODE(K)        |    |
+   |        |            |    |
+   v        v            v    |
+  [D,E]   [E,F,G]     [F,H]  | (closer peers returned)
+   |        |            |    |
+   | 3. Merge into Pn, re-sort by distance
+   |                     |
+   v                     |
+   ┌─────────┐           |
+   │ Pn list │ (updated, re-sorted)
+   │ [D,E,F, │           |
+   │  G,H]   │           |
+   └────┬────┘           |
+        |                |
+        | 4. Query next alpha peers...
+        |                |
+   ┌────┴────────────┐   |
+   v        v         v  |
+ ┌───┐   ┌───┐    ┌───┐ |
+ │ D │   │ E │    │ F │ |
+ └─┬─┘   └─┬─┘    └─┬─┘ |
+   |       |         |   |
+   v       v         v   |
+ [I,J]  [I,K]     [J,L]  | (even closer peers)
+   |       |         |   |
+   | 5. Merge, re-sort   |
+   |                     |
+   v                     |
+   ┌─────────┐           |
+   │ Pn list │           |
+   │ [I,J,K, │           |
+   │  L, ...]│ ──► Converging toward K
+   └─────────┘
+        |
+        | 6. Terminate when k closest have all responded
+        |
+        v
+   Result: k closest peers to K
+```
+
+### Termination Condition
+
+The lookup terminates when the initiator has queried and received responses
+from the `k` closest peers it has seen. At that point, no un-queried peer in
+`Pn` is closer than the `k`-th closest responding peer, so further queries
+cannot improve the result.
+
+The lookup also terminates early if:
+- `Pn` is empty (all known peers have been queried)
+- The total number of known peers is less than `k`
+
+### Value Lookup (GET_VALUE)
+
+The value lookup follows the same iterative pattern but uses `GET_VALUE`
+instead of `FIND_NODE`, and introduces additional state:
+
+- `best`: The best value found so far
+- `Pb`: Peers that returned the best value
+- `Po`: Peers that returned outdated values
+- `cnt`: Number of values collected
+
+When a value is received, it is compared against the current best using a
+`Validator.Select()` function. Peers with outdated values are added to `Po`.
+When the lookup completes, outdated peers (and close peers with no value) are
+corrected via `PUT_VALUE(Key, best)` -- this ensures eventual convergence to the
+best record.
+
+## Peer Routing vs Content Routing
+
+### Finding Peers by ID (Peer Routing)
+
+To find a specific peer by its Peer ID:
+
+1. Compute `Key = PeerID` (the raw Peer ID bytes).
+2. Run the iterative FIND_NODE lookup for `Key`.
+3. The lookup converges toward the target peer.
+4. If the target peer is online and reachable, it will appear in the
+   `closerPeers` of some response (or respond to the query directly).
+5. Extract the peer's multiaddrs from the `Peer` record.
+
+### Finding Content Providers (Content Routing)
+
+To find providers for a piece of content:
+
+1. Compute `Key = multihash(content)`.
+2. Run the iterative lookup using `GET_PROVIDERS` instead of `FIND_NODE`.
+3. Peers along the way return both `providerPeers` (known providers) and
+   `closerPeers` (for continuing the lookup).
+4. Collect provider records until sufficient providers are found or the
+   lookup terminates.
+
+To advertise content:
+
+1. Compute `Key = multihash(content)`.
+2. Run `FIND_NODE` to find the `k` closest peers to `Key`.
+3. Send `ADD_PROVIDER` to each of those `k` peers with your own `PeerInfo`.
+
+### Record Types and Validation
+
+The DHT supports different record types, each with its own validation logic.
+The validator interface (in Go-like pseudocode from the spec):
+
+```go
+// Validator is an interface that should be implemented by record
+// validators.
+type Validator interface {
+    // Validate validates the given record, returning an error if it's
+    // invalid (e.g., expired, signed by the wrong key, etc.).
+    Validate(key string, value []byte) error
+
+    // Select selects the best record from the set of records (e.g., the
+    // newest).
+    //
+    // Decisions made by select should be stable.
+    Select(key string, values [][]byte) (int, error)
+}
+```
+
+**`Validate()`** is called:
+1. When validating values retrieved in a `GET_VALUE` query.
+2. When validating values received in a `PUT_VALUE` query before storing.
+
+**`Select()`** resolves conflicts when multiple values are found for the same
+key. It returns the index of the best value. Common strategies: highest
+sequence number, most recent timestamp, or cryptographic verification.
+
+## Server Mode vs Client Mode
+
+### Server Mode
+
+A node in server mode:
+- **Advertises** `/ipfs/kad/1.0.0` via the Identify protocol
+- **Accepts** incoming Kademlia streams (responds to RPCs)
+- **Stores** records and provider information for other peers
+- **Is added** to other nodes' routing tables
+
+Server mode is appropriate for:
+- Publicly routable nodes (e.g., servers in a datacenter)
+- Nodes with stable availability, good bandwidth, and sufficient resources
+
+### Client Mode
+
+A node in client mode:
+- **Does NOT advertise** `/ipfs/kad/1.0.0` via Identify
+- **Does NOT accept** incoming Kademlia streams
+- **Initiates** queries (FIND_NODE, GET_VALUE, etc.) but does not serve them
+- **Is NOT added** to other nodes' routing tables
+
+Client mode is appropriate for:
+- Nodes behind NAT or firewall
+- Nodes with intermittent availability
+- Nodes with limited resources (CPU, RAM, bandwidth)
+
+### Routing Table Implications
+
+Both client and server nodes maintain a routing table. However, both only add
+**server-mode** peers to their routing tables. This is critical: if client
+nodes were added to routing tables, they would be unreachable for incoming
+queries, degrading DHT performance.
+
+```
+                  Routing Table Insertion Rules
+                  ─────────────────────────────
+
+  Discovered Peer Mode    Added to Routing Table?
+  ──────────────────────  ───────────────────────
+  Server                  Yes
+  Client                  No
+```
+
+## Record Format
+
+### Record Protobuf
+
+The `Record` message stores key-value pairs in the DHT:
+
+```protobuf
+message Record {
+    bytes key = 1;           // The key referencing this record
+    bytes value = 2;         // The actual value stored
+    string timeReceived = 5; // RFC 3339 timestamp, set by the receiver
+};
+```
+
+Note: Fields 3 (`author`) and 4 (`signature`) were removed from the Record
+message. Modern libp2p uses signed envelopes for authenticated records instead.
+
+### Signed Records (Routing Records)
+
+For records that require authentication (e.g., peer routing records), libp2p
+uses **signed envelopes**. A signed envelope wraps a payload with a signature
+from the originating peer's identity key:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Signed Envelope                                     │
+├──────────────────┬──────────────────────────────────┤
+│ public_key       │ Signer's public key (protobuf)   │
+│ payload_type     │ Multicodec identifying the type  │
+│ payload          │ The record bytes                  │
+│ signature        │ Signature over domain + type +    │
+│                  │ payload using identity key        │
+└──────────────────┴──────────────────────────────────┘
+```
+
+The signature covers:
+```
+sign_data = domain_string || payload_type || payload
+```
+
+This prevents replay attacks across different contexts (the domain string acts
+as a namespace).
+
+### Validator Interface (Haskell Perspective)
+
+```haskell
+-- | Validator for DHT records
+data Validator = Validator
+  { validate :: ByteString -> ByteString -> Either ValidationError ()
+    -- ^ validate key value: check if a record is valid
+  , select   :: ByteString -> [ByteString] -> Either ValidationError Int
+    -- ^ select key values: choose the best record, return its index
+  }
+```
+
+## Bootstrap Process
+
+### Overview
+
+The bootstrap process populates and refreshes the routing table. It runs:
+1. Once at startup
+2. Periodically thereafter (default: every **10 minutes**)
+
+Each run is subject to a `QueryTimeout` (default: **10 seconds**), which upon
+firing aborts the run.
+
+### Initial Bootstrap
+
+At startup, the node must know at least one bootstrap peer to join the network.
+Bootstrap nodes are well-known, stable peers whose multiaddrs are hardcoded
+or configured.
+
+For the IPFS network, the default bootstrap peers are maintained by Protocol
+Labs and are publicly listed.
+
+### Self-Lookup
+
+On every bootstrap run:
+
+1. **Self-lookup**: Perform a `FIND_NODE` lookup for the local node's own Peer
+   ID. This populates the buckets closest to the local node, which are the
+   hardest to fill naturally.
+
+2. **Random lookups**: For every non-empty k-bucket, generate a random Peer ID
+   that would fall into that bucket and perform a `FIND_NODE` lookup for it.
+   This refreshes all buckets with live peers.
+
+```
+Bootstrap Process
+─────────────────
+
+1. Connect to bootstrap peers
+       │
+       v
+2. FIND_NODE(self)
+       │  Populates nearby buckets
+       │  Discovers peers close to us
+       v
+3. For each non-empty bucket i:
+       │  Generate random ID with prefix length i
+       │  FIND_NODE(random_id)
+       │  Populates bucket i with fresh peers
+       v
+4. Routing table is now populated
+       │
+       v
+5. Wait 10 minutes, go to step 2
+```
+
+### Peers Encountered During Bootstrap
+
+All peers encountered during any lookup are candidates for insertion into the
+routing table (subject to the bucket capacity and eviction rules). This means
+that even lookups targeting a specific key indirectly improve routing table
+health by discovering new peers.
+
+## Security Considerations
+
+### Sybil Attacks
+
+An attacker creates many fake identities (Sybil nodes) to gain
+disproportionate control over portions of the keyspace.
+
+**Impact:** The attacker can:
+- Intercept or drop lookups for targeted keys
+- Return false provider records
+- Eclipse honest nodes from the network
+
+**Countermeasures:**
+- The SHA-256 hash function makes it computationally expensive to generate
+  Peer IDs close to a specific key (2^128 expected work for a 50% collision
+  in any given bucket).
+- Replication factor `k = 20` means an attacker must control many nodes near
+  a key to fully compromise it.
+- Disjoint lookup paths (from S/Kademlia) make it harder to intercept all
+  paths to a key.
+
+### Eclipse Attacks
+
+An attacker surrounds a target node with malicious peers, isolating it from
+the honest network.
+
+**Impact:** The eclipsed node:
+- Only sees attacker-controlled peers in its routing table
+- Cannot reach honest peers for lookups
+- Receives attacker-controlled records and provider information
+
+**Countermeasures:**
+- Prefer long-lived peers in the routing table (standard Kademlia eviction
+  policy). Established honest peers are not evicted in favor of new attacker
+  nodes.
+- Verify record signatures where applicable.
+- Use multiple bootstrap nodes from independent operators.
+- Periodically refresh the routing table from diverse sources.
+
+### Content Poisoning
+
+An attacker stores invalid or malicious records in the DHT.
+
+**Countermeasures:**
+- Record validation via the `Validator` interface.
+- Signed records (envelopes) for authenticated data.
+- The `Select()` function ensures that honest nodes can "outcompete" invalid
+  records by preferring records with higher sequence numbers or valid
+  signatures.
+
+### Routing Table Pollution
+
+Malicious peers advertise themselves aggressively to fill honest nodes'
+routing tables.
+
+**Countermeasures:**
+- Only add server-mode peers to the routing table (client/server distinction).
+- Bucket size limit of `k = 20` with eviction of unresponsive peers.
+- Prefer peers that have been responsive over time.
+
+## Haskell Implementation Notes
+
+### Key Data Types
+
+```haskell
+-- | 256-bit key in the DHT keyspace
+newtype DHTKey = DHTKey ByteString
+  -- ^ Always exactly 32 bytes (SHA-256 output)
+  deriving (Eq, Ord, Show)
+
+-- | Compute the DHT key for a Peer ID
+peerIdToKey :: PeerId -> DHTKey
+peerIdToKey pid = DHTKey (SHA256.hash (peerIdToBytes pid))
+
+-- | XOR distance between two DHT keys
+xorDistance :: DHTKey -> DHTKey -> DHTKey
+xorDistance (DHTKey a) (DHTKey b) =
+    DHTKey (BS.pack (BS.zipWith xor a b))
+
+-- | Common prefix length (determines bucket index)
+commonPrefixLength :: DHTKey -> DHTKey -> Int
+commonPrefixLength (DHTKey a) (DHTKey b) =
+    countLeadingZeros (BS.pack (BS.zipWith xor a b))
+  where
+    countLeadingZeros bs =
+      let bits = concatMap byteToBits (BS.unpack bs)
+      in  length (takeWhile (== False) bits)
+
+-- | A single entry in a k-bucket
+data BucketEntry = BucketEntry
+  { entryPeerId    :: !PeerId
+  , entryAddrs     :: ![Multiaddr]
+  , entryLastSeen  :: !UTCTime
+  , entryConnType  :: !ConnectionType
+  } deriving (Show)
+
+-- | A k-bucket holding up to k peers
+data KBucket = KBucket
+  { bucketEntries  :: !(Seq BucketEntry)  -- ordered by last-seen time
+  , bucketCapacity :: !Int                 -- k = 20
+  } deriving (Show)
+
+-- | The full routing table: 256 k-buckets
+data RoutingTable = RoutingTable
+  { rtSelfKey  :: !DHTKey
+  , rtBuckets  :: !(Vector KBucket)  -- indexed 0..255
+  , rtK        :: !Int               -- replication parameter (20)
+  } deriving (Show)
+```
+
+### XOR Distance Operations
+
+For comparing distances, you can work with `ByteString` directly:
+
+```haskell
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Bits (xor)
+
+-- | Compare two XOR distances.
+-- Returns LT if distance a is less than distance b.
+compareDistance :: DHTKey -> DHTKey -> DHTKey -> Ordering
+compareDistance target a b =
+    compare (xorDistance target a) (xorDistance target b)
+  -- Ord instance on DHTKey (which wraps ByteString) gives
+  -- lexicographic comparison, which is correct for big-endian
+  -- unsigned 256-bit integers.
+
+-- | Sort peers by distance to a target key
+sortByDistance :: DHTKey -> [PeerId] -> [PeerId]
+sortByDistance target =
+    sortBy (\a b -> compareDistance target
+                      (peerIdToKey a)
+                      (peerIdToKey b))
+```
+
+Note: Lexicographic `ByteString` comparison is equivalent to big-endian
+unsigned integer comparison, which is exactly what we need for XOR distances.
+
+### Concurrent Lookup with async
+
+The iterative lookup naturally maps to Haskell's `async` library:
+
+```haskell
+import Control.Concurrent.Async (mapConcurrently, race, withAsync)
+import Control.Concurrent.STM
+
+-- | Perform an iterative FIND_NODE lookup
+iterativeFindNode
+  :: DHTNode
+  -> DHTKey           -- ^ target key
+  -> IO [PeerInfo]    -- ^ k closest peers
+iterativeFindNode node targetKey = do
+    -- Seed candidates from local routing table
+    let seeds = closestPeers (routingTable node) targetKey (rtK (routingTable node))
+
+    -- Mutable state via STM
+    candidatesVar <- newTVarIO (sortByDistance targetKey seeds)
+    queriedVar    <- newTVarIO Set.empty
+    resultsVar    <- newTVarIO []
+
+    let alpha = 10  -- concurrency parameter
+
+    let loop = do
+          -- Pick next batch of candidates
+          batch <- atomically $ do
+            candidates <- readTVar candidatesVar
+            queried    <- readTVar queriedVar
+            let unqueried = filter (`Set.notMember` queried) candidates
+                batch     = take alpha unqueried
+            mapM_ (\p -> modifyTVar' queriedVar (Set.insert p)) batch
+            return batch
+
+          if null batch
+            then return ()  -- no more candidates
+            else do
+              -- Query all batch peers concurrently
+              responses <- mapConcurrently (sendFindNode node targetKey) batch
+
+              -- Merge results
+              atomically $ do
+                queried <- readTVar queriedVar
+                let newPeers = concatMap closerPeersFromResponse responses
+                    filtered = filter (`Set.notMember` queried) newPeers
+                modifyTVar' candidatesVar $ \cs ->
+                  sortByDistance targetKey (cs ++ filtered)
+
+              -- Check termination: have we queried the k closest?
+              done <- atomically $ do
+                candidates <- readTVar candidatesVar
+                queried    <- readTVar queriedVar
+                let kClosest = take (rtK (routingTable node)) candidates
+                return (all (`Set.member` queried) kClosest)
+
+              unless done loop
+
+    loop
+
+    -- Return k closest peers from candidates
+    atomically $ do
+      candidates <- readTVar candidatesVar
+      return (take (rtK (routingTable node)) candidates)
+```
+
+### DHT Message Encoding
+
+Use the `proto-lens` or `proto3-wire` library for protobuf encoding/decoding:
+
+```haskell
+-- | DHT Message type tags
+data MessageType
+  = PutValue       -- 0
+  | GetValue       -- 1
+  | AddProvider    -- 2
+  | GetProviders   -- 3
+  | FindNode       -- 4
+  | Ping           -- 5 (deprecated)
+  deriving (Show, Eq, Enum)
+
+-- | A DHT RPC message
+data DHTMessage = DHTMessage
+  { msgType         :: !MessageType
+  , msgKey          :: !ByteString
+  , msgRecord       :: !(Maybe Record)
+  , msgCloserPeers  :: ![PeerInfo]
+  , msgProviderPeers :: ![PeerInfo]
+  } deriving (Show)
+
+-- | Encode a DHTMessage to wire format (uvarint-prefixed protobuf)
+encodeDHTMessage :: DHTMessage -> ByteString
+encodeDHTMessage msg =
+    let payload = encodeProtobuf msg  -- protobuf encoding
+        len     = encodeUvarint (BS.length payload)
+    in  len <> payload
+
+-- | Decode a DHTMessage from wire format
+decodeDHTMessage :: ByteString -> Either String DHTMessage
+decodeDHTMessage bs = do
+    (len, rest) <- decodeUvarint bs
+    let (payload, _) = BS.splitAt (fromIntegral len) rest
+    decodeProtobuf payload
+```
+
+### Provider Record Management
+
+```haskell
+-- | Provider record with expiration
+data ProviderRecord = ProviderRecord
+  { prPeerId    :: !PeerId
+  , prAddrs     :: ![Multiaddr]
+  , prTimestamp  :: !UTCTime
+  } deriving (Show)
+
+-- | Provider store: maps content multihash to providers
+type ProviderStore = Map ByteString [ProviderRecord]
+
+-- | Expiration interval for provider records (IPFS: 48 hours)
+providerRecordExpiration :: NominalDiffTime
+providerRecordExpiration = 48 * 3600
+
+-- | Republish interval for provider records (IPFS: 22 hours)
+providerRecordRepublish :: NominalDiffTime
+providerRecordRepublish = 22 * 3600
+
+-- | Remove expired provider records
+cleanExpiredProviders :: UTCTime -> ProviderStore -> ProviderStore
+cleanExpiredProviders now =
+    Map.map (filter isValid)
+  where
+    isValid pr = diffUTCTime now (prTimestamp pr) < providerRecordExpiration
+```
+
+## Spec References
+
+- Kademlia DHT spec: https://github.com/libp2p/specs/blob/master/kad-dht/README.md
+- Kademlia paper: Maymounkov, P., & Mazieres, D. (2002). *Kademlia: A Peer-to-Peer Information System Based on the XOR Metric.* https://doi.org/10.1007/3-540-45748-8_5
+- S/Kademlia paper: Baumgart, I., & Mies, S. (2007). *S/Kademlia: A Practicable Approach Towards Secure Key-Based Routing.* https://doi.org/10.1109/ICPADS.2007.4447808
+- Coral paper: Freedman, M. J., & Mazieres, D. (2003). *Sloppy Hashing and Self-Organizing Clusters.* https://www.cs.princeton.edu/~mfreed/docs/coral-iptps03.pdf
+- BitTorrent DHT (BEP-5): http://bittorrent.org/beps/bep_0005.html
+- Unsigned varint spec: https://github.com/multiformats/unsigned-varint
+- Provider record measurements: https://github.com/protocol/network-measurements/blob/master/results/rfm17-provider-record-liveness.md
+- Identify protocol: https://github.com/libp2p/specs/blob/master/identify/README.md

--- a/docs/10-nat-traversal.md
+++ b/docs/10-nat-traversal.md
@@ -1,0 +1,880 @@
+# Chapter 10: NAT Traversal
+
+Network Address Translation (NAT) is the single biggest obstacle to peer-to-peer
+connectivity. This chapter covers the full NAT traversal stack in libp2p: detecting
+NAT status with AutoNAT, relaying connections through Circuit Relay v2, and
+establishing direct connections via hole punching coordinated by DCUtR.
+
+## The NAT Problem
+
+### Why NAT Breaks P2P Connectivity
+
+In a typical home or corporate network, a NAT device (router) maps private IP
+addresses to a single public IP address. Outbound connections from a private host
+work fine: the NAT creates a mapping from (private_ip:private_port) to
+(public_ip:mapped_port) and routes return traffic back. But **inbound connections
+from the public Internet fail** because there is no existing mapping to route the
+traffic to the correct internal host.
+
+This is catastrophic for P2P networks. If peer A is behind a NAT and peer B
+wants to connect to A, B has no routable address to dial. The address A advertises
+(e.g., `192.168.1.5:4001`) is meaningless outside A's local network.
+
+```
+                    NAT/Firewall
+Peer B (public)        │          Peer A (private)
+  203.0.113.5 ────X────┤          192.168.1.5
+                        │
+  B cannot reach A:     │    A's address is not
+  no inbound mapping    │    routable from outside
+```
+
+### Types of NAT
+
+NAT behavior varies significantly across devices, and the type of NAT determines
+which traversal techniques will succeed. The classification comes from RFC 3489:
+
+| NAT Type | Mapping Rule | Filtering Rule | Hole Punching |
+|---|---|---|---|
+| **Full Cone** | Same mapping for all destinations | No filtering: any external host can send to mapped port | Easy |
+| **Address-Restricted Cone** | Same mapping for all destinations | Only hosts A has sent to (by IP) can reply | Moderate |
+| **Port-Restricted Cone** | Same mapping for all destinations | Only hosts A has sent to (by IP:port) can reply | Moderate |
+| **Symmetric** | Different mapping per destination | Only the specific destination can reply | Very difficult |
+
+**Full Cone (Endpoint-Independent Mapping):** Once a mapping is created, any
+external host can send packets to the mapped address. This is the easiest to
+traverse.
+
+**Address-Restricted Cone:** The NAT only forwards inbound packets from an IP
+address that the internal host has previously sent a packet to. Hole punching
+works by having both peers send packets to each other, creating the necessary
+mappings.
+
+**Port-Restricted Cone:** Like address-restricted, but the restriction also
+applies to the source port. The internal host must have sent a packet to the
+specific IP:port combination. Hole punching still works with proper coordination.
+
+**Symmetric NAT:** Creates a different mapping for each destination. This makes
+hole punching extremely difficult because the mapped port used when talking to a
+relay is different from the mapped port that would be used for a direct connection
+to the other peer. The predicted external address is unreliable.
+
+In practice, libp2p's hole punching works well for cone NATs and has limited
+success with symmetric NATs. When hole punching fails, peers fall back to relayed
+connections.
+
+## AutoNAT Protocol
+
+AutoNAT allows a node to determine whether it is publicly reachable or behind a
+NAT. The node asks other peers to dial its addresses; if they succeed, the node
+is public. If they fail, the node is behind a NAT.
+
+### AutoNAT v1
+
+#### Protocol ID
+
+```
+/libp2p/autonat/1.0.0
+```
+
+#### How It Works
+
+1. Node A wants to know its NAT status.
+2. A opens a stream to a peer B using `/libp2p/autonat/1.0.0`.
+3. A sends a `Dial` message containing a list of its addresses.
+4. B dials those addresses (restricted to A's observed IP for security).
+5. B responds with a `DialResponse` indicating success or failure.
+6. A repeats with multiple peers and uses a threshold to determine status.
+
+If more than 3 peers report a successfully dialed address, the node assumes it is
+publicly reachable. If more than 3 peers report unsuccessful dials, the node
+assumes it is behind a NAT.
+
+#### Security Constraints
+
+To prevent amplification attacks (as described in RFC 3489, Section 12.1.1), the
+server MUST NOT dial any multiaddress unless it is based on the IP address the
+requesting node is observed as. This also means implementations MUST NOT accept
+dial requests via relayed connections, since the true IP of the requesting node
+cannot be validated.
+
+#### Protobuf Definition
+
+```protobuf
+syntax = "proto2";
+
+message Message {
+    enum MessageType {
+        DIAL          = 0;
+        DIAL_RESPONSE = 1;
+    }
+
+    enum ResponseStatus {
+        OK              = 0;
+        E_DIAL_ERROR    = 100;
+        E_DIAL_REFUSED  = 101;
+        E_BAD_REQUEST   = 200;
+        E_INTERNAL_ERROR = 300;
+    }
+
+    message PeerInfo {
+        optional bytes  id    = 1;
+        repeated bytes  addrs = 2;
+    }
+
+    message Dial {
+        optional PeerInfo peer = 1;
+    }
+
+    message DialResponse {
+        optional ResponseStatus status     = 1;
+        optional string         statusText = 2;
+        optional bytes          addr       = 3;
+    }
+
+    optional MessageType  type         = 1;
+    optional Dial         dial         = 2;
+    optional DialResponse dialResponse = 3;
+}
+```
+
+#### Sequence Diagram
+
+```
+Node A                              Node B (AutoNAT server)
+  │                                       │
+  │  ── stream: /libp2p/autonat/1.0.0 ──► │
+  │                                       │
+  │  ── Dial { peer: {                    │
+  │       id: QmA,                        │
+  │       addrs: [/ip4/203.0.113.5/tcp/4001]  │
+  │     }} ──────────────────────────────► │
+  │                                       │
+  │                           B dials A's │
+  │                           addresses   │
+  │                           (same IP    │
+  │                            only)      │
+  │                                       │
+  │  ◄── DialResponse {                   │
+  │        status: OK,                    │
+  │        addr: /ip4/203.0.113.5/tcp/4001│
+  │      } ────────────────────────────── │
+  │                                       │
+  │  (repeat with 3+ peers to confirm)    │
+```
+
+All RPC messages are prefixed with the message length in bytes, encoded as an
+unsigned variable-length integer per the
+[multiformats unsigned-varint spec](https://github.com/multiformats/unsigned-varint).
+
+### AutoNAT v2
+
+AutoNAT v2 improves on v1 by allowing nodes to test **individual addresses** for
+reachability, rather than testing reachability of the node as a whole.
+
+#### Protocol IDs
+
+```
+/libp2p/autonat/2/dial-request
+/libp2p/autonat/2/dial-back
+```
+
+#### Key Differences from v1
+
+1. **Per-address testing:** The server dials exactly one address from a priority-
+   ordered list, enabling the client to determine reachability per address.
+2. **Nonce verification:** The client sends a `nonce` in the request. The server
+   sends this nonce back on the `/libp2p/autonat/2/dial-back` stream, proving it
+   actually connected to the client's address.
+3. **Amplification attack prevention:** If the server is asked to dial an address
+   with a different IP than the client's observed IP, the server requires the
+   client to send 30k-100k bytes of data first, making amplification attacks
+   unattractive.
+
+#### Protobuf Definition
+
+```protobuf
+syntax = "proto3";
+
+message Message {
+    oneof msg {
+        DialRequest      dialRequest      = 1;
+        DialResponse     dialResponse     = 2;
+        DialDataRequest  dialDataRequest  = 3;
+        DialDataResponse dialDataResponse = 4;
+    }
+}
+
+message DialRequest {
+    repeated bytes addrs = 1;
+    fixed64        nonce = 2;
+}
+
+message DialDataRequest {
+    uint32 addrIdx  = 1;
+    uint64 numBytes = 2;
+}
+
+enum DialStatus {
+    UNUSED           = 0;
+    E_DIAL_ERROR     = 100;
+    E_DIAL_BACK_ERROR = 101;
+    OK               = 200;
+}
+
+message DialResponse {
+    enum ResponseStatus {
+        E_INTERNAL_ERROR  = 0;
+        E_REQUEST_REJECTED = 100;
+        E_DIAL_REFUSED    = 101;
+        OK                = 200;
+    }
+
+    ResponseStatus status     = 1;
+    uint32         addrIdx    = 2;
+    DialStatus     dialStatus = 3;
+}
+
+message DialDataResponse {
+    bytes data = 1;
+}
+
+message DialBack {
+    fixed64 nonce = 1;
+}
+
+message DialBackResponse {
+    enum DialBackStatus {
+        OK = 0;
+    }
+
+    DialBackStatus status = 1;
+}
+```
+
+#### Sequence Diagram
+
+```
+Client A                                Server B
+  │                                          │
+  │  ── stream: /libp2p/autonat/2/dial-request ──► │
+  │                                          │
+  │  ── DialRequest {                        │
+  │       addrs: [addr1, addr2, ...],        │
+  │       nonce: 0xABCD1234                  │
+  │     } ──────────────────────────────────►│
+  │                                          │
+  │                         B selects first  │
+  │                         dialable addr    │
+  │                                          │
+  │     [If selected addr has different IP   │
+  │      than A's observed IP:]              │
+  │                                          │
+  │  ◄── DialDataRequest {                   │
+  │        addrIdx: 0,                       │
+  │        numBytes: 30000                   │
+  │      } ──────────────────────────────── │
+  │                                          │
+  │  ── DialDataResponse { data: [...] } ──►│
+  │  ── DialDataResponse { data: [...] } ──►│
+  │  ── ...  (until numBytes sent) ────────►│
+  │                                          │
+  │                     B dials selected addr│
+  │                                          │
+  │  ◄─── (new conn) /libp2p/autonat/2/dial-back ──│
+  │  ◄── DialBack { nonce: 0xABCD1234 } ─── │
+  │  ── DialBackResponse { status: OK } ───►│
+  │                                          │
+  │  ◄── DialResponse {                      │
+  │        status: OK,                       │
+  │        addrIdx: 0,                       │
+  │        dialStatus: OK                    │
+  │      } ──────────────────────────────── │
+  │                                          │
+  │  Client verifies nonce matches,          │
+  │  confirms addr[0] is reachable.          │
+```
+
+## Circuit Relay v2
+
+When a peer is behind a NAT and cannot be reached directly, it can use a relay
+peer to receive connections. Circuit Relay v2 provides **limited** relay service
+with explicit resource reservations, designed for short-lived connections that
+facilitate hole punching rather than long-term proxying.
+
+### Protocol IDs
+
+```
+/libp2p/circuit/relay/0.2.0/hop   (client ↔ relay)
+/libp2p/circuit/relay/0.2.0/stop  (relay ↔ target)
+```
+
+The protocol is split into two subprotocols:
+
+- **Hop protocol:** Client-initiated, used for reserving resources in the relay
+  and opening a switched connection to a peer through the relay.
+- **Stop protocol:** Governs connection termination between the relay and the
+  target peer.
+
+### Relay Address Format
+
+A relay address encodes the path through a relay peer to reach a target peer:
+
+```
+/ip4/198.51.100.1/tcp/4001/p2p/QmRelay/p2p-circuit/p2p/QmTarget
+```
+
+The format is:
+
+```
+<relay-transport-addr>/p2p/<relay-peer-id>/p2p-circuit/p2p/<target-peer-id>
+```
+
+The `p2p-circuit` component signals that the connection should be routed through
+the relay rather than established directly.
+
+### Protobuf Definition
+
+```protobuf
+syntax = "proto3";
+
+message HopMessage {
+    enum Type {
+        RESERVE = 0;
+        CONNECT = 1;
+        STATUS  = 2;
+    }
+
+    optional Type        type        = 1;
+    optional Peer        peer        = 2;
+    optional Reservation reservation = 3;
+    optional Limit       limit       = 4;
+    optional Status      status      = 5;
+}
+
+message StopMessage {
+    enum Type {
+        CONNECT = 0;
+        STATUS  = 1;
+    }
+
+    optional Type   type   = 1;
+    optional Peer   peer   = 2;
+    optional Limit  limit  = 3;
+    optional Status status = 4;
+}
+
+message Peer {
+    optional bytes  id    = 1;
+    repeated bytes  addrs = 2;
+}
+
+message Reservation {
+    optional uint64 expire  = 1;  // Unix expiration time (UTC)
+    repeated bytes  addrs   = 2;  // relay addrs for reserving peer
+    optional bytes  voucher = 3;  // reservation voucher
+}
+
+message Limit {
+    optional uint32 duration = 1;  // seconds
+    optional uint64 data     = 2;  // bytes
+}
+
+enum Status {
+    UNUSED                  = 0;
+    OK                      = 100;
+    RESERVATION_REFUSED     = 200;
+    RESOURCE_LIMIT_EXCEEDED = 201;
+    PERMISSION_DENIED       = 202;
+    CONNECTION_FAILED       = 203;
+    NO_RESERVATION          = 204;
+    MALFORMED_MESSAGE       = 400;
+    UNEXPECTED_MESSAGE      = 401;
+}
+```
+
+### Reservation Voucher
+
+Successful reservations come with a **Reservation Voucher**, a
+[Signed Envelope](https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md)
+with domain `libp2p-relay-rsvp` and multicodec code `0x0302`. The payload:
+
+```protobuf
+syntax = "proto3";
+
+message Voucher {
+    optional bytes  relay      = 1;  // Peer ID of the relay
+    optional bytes  peer       = 2;  // Peer ID of the reserving peer
+    optional uint64 expiration = 3;  // UNIX UTC expiration time
+}
+```
+
+The wire representation is canonicalized: fields are written in field ID order
+with no unknown fields.
+
+### Reservation Flow
+
+A private peer reserves a relay slot to make itself reachable via the relay.
+
+```
+Private Peer A                          Relay R
+     │                                       │
+     │  ── stream: .../hop ─────────────────►│
+     │                                       │
+     │  ── HopMessage {                      │
+     │       type: RESERVE                   │
+     │     } ───────────────────────────────►│
+     │                                       │
+     │  ◄── HopMessage {                     │
+     │        type: STATUS,                  │
+     │        status: OK,                    │
+     │        reservation: Reservation {     │
+     │          expire: 1700000000,          │
+     │          addrs: [/ip4/.../p2p/QmR],   │
+     │          voucher: <signed envelope>   │
+     │        },                             │
+     │        limit: Limit {                 │
+     │          duration: 120,               │
+     │          data: 131072                 │
+     │        }                              │
+     │      } ──────────────────────────────│
+     │                                       │
+     │  A keeps connection alive.            │
+     │  A constructs relay addrs:            │
+     │   /ip4/.../p2p/QmR/p2p-circuit/p2p/QmA │
+     │  A advertises these addrs.            │
+     │                                       │
+     │  (reservation timeout approaching)    │
+     │                                       │
+     │  ── HopMessage { type: RESERVE } ───►│
+     │  ◄── HopMessage { type: STATUS,      │
+     │        status: OK, ... } ────────────│
+```
+
+Key points about reservations:
+
+- The reservation remains valid **as long as the connection to the relay is
+  maintained**. If the peer disconnects, the reservation is invalidated.
+- The `addrs` field in the `Reservation` contains the relay's addresses (without
+  the trailing `p2p-circuit` part). The client appends
+  `/p2p-circuit/p2p/<own-peer-id>` to construct its full relay address.
+- The client is responsible for refreshing the reservation before `expire`.
+
+### Resource Limits
+
+Circuit Relay v2 enforces resource limits to prevent abuse:
+
+| Resource | Field | Description |
+|---|---|---|
+| **Duration** | `Limit.duration` | Maximum time (seconds) a relayed connection can remain open. 0 = unlimited. |
+| **Data** | `Limit.data` | Maximum bytes allowed in each direction. 0 = unlimited. |
+
+If the data limit is exceeded or the duration expires, the relay resets both the
+source and destination streams.
+
+Implementations SHOULD NOT accept reservations or connection initiations over
+already-relayed connections (to prevent relay chaining).
+
+### Relay Connection Flow
+
+When peer B wants to connect to peer A through relay R:
+
+```
+Peer B                       Relay R                       Peer A
+  │                              │                              │
+  │  ── stream: .../hop ────────►│                              │
+  │                              │                              │
+  │  ── HopMessage {             │                              │
+  │       type: CONNECT,         │                              │
+  │       peer: { id: QmA }     │                              │
+  │     } ─────────────────────►│                              │
+  │                              │                              │
+  │                              │  ── stream: .../stop ──────►│
+  │                              │                              │
+  │                              │  ── StopMessage {            │
+  │                              │       type: CONNECT,         │
+  │                              │       peer: { id: QmB },    │
+  │                              │       limit: Limit {         │
+  │                              │         duration: 120,       │
+  │                              │         data: 131072         │
+  │                              │       }                      │
+  │                              │     } ─────────────────────►│
+  │                              │                              │
+  │                              │  ◄── StopMessage {           │
+  │                              │        type: STATUS,         │
+  │                              │        status: OK            │
+  │                              │      } ────────────────────│
+  │                              │                              │
+  │  ◄── HopMessage {            │                              │
+  │        type: STATUS,         │                              │
+  │        status: OK,           │                              │
+  │        limit: Limit {        │                              │
+  │          duration: 120,      │                              │
+  │          data: 131072        │                              │
+  │        }                     │                              │
+  │      } ────────────────────│                              │
+  │                              │                              │
+  │  ◄═══════ relayed connection (bridged streams) ══════════►│
+  │  (hop stream)                │              (stop stream)   │
+  │                              │                              │
+  │  B and A upgrade the relayed connection with a              │
+  │  security protocol and multiplexer, just as they            │
+  │  would upgrade a direct TCP connection.                     │
+```
+
+## Hole Punching
+
+Hole punching is the process of establishing a direct connection between two
+peers, one or both of which are behind NATs, by exploiting the NAT mapping
+behavior. The libp2p hole punching process has two phases.
+
+### Two-Phase Process Overview
+
+```
+ Phase I: Discovery & Relay          Phase II: Direct Connection
+ ┌────────────────────────┐          ┌────────────────────────────┐
+ │                        │          │                            │
+ │  1. AutoNAT: detect    │          │  4. DCUtR: coordinate      │
+ │     NAT status         │          │     hole punch over        │
+ │                        │          │     relay connection       │
+ │  2. Reserve relay slot │          │                            │
+ │     (Circuit Relay v2) │   ────►  │  5. Simultaneous connect:  │
+ │                        │          │     both peers dial each   │
+ │  3. Establish relayed  │          │     other at the same time │
+ │     connection         │          │                            │
+ │                        │          │  6. Upgrade to direct      │
+ │                        │          │     connection             │
+ └────────────────────────┘          └────────────────────────────┘
+```
+
+### Phase I: NAT Detection and Relay Connection
+
+1. **NAT detection:** Peer A uses AutoNAT (v1 or v2) to determine that it is
+   behind a NAT and not publicly reachable.
+
+2. **Relay reservation:** A finds a publicly reachable relay peer R and makes a
+   reservation using Circuit Relay v2. A now has a relay address:
+   `/p2p/QmR/p2p-circuit/p2p/QmA`.
+
+3. **Address advertisement:** A advertises its relay address through a discovery
+   mechanism (DHT, rendezvous, etc.).
+
+4. **Relay connection:** When peer B wants to connect to A, it discovers A's
+   relay address and establishes a relayed connection through R.
+
+### Phase II: DCUtR Coordination and Simultaneous Connect
+
+5. **Connection observation:** Upon receiving the relayed connection from B, peer
+   A examines B's addresses from the Identify protocol. If B has public
+   addresses, A first attempts a unilateral direct connection. If that fails (or
+   B is also behind a NAT), A initiates the DCUtR protocol.
+
+6. **DCUtR exchange:** A and B exchange `Connect` messages containing their
+   observed external addresses and a `Sync` message to synchronize timing.
+
+7. **Simultaneous open:** Both peers dial each other at the predicted external
+   addresses simultaneously. For TCP, this results in a TCP Simultaneous Open.
+   For QUIC, A dials B while B sends UDP packets to punch the NAT.
+
+8. **Upgrade:** If a direct connection is established, both peers migrate to it
+   and close the relay connection after a grace period.
+
+## DCUtR Protocol
+
+Direct Connection Upgrade through Relay (DCUtR) is the coordination protocol
+that enables hole punching. It runs over an existing relayed connection and
+synchronizes both peers to attempt simultaneous direct connections.
+
+### Protocol ID
+
+```
+/libp2p/dcutr
+```
+
+### Protobuf Definition
+
+```protobuf
+syntax = "proto2";
+
+package holepunch.pb;
+
+message HolePunch {
+    enum Type {
+        CONNECT = 100;
+        SYNC    = 300;
+    }
+
+    required Type  type     = 1;
+    repeated bytes ObsAddrs = 2;
+}
+```
+
+`ObsAddrs` is a list of multiaddrs encoded in the binary multiaddr
+representation.
+
+All RPC messages are prefixed with the message length in bytes, encoded as an
+unsigned variable-length integer per the
+[multiformats unsigned-varint spec](https://github.com/multiformats/unsigned-varint).
+Implementations SHOULD refuse encoded RPC messages (length prefix excluded)
+larger than 4 KiB.
+
+### Message Flow
+
+The protocol uses three messages: two `CONNECT` messages and one `SYNC` message.
+
+1. **B sends Connect:** The inbound peer (B, the one that received the relayed
+   connection) opens a DCUtR stream and sends a `CONNECT` message containing its
+   observed/predicted addresses. B starts a timer to measure the relay RTT.
+
+2. **A responds with Connect:** A sends back a `CONNECT` message with its own
+   observed/predicted addresses.
+
+3. **B sends Sync:** Upon receiving A's `CONNECT`, B calculates the relay RTT
+   and sends a `SYNC` message. B starts a timer for half the RTT.
+
+4. **Simultaneous dial:** Both peers attempt direct connections:
+   - **A** dials B's addresses immediately upon receiving `SYNC`.
+   - **B** dials A's addresses when the half-RTT timer expires.
+
+The half-RTT timer compensates for the relay latency: B's `SYNC` takes
+approximately RTT/2 to reach A through the relay. By the time A receives `SYNC`
+and starts dialing, approximately RTT/2 has passed. If B also starts dialing
+after RTT/2, both peers begin their dial attempts at approximately the same
+wall-clock time.
+
+### Transport-Specific Behavior
+
+**TCP:**
+- Both peers dial each other simultaneously, resulting in a TCP Simultaneous
+  Open. For all protocols layered on top, A is the client and B is the server.
+
+**QUIC:**
+- Upon receiving `SYNC`, A immediately dials B.
+- Upon RTT/2 timer expiry, B sends UDP packets filled with random bytes to A's
+  address at random intervals between 10-200ms. This punches a hole in B's NAT
+  for A's QUIC connection to traverse.
+- A is the QUIC client, B is the QUIC server.
+
+### Retry Behavior
+
+The inbound peer (B) SHOULD retry twice (for a total of 3 attempts) before
+considering the upgrade failed. Each retry performs a fresh `CONNECT`/`SYNC`
+exchange to get a new RTT measurement, preventing a flawed measurement on the
+first attempt from distorting subsequent retries.
+
+### DCUtR Sequence Diagram
+
+```
+Peer A (initiator)                    Relay                    Peer B (inbound)
+     │                                  │                           │
+     │  ◄════ relayed connection (via Circuit Relay v2) ═══════════►│
+     │                                  │                           │
+     │                                  │   B examines A's addrs    │
+     │                                  │   from Identify.          │
+     │                                  │   A is behind NAT too.    │
+     │                                  │   B initiates DCUtR.      │
+     │                                  │                           │
+     │  ◄── stream: /libp2p/dcutr (over relayed conn) ────────────│
+     │                                  │                           │
+     │  ◄── HolePunch {                 │              t0: B sends  │
+     │        type: CONNECT,            │              Connect,     │
+     │        ObsAddrs: [B_addr1, ...]  │              starts RTT   │
+     │      } ─────────────────────────────────────────────────── │
+     │                                  │                           │
+     │  ── HolePunch {                  │                           │
+     │       type: CONNECT,             │                           │
+     │       ObsAddrs: [A_addr1, ...]   │                           │
+     │     } ─────────────────────────────────────────────────────►│
+     │                                  │              t1: B gets   │
+     │                                  │              A's Connect. │
+     │                                  │              RTT=t1-t0.   │
+     │                                  │                           │
+     │  ◄── HolePunch {                 │              B sends Sync.│
+     │        type: SYNC                │              B starts     │
+     │      } ─────────────────────────────────── timer: RTT/2.    │
+     │                                  │                           │
+     │  A receives SYNC.                │                           │
+     │  A dials B_addr1                 │                           │
+     │  immediately.                    │              (RTT/2 later)│
+     │                                  │              B dials      │
+     │                                  │              A_addr1.     │
+     │                                  │                           │
+     │  ═══════════ direct connection established ═════════════════►│
+     │                                  │                           │
+     │  Migrate streams to direct conn. │                           │
+     │  Close relay connection after    │                           │
+     │  grace period.                   │                           │
+```
+
+## End-to-End Hole Punching Walkthrough
+
+The following walks through the complete sequence from a node discovering it is
+behind a NAT all the way to establishing a direct connection with another NATed
+peer.
+
+### Complete Sequence
+
+```
+Step 1: NAT Detection (AutoNAT)
+────────────────────────────────────────────────────────────────────────
+
+  Peer A                         Peers X, Y, Z (public)
+    │                                    │
+    │  ── /libp2p/autonat/1.0.0 ───────►│
+    │  ── Dial { addrs: [A's addrs] } ─►│
+    │  ◄── DialResponse { E_DIAL_ERROR } │
+    │                                    │
+    │  (repeated with X, Y, Z)           │
+    │                                    │
+    │  Result: A is behind NAT.          │
+
+
+Step 2: Relay Reservation (Circuit Relay v2)
+────────────────────────────────────────────────────────────────────────
+
+  Peer A                              Relay R (public)
+    │                                       │
+    │  ── /libp2p/circuit/relay/0.2.0/hop ─►│
+    │  ── RESERVE ─────────────────────────►│
+    │  ◄── STATUS: OK, Reservation {...} ───│
+    │                                       │
+    │  A's relay addr:                      │
+    │  /ip4/.../tcp/4001/p2p/QmR/p2p-circuit/p2p/QmA
+    │                                       │
+    │  A advertises relay addr via DHT.     │
+
+
+Step 3: Relay Connection
+────────────────────────────────────────────────────────────────────────
+
+  Peer B           Relay R                          Peer A
+    │                 │                                │
+    │  B discovers A's relay addr via DHT.             │
+    │                 │                                │
+    │  ── CONNECT ──►│                                │
+    │                 │  ── CONNECT ──────────────────►│
+    │                 │  ◄── STATUS: OK ──────────────│
+    │  ◄── STATUS: OK │                                │
+    │                 │                                │
+    │  ◄═══════ relayed connection ═══════════════════►│
+    │                 │                                │
+    │  B and A perform security handshake and          │
+    │  multiplexer negotiation over relayed conn.      │
+
+
+Step 4: DCUtR Hole Punch Coordination
+────────────────────────────────────────────────────────────────────────
+
+  Peer B (inbound)                      Peer A (initiator)
+    │                                       │
+    │  (over relayed connection)            │
+    │                                       │
+    │  ── /libp2p/dcutr ──────────────────►│
+    │  ── CONNECT { ObsAddrs: [B1, B2] } ─►│
+    │  ◄── CONNECT { ObsAddrs: [A1, A2] } ─│
+    │  ── SYNC ────────────────────────────►│
+    │                                       │
+    │  Start timer: RTT/2     A dials B1, B2│
+    │  Timer fires: dial A1, A2    immediately│
+    │                                       │
+
+
+Step 5: Direct Connection
+────────────────────────────────────────────────────────────────────────
+
+  Peer B                                Peer A
+    │                                       │
+    │  TCP Simultaneous Open succeeds       │
+    │  (or QUIC connection established)     │
+    │                                       │
+    │  ◄═══════ direct connection ═════════►│
+    │                                       │
+    │  Security handshake + muxer on        │
+    │  direct connection.                   │
+    │                                       │
+    │  Migrate to direct connection.        │
+    │  Close relay connection.              │
+```
+
+### ASCII Overview: Complete Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                     NAT Traversal Stack                          │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌─────────────┐    ┌─────────────────┐    ┌──────────────────┐ │
+│  │  AutoNAT    │    │ Circuit Relay v2 │    │     DCUtR        │ │
+│  │             │    │                 │    │                  │ │
+│  │ "Am I       │───►│ "Route through  │───►│ "Upgrade to      │ │
+│  │  reachable?"│    │  a relay peer"  │    │  direct conn"    │ │
+│  │             │    │                 │    │                  │ │
+│  │ /libp2p/    │    │ .../hop         │    │ /libp2p/dcutr    │ │
+│  │ autonat/    │    │ .../stop        │    │                  │ │
+│  │ 1.0.0       │    │                 │    │ CONNECT/SYNC     │ │
+│  │             │    │ RESERVE/CONNECT │    │ msgs for         │ │
+│  │ Dial/       │    │ msgs + Limits   │    │ synchronized     │ │
+│  │ DialResponse│    │                 │    │ hole punch       │ │
+│  └─────────────┘    └─────────────────┘    └──────────────────┘ │
+│                                                                  │
+│  Phase I: Detection ──────── Phase I: Relay ──── Phase II: Punch │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Haskell Implementation Notes
+
+### Key Types and Architecture
+
+A Haskell implementation of the NAT traversal stack would involve the following
+key types and components:
+
+- **AutoNAT service:** A background service that periodically probes peers to
+  determine reachability status. The core state can be modeled as:
+  - `NATStatus`: An enumeration of `Public`, `Private`, or `Unknown`.
+  - A threshold counter tracking successful/failed dial-back reports.
+
+- **Circuit Relay client:** Manages relay reservations and relayed connections:
+  - `Reservation`: Tracks expiry time, relay addresses, and voucher.
+  - `RelayedConnection`: A connection wrapper that bridges the hop/stop streams.
+  - Reservation refresh logic using a timer or background thread.
+
+- **DCUtR coordinator:** Implements the hole punch coordination:
+  - RTT measurement between `CONNECT` send and receive.
+  - Timer-based synchronization for simultaneous dial.
+  - Retry logic (up to 3 attempts).
+
+### Relevant Packages
+
+- **Protobuf encoding:** `proto-lens` or `protobuf` for encoding/decoding the
+  protocol messages.
+- **Networking:** `network` package for TCP socket operations. Port reuse
+  (`SO_REUSEADDR` / `SO_REUSEPORT`) is critical for TCP hole punching.
+- **Concurrency:** `async` for managing simultaneous dial attempts and background
+  services (reservation refresh, AutoNAT probing).
+- **Multiaddr:** A multiaddr library for parsing and constructing circuit relay
+  addresses.
+- **Signed envelopes:** Implementation of the signed envelope format for
+  reservation vouchers (see
+  [RFC 0002](https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md)).
+
+### Implementation Order
+
+A recommended implementation order:
+
+1. **AutoNAT v1** -- simplest, provides the foundation for NAT detection.
+2. **Circuit Relay v2 client** -- reservation and relayed connections (client
+   side only; implementing relay server functionality is optional).
+3. **DCUtR** -- hole punch coordination, depends on both AutoNAT and relay.
+4. **AutoNAT v2** -- per-address reachability testing with nonce verification.
+
+## Spec References
+
+- AutoNAT v1: https://github.com/libp2p/specs/blob/master/autonat/autonat-v1.md
+- AutoNAT v2: https://github.com/libp2p/specs/blob/master/autonat/autonat-v2.md
+- Circuit Relay v2: https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md
+- DCUtR: https://github.com/libp2p/specs/blob/master/relay/DCUtR.md
+- Hole Punching overview: https://github.com/libp2p/specs/blob/master/connections/hole-punching.md
+- Signed Envelopes (RFC 0002): https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md
+- Ford & Srisuresh, "Peer-to-Peer Communication Across NATs": https://pdos.csail.mit.edu/papers/p2pnat.pdf
+- ICE (RFC 5245): https://tools.ietf.org/html/rfc5245

--- a/docs/11-pubsub.md
+++ b/docs/11-pubsub.md
@@ -1,0 +1,1060 @@
+# Chapter 11: Publish/Subscribe (GossipSub)
+
+libp2p provides a topic-based publish/subscribe system built on GossipSub, a
+gossip-based mesh routing protocol. This chapter covers the PubSub interface,
+GossipSub v1.0 and the v1.1 security extensions, including peer scoring, flood
+publishing, and all control message semantics.
+
+## PubSub Interface
+
+### Protocol ID
+
+```
+/meshsub/1.1.0
+```
+
+GossipSub v1.1 peers advertise this protocol string. The protocol is backwards
+compatible with v1.0 (`/meshsub/1.0.0`). Peers discover each other's protocol
+support via multistream-select negotiation on the pubsub stream.
+
+### Topic-Based Model
+
+PubSub uses a topic-based publish/subscribe model:
+
+- **Topics** are identified by opaque string IDs (e.g., `"blocks"`, `"tx"`)
+- **Publishers** send messages to a topic
+- **Subscribers** register interest in topics and receive messages published to them
+- A peer can be both publisher and subscriber for any number of topics
+- A peer can publish to topics it is not subscribed to (via fan-out)
+
+### Message Format (Protobuf)
+
+The `Message` protobuf defines the content exchanged over PubSub:
+
+```protobuf
+syntax = "proto2";
+
+message Message {
+    optional string from = 1;
+    optional bytes data = 2;
+    optional bytes seqno = 3;
+    required string topic = 4;
+    optional bytes signature = 5;
+    optional bytes key = 6;
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `from` | string | Original author's Peer ID (not the forwarder) |
+| `data` | bytes | Opaque application payload |
+| `seqno` | bytes | 64-bit big-endian uint, unique per (from, topic) pair |
+| `topic` | string | Topic ID this message is published to |
+| `signature` | bytes | Signature over the marshalled message (excluding this field) |
+| `key` | bytes | Author's public key (when not inlineable in `from`) |
+
+The presence of `from`, `seqno`, `signature`, and `key` depends on the
+**signature policy** configured for the topic:
+
+| Policy | `from` | `seqno` | `signature` | `key` |
+|--------|--------|---------|-------------|-------|
+| `StrictSign` | Present | Present | Present | Present (if needed) |
+| `StrictNoSign` | Absent | Absent | Absent | Absent |
+
+For `StrictSign`, the signature is computed over the marshalled protobuf
+(excluding the `signature` field) prefixed with the literal string
+`"libp2p-pubsub:"`.
+
+Message size SHOULD be limited to 1 MiB. Messages exceeding this limit are
+rejected.
+
+### RPC Message Wrapper
+
+All PubSub communication is wrapped in an `RPC` protobuf:
+
+```protobuf
+syntax = "proto2";
+
+message RPC {
+    repeated SubOpts subscriptions = 1;
+    repeated Message publish = 2;
+    optional ControlMessage control = 3;
+
+    message SubOpts {
+        optional bool subscribe = 1;
+        optional string topicid = 2;
+    }
+}
+```
+
+A single `RPC` message can contain:
+
+- **Subscription changes**: subscribe/unsubscribe announcements
+- **Published messages**: zero or more `Message` payloads
+- **Control messages**: GossipSub-specific mesh management (GRAFT, PRUNE, IHAVE, IWANT)
+
+Control messages are piggybacked on regular RPC messages whenever possible to
+reduce message rate.
+
+### Control Message Protobuf
+
+```protobuf
+syntax = "proto2";
+
+message ControlMessage {
+    repeated ControlIHave ihave = 1;
+    repeated ControlIWant iwant = 2;
+    repeated ControlGraft graft = 3;
+    repeated ControlPrune prune = 4;
+}
+
+message ControlIHave {
+    optional string topicID = 1;
+    repeated bytes messageIDs = 2;
+}
+
+message ControlIWant {
+    repeated bytes messageIDs = 1;
+}
+
+message ControlGraft {
+    optional string topicID = 1;
+}
+
+message ControlPrune {
+    optional string topicID = 1;
+    repeated PeerInfo peers = 2;       // v1.1 Peer Exchange
+    optional uint64 backoff = 3;       // v1.1 backoff time (seconds)
+}
+
+message PeerInfo {
+    optional bytes peerID = 1;
+    optional bytes signedPeerRecord = 2;
+}
+```
+
+## GossipSub Design
+
+### Two Overlay Networks
+
+GossipSub constructs two overlapping overlay networks for each topic:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Topic "blocks"                            │
+│                                                             │
+│   Full-Message Mesh (eager push)                            │
+│   ┌───┐     ┌───┐     ┌───┐                                │
+│   │ A │─────│ B │─────│ C │    Degree D=6                   │
+│   └───┘     └───┘     └───┘    (Dlo=4, Dhi=12)             │
+│     │  \      │      /  │                                   │
+│     │   \     │     /   │      Full messages flow along     │
+│   ┌───┐  \  ┌───┐ /  ┌───┐    mesh links immediately       │
+│   │ D │   ──│ E │──  │ F │                                  │
+│   └───┘     └───┘     └───┘                                 │
+│                                                             │
+│   Metadata-Only Gossip (lazy push)                          │
+│   ┌───┐ ╌╌╌ ┌───┐ ╌╌╌ ┌───┐                                │
+│   │ A │     │ G │     │ H │    IHAVE messages sent to       │
+│   └───┘     └───┘     └───┘    random non-mesh peers        │
+│     ╎         ╎         ╎      every heartbeat              │
+│   ┌───┐     ┌───┐     ┌───┐                                 │
+│   │ I │     │ J │     │ K │    Peers request full messages   │
+│   └───┘     └───┘     └───┘    with IWANT on demand         │
+│                                                             │
+│   ───  mesh link (full messages)                            │
+│   ╌╌╌  gossip link (metadata only)                          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+1. **Full-message mesh**: A sparse, bidirectional overlay where complete messages
+   are eagerly forwarded. Each peer maintains `D` (target 6) mesh links per topic.
+
+2. **Metadata-only gossip**: A supplementary overlay where peers periodically
+   announce message IDs (via IHAVE) to random non-mesh peers. This allows
+   recovery from mesh failures and accelerates propagation.
+
+### Mesh Peering Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `D` | 6 | Desired mesh degree (outbound links per topic) |
+| `D_lo` | 4 | Lower bound; below this, GRAFT new peers |
+| `D_hi` | 12 | Upper bound; above this, PRUNE excess peers |
+| `D_lazy` | 6 | Number of peers for gossip emission (or `gossip_factor`) |
+| `D_score` | 4-5 | Peers retained by score during oversubscription prune |
+| `D_out` | 2 | Minimum outbound connections in mesh |
+
+**Mesh links are bidirectional**: if peer A has peer B in its mesh, then peer B
+also has peer A in its mesh. This is maintained via GRAFT/PRUNE exchanges.
+
+### Gossip Peering
+
+Gossip targets peers who are in the topic but NOT in the mesh. During each
+heartbeat, the router selects peers for gossip emission:
+
+- **v1.0**: Select `D_lazy` random non-mesh peers
+- **v1.1 (adaptive)**: Select `gossip_factor` (default 0.25 = 25%) of eligible
+  peers, with a minimum of `D_lazy`
+
+With the default gossip factor of 0.25 and 3 gossip rounds per message (from
+`mcache_gossip`), each peer has approximately a 57.8% chance of receiving gossip
+about any given message: `1 - (3/4)^3 = 0.578`.
+
+## Grafting and Pruning
+
+### GRAFT Message
+
+A `GRAFT` message requests that the remote peer add the sender to its mesh for
+the specified topic.
+
+```
+Peer A                              Peer B
+  │                                    │
+  │  ── GRAFT(topicID="blocks") ───►   │
+  │     "Add me to your mesh"          │
+  │                                    │
+  │  A adds B to mesh["blocks"]        │  B adds A to mesh["blocks"]
+  │  (bidirectional link formed)       │  (if subscribed to topic)
+  │                                    │
+```
+
+**Processing rules:**
+- If the receiver is subscribed to the topic: accept and add sender to mesh
+- If the receiver is NOT subscribed: respond with `PRUNE`
+- If the sender is an explicit peer: log error and respond with `PRUNE` (v1.1)
+- If the sender has a negative score (v1.1): respond with `PRUNE`
+- If the sender is within a backoff period (v1.1): respond with `PRUNE` and
+  apply a behavioral penalty via P7
+- If the topic is unknown (v1.1): silently ignore (do NOT respond with PRUNE,
+  to prevent spam amplification)
+
+### PRUNE Message
+
+A `PRUNE` message requests that the remote peer remove the sender from its mesh.
+
+```
+Peer A                              Peer B
+  │                                    │
+  │  ── PRUNE(topicID="blocks",   ──►  │
+  │         peers=[C,D,E],             │
+  │         backoff=60) ──────────     │
+  │                                    │
+  │  A removes B from mesh["blocks"]   │  B removes A from mesh["blocks"]
+  │                                    │  B may connect to C, D, E
+  │                                    │  B starts backoff timer (60s)
+  │                                    │
+```
+
+**v1.1 extensions:**
+- `peers`: Optional list of `PeerInfo` for peer exchange (PX). Pruned peer can
+  connect to these to reform its mesh. Only peers with non-negative scores are
+  exchanged.
+- `backoff`: Duration in seconds before the pruned peer may re-GRAFT. Default
+  is 60 seconds. The pruned peer must wait the full backoff plus slack for the
+  next heartbeat before attempting to re-GRAFT.
+
+### Backoff Timers
+
+```
+PRUNE received at t=0, backoff=60s
+  │
+  ├── t=0..60s: backoff period, GRAFT attempts are rejected
+  │             Early GRAFT → immediate PRUNE + P₇ penalty
+  │
+  ├── t=60s: backoff expires
+  │
+  └── t=61s (next heartbeat): safe to re-GRAFT
+```
+
+| Backoff Type | Default Duration | When Used |
+|-------------|------------------|-----------|
+| `PruneBackoff` | 60 seconds | Normal mesh prune |
+| `UnsubscribeBackoff` | 10 seconds | When unsubscribing from a topic |
+
+Both the pruning and pruned peers maintain backoff state. A peer that attempts
+to GRAFT during the backoff period will have the GRAFT rejected and receive a
+behavioral penalty (P7).
+
+## Message Propagation
+
+### Full Message Forwarding
+
+Within the mesh, messages are forwarded eagerly (full push):
+
+```
+Publisher                Mesh Peers              Further Mesh Peers
+   │                                                   │
+   │  publish("blocks", data)                          │
+   │                                                   │
+   ├──► Peer A ──────► Peer C ──────► Peer E           │
+   ├──► Peer B ──────► Peer D ──────► Peer F           │
+   │         └────────► Peer G                         │
+   │                                                   │
+```
+
+When a peer receives a valid, unseen message:
+
+1. Add message ID to the `seen` cache
+2. Store message in the `mcache` (message cache)
+3. Forward to all peers in `mesh[topic]` except the sender
+4. Forward to all `peers.floodsub[topic]` (backwards compatibility)
+5. Deliver to the local application
+
+### Message Deduplication (Seen Cache)
+
+The `seen` cache is a timed least-recently-used cache of message IDs:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `seen_ttl` | 2 minutes | Expiry time for seen message IDs |
+
+**Message ID calculation** (default, origin-stamped):
+```
+message_id = from || seqno
+```
+
+Alternatively, applications can provide a custom `message_id_fn`:
+```
+message_id = hash(message.data)    // content-addressed messaging
+```
+
+All peers in a topic MUST use identical message ID calculation logic.
+
+Before forwarding or delivering a message, the router checks:
+1. Is the message ID in the `seen` cache? If yes, drop (duplicate).
+2. Was this message published by us? If yes, drop (no self-forwarding).
+3. Is the message valid? If no, drop and penalize sender.
+
+### Message Cache (mcache)
+
+The message cache stores recent messages segmented into history windows:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `mcache_len` | 5 | Total history windows retained |
+| `mcache_gossip` | 3 | Windows examined for gossip emission |
+
+```
+Window 0 (current)  │ Window 1  │ Window 2  │ Window 3  │ Window 4
+  newest messages    │           │           │           │  oldest
+  ◄── gossip range (mcache_gossip=3) ──►    │           │
+  ◄── full cache (mcache_len=5) ────────────────────────►
+```
+
+Operations:
+- `mcache.put(m)`: Store message in current window
+- `mcache.get(id)`: Retrieve message by ID (for IWANT responses)
+- `mcache.get_gossip_ids(topic)`: Get IDs from recent `mcache_gossip` windows
+- `mcache.shift()`: Rotate windows during heartbeat, discard oldest
+
+### Message Validation
+
+Messages undergo a three-stage validation:
+
+1. **Structural validation**: Correct protobuf format, required fields present,
+   size within limits
+2. **Signature validation** (if `StrictSign`): Verify `signature` against `key`
+   and `from`
+3. **Application validation**: Custom validator function registered per topic
+
+**v1.1 Extended Validators** return one of three results:
+
+| Result | Action | Score Impact |
+|--------|--------|-------------|
+| `Accept` | Deliver and forward | P2 credit (first delivery) |
+| `Reject` | Drop, do not forward | P4 penalty (invalid message) |
+| `Ignore` | Drop, do not forward | No penalty |
+
+The `Ignore` result is useful when a peer cannot determine validity (e.g.,
+during blockchain sync) without triggering a penalty.
+
+## Gossip Protocol (IHAVE/IWANT)
+
+### IHAVE: Announce Message IDs
+
+The `IHAVE` message announces message IDs that the sender has recently seen.
+It is emitted during the heartbeat to random non-mesh peers:
+
+```
+Peer A (has messages m1, m2, m3)         Peer B (non-mesh peer)
+  │                                          │
+  │  ── IHAVE(topic="blocks",           ──►  │
+  │          messageIDs=[m1, m2, m3])        │
+  │                                          │
+  │  "I have these messages, want any?"      │
+  │                                          │
+```
+
+**Emission rules (v1.1):**
+- Emitted every heartbeat (default 1 second)
+- Targets: `gossip_factor` (0.25) of eligible non-mesh peers, minimum `D_lazy`
+  peers
+- Only peers with score above `GossipThreshold` receive gossip
+- Message IDs are drawn from the last `mcache_gossip` (3) windows
+
+**Spam protection (v1.1):**
+- IHAVE messages per heartbeat are capped per peer
+- Total advertised message IDs per heartbeat are capped
+- Additional IHAVE messages beyond the cap are silently ignored
+
+### IWANT: Request Full Messages
+
+The `IWANT` message requests the full content of messages by their IDs:
+
+```
+Peer B (wants m2)                     Peer A (has m2 in mcache)
+  │                                          │
+  │  ── IWANT(messageIDs=[m2])          ──►  │
+  │                                          │
+  │  ◄── Message(m2)                    ───  │
+  │                                          │
+```
+
+**Processing rules:**
+- On receiving IHAVE, check `seen` cache. Request only unseen messages via IWANT.
+- On receiving IWANT, look up in `mcache`. Forward if present.
+- **v1.1**: IWANT responses are limited per peer to prevent resource drain
+- **v1.1**: In-flight IWANT requests are probabilistically tracked. If a random
+  tracked message is not received within a timeout, the advertising peer gets
+  a P7 behavioral penalty.
+
+### Lazy Push/Pull Pattern
+
+```
+                    Eager Push (mesh)
+Publisher ──────────────────────────────► Mesh Peer
+    │
+    │               Lazy Push (gossip)
+    │  ┌──────────────────────────────────────────────┐
+    │  │  1. IHAVE(ids)                               │
+    │  │  ──────────────────►  Non-Mesh Peer          │
+    │  │                                              │
+    │  │  2. IWANT(ids)                               │
+    │  │  ◄──────────────────  Non-Mesh Peer          │
+    │  │                                              │
+    │  │  3. Full Message                             │
+    │  │  ──────────────────►  Non-Mesh Peer          │
+    │  └──────────────────────────────────────────────┘
+```
+
+The gossip mechanism serves as a secondary propagation channel:
+- Recovers from mesh link failures
+- Detects missing messages
+- Enables epidemic-style protocols (e.g., episub) to build broadcast trees
+
+## Fan-out for Non-Subscribers
+
+A peer can publish messages to topics it has NOT subscribed to using the
+**fan-out** mechanism:
+
+```
+Publisher (not subscribed to "tx")
+  │
+  │  First publish to "tx":
+  │    1. Select D (6) peers from peers.gossipsub["tx"]
+  │    2. Store them in fanout["tx"]
+  │    3. Send message to all fanout peers
+  │
+  │  Subsequent publishes (within TTL):
+  │    1. Use existing fanout["tx"] peers
+  │    2. Send message to all fanout peers
+  │
+  │  After fanout_ttl (60s) with no publishes:
+  │    1. Remove fanout["tx"] from state
+  │
+```
+
+### Fan-out Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| Fan-out peers | `D` (6) | Number of fan-out peers per topic |
+| `fanout_ttl` | 60 seconds | Time without publishing before fan-out state is discarded |
+
+### Fan-out Maintenance (Heartbeat)
+
+During each heartbeat:
+
+```
+for each topic in fanout:
+    if time_since_last_published > fanout_ttl:
+        remove topic from fanout
+    else if |fanout[topic]| < D:
+        select D - |fanout[topic]| peers from peers.gossipsub[topic]
+        add selected peers to fanout[topic]
+```
+
+### Fan-out to Mesh Transition
+
+When a peer subscribes to a topic (JOIN), it first checks the fan-out map:
+
+1. If `fanout[topic]` exists: move those peers to `mesh[topic]`
+2. If fewer than `D` peers: fill from `peers.gossipsub[topic]`
+3. Send GRAFT to all new mesh members
+4. Remove `fanout[topic]`
+
+This avoids rebuilding mesh state from scratch when a publisher becomes a
+subscriber.
+
+**Note (v1.1)**: When `FloodPublish` is enabled (default `true`), the fan-out
+mechanism is not used. Instead, published messages are sent to ALL connected
+peers in the topic with a score above `PublishThreshold`.
+
+## Per-Peer State
+
+### Router State Overview
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   GossipSub Router                  │
+│                                                     │
+│  peers.gossipsub: Set PeerId                        │
+│    All known gossipsub-capable peers                │
+│                                                     │
+│  peers.floodsub: Set PeerId                         │
+│    All known floodsub-capable peers                 │
+│                                                     │
+│  mesh: Map Topic (Set PeerId)                       │
+│    Mesh peers for each subscribed topic             │
+│                                                     │
+│  fanout: Map Topic (Set PeerId)                     │
+│    Fan-out peers for unsubscribed topics            │
+│                                                     │
+│  mcache: MessageCache                               │
+│    Recent messages in history windows               │
+│                                                     │
+│  seen: TimedLRUCache MessageId                      │
+│    Recently seen message IDs (dedup)                │
+│                                                     │
+│  backoff: Map (PeerId, Topic) Timestamp             │
+│    Backoff timers from PRUNE (v1.1)                 │
+│                                                     │
+│  scores: Map PeerId Score                           │
+│    Peer scores (v1.1)                               │
+│                                                     │
+│  direct_peers: Set PeerId                           │
+│    Explicit peering agreements (v1.1)               │
+│                                                     │
+│  fanout_last_pub: Map Topic Timestamp               │
+│    Last publish time per fan-out topic              │
+│                                                     │
+│  peer_topics: Map PeerId (Set Topic)                │
+│    Topics each peer is subscribed to                │
+│                                                     │
+│  outbound: Set PeerId                               │
+│    Peers we initiated connections to                │
+│                                                     │
+└─────────────────────────────────────────────────────┘
+```
+
+### Per-Peer Tracked State
+
+For each connected peer, the router tracks:
+
+| State | Description |
+|-------|-------------|
+| Peer ID | Unique identifier |
+| Protocol | `gossipsub` or `floodsub` |
+| Topics | Set of topics the peer is subscribed to |
+| Score | Computed peer score (v1.1) |
+| Mesh membership | Which topics this peer is in our mesh for |
+| Connection direction | Inbound or outbound (for `D_out` quota) |
+| Backoff timers | Per-topic backoff expiration times |
+| IP address | For IP colocation scoring (P6) |
+| First message deliveries | Counter per topic (for P2) |
+| Mesh message deliveries | Counter per topic (for P3) |
+| Invalid messages | Counter per topic (for P4) |
+| Mesh time | Time since GRAFT per topic (for P1) |
+| Behavioral penalties | Counter for P7 |
+| IHAVE budget | Remaining IHAVE messages this heartbeat |
+| IWANT budget | Remaining IWANT responses this heartbeat |
+
+## Peer Scoring (v1.1)
+
+### Score Function
+
+Each peer computes a local score for every other peer. Scores are **not shared**
+between peers. The score determines how the router treats the peer across all
+protocol operations.
+
+```
+Score(p) = TopicCap(
+               Sum over topics t_i of:
+                   t_i * (w1*P1 + w2*P2 + w3*P3 + w3b*P3b + w4*P4)
+           )
+           + w5*P5 + w6*P6 + w7*P7
+```
+
+### Score Components
+
+| Parameter | Name | Weight | Description |
+|-----------|------|--------|-------------|
+| **P1** | Time in Mesh | Positive (small) | Rewards mesh longevity. Capped to prevent abuse. |
+| **P2** | First Message Deliveries | Positive | Rewards peers who deliver messages first. |
+| **P3** | Mesh Message Delivery Rate | Negative | Penalizes peers below expected delivery threshold. Value = deficit^2. |
+| **P3b** | Mesh Message Delivery Failures | Negative | Sticky penalty accumulated on prune. Value = deficit^2 at prune time. |
+| **P4** | Invalid Messages | Negative | Penalizes invalid message transmission. Value = counter^2. |
+| **P5** | Application-Specific | Positive weight, arbitrary value | Application-defined score component. |
+| **P6** | IP Colocation Factor | Negative | Penalizes multiple peers on same IP. Value = (count - threshold)^2. |
+| **P7** | Behavioral Penalty | Negative | Explicit penalties for misbehavior (e.g., early re-GRAFT). Value = counter^2. |
+
+### Topic Score Parameters
+
+Each topic can be independently configured:
+
+| Parameter | Description |
+|-----------|-------------|
+| `TopicWeight` | How much this topic contributes to overall score |
+| `TimeInMeshWeight` | Weight for P1 (small positive) |
+| `TimeInMeshQuantum` | Duration unit for P1 accrual |
+| `TimeInMeshCap` | Maximum P1 value |
+| `FirstMessageDeliveriesWeight` | Weight for P2 (positive) |
+| `FirstMessageDeliveriesDecay` | Decay factor for P2 counter |
+| `FirstMessageDeliveriesCap` | Maximum P2 counter value |
+| `MeshMessageDeliveriesWeight` | Weight for P3 (negative) |
+| `MeshMessageDeliveriesDecay` | Decay factor for P3 counter |
+| `MeshMessageDeliveriesThreshold` | Expected delivery rate threshold |
+| `MeshMessageDeliveriesCap` | Maximum P3 counter (>= threshold) |
+| `MeshMessageDeliveriesActivation` | Grace period before P3 applies |
+| `MeshMessageDeliveryWindow` | Near-first delivery window (1-5 ms) |
+| `MeshFailurePenaltyWeight` | Weight for P3b (negative) |
+| `MeshFailurePenaltyDecay` | Decay factor for P3b counter |
+| `InvalidMessageDeliveriesWeight` | Weight for P4 (negative) |
+| `InvalidMessageDeliveriesDecay` | Decay factor for P4 counter |
+
+### Behavioral Penalties
+
+The P7 behavioral penalty counter is explicitly incremented by the router for:
+
+- Attempting to GRAFT during a backoff period
+- Advertising bogus message IDs via IHAVE (tracked probabilistically)
+- Other protocol violations
+
+The penalty value is the **square** of the counter, mixed with a negative weight.
+This provides quadratic escalation for repeated offenses.
+
+### Score Thresholds
+
+Thresholds control how the router treats peers based on their score:
+
+```
+Score axis:
+  ◄───── negative ──────────── 0 ─────────── positive ─────►
+
+  GraylistThreshold  PublishThreshold  GossipThreshold    0    AcceptPXThreshold
+        │                  │                │             │           │
+        ▼                  ▼                ▼             ▼           ▼
+  ┌──────────┬──────────────┬───────────────┬─────────────┬──────────┐
+  │  Ignore  │  No publish  │  No gossip    │  No mesh    │  Accept  │
+  │  all RPC │  to peer     │  to/from peer │  (prune)    │  PX from │
+  │          │              │               │             │  peer    │
+  └──────────┴──────────────┴───────────────┴─────────────┴──────────┘
+```
+
+| Threshold | Constraint | Effect |
+|-----------|-----------|--------|
+| `0` (baseline) | -- | Peers below 0 are pruned from mesh. No PX emitted/accepted. |
+| `GossipThreshold` | < 0 | No gossip emitted to or accepted from peer |
+| `PublishThreshold` | <= `GossipThreshold` | No flood-published messages sent to peer |
+| `GraylistThreshold` | < `PublishThreshold` | All RPCs from peer are ignored |
+| `AcceptPXThreshold` | >= 0 | PX from PRUNE is only accepted from peers above this |
+| `OpportunisticGraftThreshold` | >= 0 | Triggers opportunistic grafting when median mesh score falls below |
+
+### Parameter Decay
+
+All counters (P2, P3, P3b, P4, P7) decay periodically:
+
+```
+counter = counter * decay_factor
+if counter < DecayToZero:
+    counter = 0
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `DecayInterval` | How often decay is applied (e.g., 1 second) |
+| `DecayToZero` | Threshold below which a counter is zeroed |
+| `RetainScore` | How long to retain scores after peer disconnects |
+
+Scores are retained after disconnection for `RetainScore` duration. This
+prevents malicious peers from resetting their score by reconnecting.
+
+## Topic Subscription Management
+
+### JOIN: Subscribe to Topic
+
+When the application subscribes to a topic:
+
+```
+JOIN(topic):
+    1. Announce subscription to all known peers via RPC SubOpts
+    2. Check fanout[topic]:
+       - If exists: move fanout peers to mesh[topic]
+       - Remove fanout[topic] and fanout_last_pub[topic]
+    3. If |mesh[topic]| < D:
+       - Select D - |mesh[topic]| peers from peers.gossipsub[topic]
+         (excluding those already in mesh, with non-negative score)
+       - Add to mesh[topic]
+    4. For each new mesh peer:
+       - Send GRAFT(topic)
+```
+
+### LEAVE: Unsubscribe from Topic
+
+When the application unsubscribes from a topic:
+
+```
+LEAVE(topic):
+    1. Announce unsubscription to all known peers via RPC SubOpts
+    2. For each peer in mesh[topic]:
+       - Send PRUNE(topic) with backoff=UnsubscribeBackoff (10s)
+    3. Delete mesh[topic]
+```
+
+The `UnsubscribeBackoff` (10 seconds) is shorter than the normal `PruneBackoff`
+(60 seconds) to allow faster resubscription.
+
+### Mesh Construction Example
+
+```
+Peer X joins topic "blocks" (D=6, no prior fanout state):
+
+Known gossipsub peers in "blocks": [A, B, C, D, E, F, G, H, I, J]
+
+Step 1: Select 6 random peers → [A, C, D, F, H, J]
+Step 2: mesh["blocks"] = {A, C, D, F, H, J}
+Step 3: Send GRAFT("blocks") to each
+
+        X
+       /|\\ \  \
+      A C D F H J     (6 mesh links formed)
+```
+
+## Heartbeat
+
+### Overview
+
+The heartbeat is a periodic maintenance procedure that keeps the mesh healthy:
+
+| Parameter | Default |
+|-----------|---------|
+| `heartbeat_interval` | 1 second |
+
+### Heartbeat Procedure
+
+Each heartbeat performs three main tasks in order:
+
+#### 1. Mesh Maintenance
+
+```
+for each topic in mesh:
+    // Remove peers with negative scores (v1.1)
+    for each peer in mesh[topic]:
+        if score(peer) < 0:
+            remove peer from mesh[topic]
+            send PRUNE(topic) to peer
+
+    // Undersubscribed: add peers
+    if |mesh[topic]| < D_lo:
+        select D - |mesh[topic]| peers from peers.gossipsub[topic]
+            where peer not in mesh[topic]
+            and score(peer) >= 0              // v1.1
+            and backoff not active            // v1.1
+        for each selected peer:
+            add to mesh[topic]
+            send GRAFT(topic)
+
+    // Oversubscribed: remove peers
+    if |mesh[topic]| > D_hi:
+        keep best D_score peers by score      // v1.1
+        keep D - D_score random peers
+            (ensuring D_out outbound peers)   // v1.1
+        for each removed peer:
+            remove from mesh[topic]
+            send PRUNE(topic) with PX
+
+    // Outbound quota check (v1.1)
+    if |mesh[topic]| >= D_lo:
+        if outbound peers in mesh < D_out:
+            select peers to fill D_out quota
+            add to mesh[topic]
+            send GRAFT(topic)
+```
+
+#### 2. Fanout Maintenance
+
+```
+for each topic in fanout:
+    if time_since_last_published > fanout_ttl:
+        remove topic from fanout
+    else if |fanout[topic]| < D:
+        fill from peers.gossipsub[topic]
+```
+
+#### 3. Gossip Emission
+
+```
+for each topic in mesh + fanout:
+    mids = mcache.get_gossip_ids(topic)
+    if mids is not empty:
+        // v1.1: adaptive gossip
+        eligible = peers in topic with score > GossipThreshold
+        n = max(D_lazy, |eligible| * gossip_factor)
+        select n peers from eligible, not in mesh[topic] or fanout[topic]
+        send IHAVE(topic, mids) to selected peers
+
+mcache.shift()     // rotate message cache windows
+```
+
+#### 4. Score Decay (v1.1)
+
+```
+for each peer:
+    for each topic:
+        decay P1 (mesh time), P2, P3, P3b, P4 counters
+    decay P7 counter
+```
+
+#### 5. Opportunistic Grafting (v1.1, every ~60 heartbeats)
+
+```
+for each topic in mesh:
+    median_score = median(scores of mesh[topic] peers)
+    if median_score < OpportunisticGraftThreshold:
+        select 2 peers with score > median_score
+        add to mesh[topic]
+        send GRAFT(topic)
+```
+
+## Flood Publishing
+
+### Behavior
+
+When `FloodPublish` is enabled (default `true` in v1.1), a peer's own messages
+are published to **all** connected peers in the topic, not just mesh peers:
+
+```
+Normal mesh forwarding:              Flood publishing:
+
+  Peer ──► mesh[topic]               Peer ──► ALL peers in topic
+           (D peers)                           with score > PublishThreshold
+```
+
+**Key properties:**
+- Applies to the peer's OWN messages only (not forwarded messages)
+- Forwarded messages still use the mesh
+- Applies regardless of whether the publisher is subscribed to the topic
+- Replaces fan-out for non-subscribers when enabled
+
+**Why flood publish?**
+- Counters eclipse attacks: even if all mesh peers are malicious, the message
+  reaches honest peers directly
+- Reduces propagation latency: message is injected at multiple points
+- Ensures newly published messages from honest nodes reach all connected
+  honest peers
+
+### Interaction with Fan-out
+
+When flood publishing is enabled:
+- The fan-out map is not used (messages go to all peers anyway)
+- No gossip is emitted for topics where the peer is a pure publisher
+  (not subscribed)
+
+## Explicit Peering Agreements (v1.1)
+
+Explicit peering agreements are configured out-of-band between node operators:
+
+```
+Peer A                                    Peer B
+  │  (configured as explicit peers)          │
+  │                                          │
+  │  ── Always forward messages ────────►    │
+  │  ◄── Always forward messages ────────    │
+  │                                          │
+  │  • Exist OUTSIDE the mesh                │
+  │  • Not subject to scoring                │
+  │  • Connections maintained at all times    │
+  │  • Reconnect check every 5 minutes       │
+  │  • GRAFT from explicit peer → error      │
+  │                                          │
+```
+
+Explicit peers:
+- Always receive forwarded messages (regardless of score)
+- Always have their RPCs accepted
+- Are NOT part of any mesh (exist outside the mesh overlay)
+- Must not be GRAFTed; a GRAFT from an explicit peer is an error
+- Connections are maintained permanently with periodic connectivity checks
+
+## Haskell Implementation Notes
+
+### Key Data Types
+
+```haskell
+-- | Topic identifier
+type Topic = Text
+
+-- | Unique message identifier
+type MessageId = ByteString
+
+-- | Peer score as a floating-point value
+type Score = Double
+
+-- | GossipSub message
+data PubSubMessage = PubSubMessage
+    { msgFrom      :: Maybe PeerId
+    , msgData      :: ByteString
+    , msgSeqNo     :: Maybe Word64
+    , msgTopic     :: Topic
+    , msgSignature :: Maybe ByteString
+    , msgKey       :: Maybe ByteString
+    }
+
+-- | RPC wrapper
+data RPC = RPC
+    { rpcSubscriptions :: [SubOpts]
+    , rpcPublish       :: [PubSubMessage]
+    , rpcControl       :: Maybe ControlMessage
+    }
+
+data SubOpts = SubOpts
+    { subOptSubscribe :: Bool
+    , subOptTopicId   :: Topic
+    }
+
+-- | Control messages
+data ControlMessage = ControlMessage
+    { ctrlIHave :: [IHave]
+    , ctrlIWant :: [IWant]
+    , ctrlGraft :: [Graft]
+    , ctrlPrune :: [Prune]
+    }
+
+data IHave = IHave Topic [MessageId]
+data IWant = IWant [MessageId]
+data Graft = Graft Topic
+data Prune = Prune Topic [PeerInfo] (Maybe Word64)  -- peers, backoff
+
+data PeerInfo = PeerInfo PeerId (Maybe ByteString)   -- signed peer record
+
+-- | Per-topic peer state for scoring
+data TopicPeerState = TopicPeerState
+    { tpsMeshTime                :: NominalDiffTime
+    , tpsFirstMessageDeliveries  :: Double
+    , tpsMeshMessageDeliveries   :: Double
+    , tpsMeshFailurePenalty      :: Double
+    , tpsInvalidMessages         :: Double
+    , tpsGraftTime               :: Maybe UTCTime
+    , tpsInMesh                  :: Bool
+    }
+
+-- | Full peer state
+data PeerState = PeerState
+    { psTopics           :: Set Topic
+    , psTopicState       :: Map Topic TopicPeerState
+    , psBehaviorPenalty  :: Double
+    , psIPAddress        :: Maybe IP
+    , psIsOutbound       :: Bool
+    , psConnectedSince   :: UTCTime
+    , psScore            :: Score      -- cached, recomputed periodically
+    }
+```
+
+### Router State with STM
+
+The GossipSub router state should be managed with STM (Software Transactional
+Memory) for safe concurrent access:
+
+```haskell
+data GossipSubRouter = GossipSubRouter
+    { gsParams      :: GossipSubParams
+    , gsMesh        :: TVar (Map Topic (Set PeerId))
+    , gsFanout      :: TVar (Map Topic (Set PeerId))
+    , gsFanoutPub   :: TVar (Map Topic UTCTime)
+    , gsPeers       :: TVar (Map PeerId PeerState)
+    , gsMcache      :: TVar MessageCache
+    , gsSeen        :: TVar (Map MessageId UTCTime)
+    , gsBackoff     :: TVar (Map (PeerId, Topic) UTCTime)
+    , gsDirectPeers :: Set PeerId
+    , gsScores      :: TVar (Map PeerId Score)
+    }
+
+data GossipSubParams = GossipSubParams
+    { paramD                  :: Int           -- 6
+    , paramDlo                :: Int           -- 4
+    , paramDhi                :: Int           -- 12
+    , paramDlazy              :: Int           -- 6
+    , paramDscore             :: Int           -- 4
+    , paramDout               :: Int           -- 2
+    , paramHeartbeatInterval  :: NominalDiffTime  -- 1 second
+    , paramFanoutTTL          :: NominalDiffTime  -- 60 seconds
+    , paramMcacheLen          :: Int           -- 5
+    , paramMcacheGossip       :: Int           -- 3
+    , paramSeenTTL            :: NominalDiffTime  -- 120 seconds
+    , paramPruneBackoff       :: NominalDiffTime  -- 60 seconds
+    , paramUnsubBackoff       :: NominalDiffTime  -- 10 seconds
+    , paramGossipFactor       :: Double        -- 0.25
+    , paramFloodPublish       :: Bool          -- True
+    }
+```
+
+### Timer-Based Heartbeat
+
+The heartbeat should run as a background thread using `async`:
+
+```haskell
+runHeartbeat :: GossipSubRouter -> IO ()
+runHeartbeat router = forever $ do
+    threadDelay (toMicroseconds $ paramHeartbeatInterval $ gsParams router)
+    atomically $ do
+        meshMaintenance router
+        fanoutMaintenance router
+    -- Gossip emission may require IO for sending messages
+    emitGossip router
+    atomically $ do
+        decayScores router
+        shiftMcache router
+    -- Opportunistic grafting (every ~60 heartbeats)
+    checkOpportunisticGraft router
+```
+
+### Mesh Management with STM
+
+```haskell
+-- | Add a peer to the mesh for a topic (within STM)
+graftPeer :: GossipSubRouter -> Topic -> PeerId -> STM ()
+graftPeer router topic peer = do
+    mesh <- readTVar (gsMesh router)
+    let topicPeers = Map.findWithDefault Set.empty topic mesh
+    writeTVar (gsMesh router) $
+        Map.insert topic (Set.insert peer topicPeers) mesh
+
+-- | Remove a peer from the mesh for a topic (within STM)
+prunePeer :: GossipSubRouter -> Topic -> PeerId -> STM ()
+prunePeer router topic peer = do
+    mesh <- readTVar (gsMesh router)
+    let topicPeers = Map.findWithDefault Set.empty topic mesh
+    writeTVar (gsMesh router) $
+        Map.insert topic (Set.delete peer topicPeers) mesh
+```
+
+### Recommended Haskell Libraries
+
+| Purpose | Library | Notes |
+|---------|---------|-------|
+| Protobuf encoding | `proto-lens` or `proto3-wire` | For RPC/Message encoding |
+| Concurrency | `stm`, `async` | Mesh state, heartbeat timer |
+| Time | `time` | Backoff timers, score decay |
+| Random selection | `random` | Peer selection for mesh/gossip |
+| LRU Cache | `lrucache` | Seen cache implementation |
+| IP addresses | `iproute` | For P6 IP colocation scoring |
+| ByteString | `bytestring` | Message payloads and IDs |
+
+## Spec References
+
+- PubSub interface: https://github.com/libp2p/specs/blob/master/pubsub/README.md
+- GossipSub v1.0: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md
+- GossipSub v1.1: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md
+- Go implementation: https://github.com/libp2p/go-libp2p-pubsub
+- Rust implementation: https://github.com/libp2p/rust-libp2p/tree/master/protocols/gossipsub

--- a/docs/12-connection-flow.md
+++ b/docs/12-connection-flow.md
@@ -1,0 +1,921 @@
+# Chapter 12: Connection Flow
+
+This chapter provides a complete end-to-end walkthrough of libp2p connection
+establishment, tying together transports (Chapter 4), secure channels
+(Chapter 5), stream multiplexing (Chapter 6), and protocol negotiation into a
+single narrative. It traces exactly what bytes flow over the wire from the
+moment a TCP socket opens to the point where application data is exchanged.
+
+## Overview
+
+Establishing a libp2p connection over TCP requires multiple sequential
+negotiations. The raw transport provides only a bidirectional byte stream; on
+top of it, the peers must agree on a security protocol, perform a cryptographic
+handshake, agree on a stream multiplexer, and then open individual streams for
+application protocols. Each agreement step uses multistream-select.
+
+The full pipeline looks like this:
+
+```
+TCP connect
+    |
+    v
+multistream-select --> agree on security protocol (/noise)
+    |
+    v
+Noise XX handshake (3 messages)
+    |
+    v
+multistream-select --> agree on muxer protocol (/yamux/1.0.0)
+    |
+    v
+Yamux session established
+    |
+    v
+Stream 1: Identify exchange (/ipfs/id/1.0.0)
+Stream 2+: Application protocols
+```
+
+QUIC collapses this entire pipeline into a single round trip because TLS 1.3
+and native multiplexing are built into the transport itself.
+
+## TCP Connection Example (Full Detail)
+
+This section walks through every message exchanged between two peers, Alice
+(initiator/dialer) and Bob (responder/listener), establishing a connection over
+TCP with Noise security and Yamux multiplexing.
+
+### Step 1: TCP Three-Way Handshake
+
+```
+Alice                                          Bob
+  |                                              |
+  |-------- SYN (seq=x) ----------------------->|
+  |                                              |
+  |<------- SYN-ACK (seq=y, ack=x+1) ----------|
+  |                                              |
+  |-------- ACK (ack=y+1) --------------------->|
+  |                                              |
+  |  TCP connection established                  |
+```
+
+This is standard TCP. After the three-way handshake, both sides have a
+reliable, bidirectional byte stream. No libp2p data has been exchanged yet.
+
+**Cost: 1.5 RTT** (the ACK can carry data, but typically does not in libp2p).
+
+### Step 2: multistream-select for Security Protocol
+
+Both peers send the multistream-select protocol identifier simultaneously,
+without waiting for the other side. Messages are UTF-8 strings, each prefixed
+with its length as an unsigned varint, and terminated with a newline (`\n`).
+
+```
+Alice                                          Bob
+  |                                              |
+  |-- "/multistream/1.0.0\n" ------------------>|
+  |                                              |
+  |<-- "/multistream/1.0.0\n" ------------------ |
+  |                                              |
+  |-- "/noise\n" ------------------------------>|
+  |                                              |
+  |<-- "/noise\n" ------------------------------ |
+  |                                              |
+  |  Security protocol agreed: Noise             |
+```
+
+**Wire bytes for `/multistream/1.0.0\n`:**
+
+```
+13 2f 6d 75 6c 74 69 73 74 72 65 61 6d 2f 31 2e 30 2e 30 0a
+^^                                                         ^^
+varint(19)    "/multistream/1.0.0"                         \n
+```
+
+- Varint `0x13` = 19 (length of the string including `\n`)
+- `2f 6d 75 6c 74 69 73 74 72 65 61 6d 2f 31 2e 30 2e 30` = `/multistream/1.0.0`
+- `0a` = `\n`
+
+**Wire bytes for `/noise\n`:**
+
+```
+07 2f 6e 6f 69 73 65 0a
+^^                   ^^
+varint(7)  "/noise"  \n
+```
+
+The initiator proposes `/noise` and the responder echoes it back to confirm
+agreement. If the responder did not support Noise, it would respond with `na\n`
+(`03 6e 61 0a`), and the initiator would propose an alternative.
+
+Both sides can pipeline: Alice sends `/multistream/1.0.0\n` and `/noise\n` in
+the same TCP segment without waiting for Bob's response. This is called
+**optimistic sending** and saves a round trip in the common case.
+
+**Cost: 1 RTT** (with pipelining; 2 RTT without).
+
+### Step 3: Noise XX Handshake
+
+After both sides agree on `/noise`, the Noise XX handshake begins. All Noise
+messages are framed with a 2-byte big-endian length prefix (see Chapter 5).
+
+```
+Alice (Initiator)                              Bob (Responder)
+  |                                              |
+  |-- Noise Msg 1: [e] ----------------------->|
+  |   [2-byte len][32-byte ephemeral pubkey]     |
+  |   (34 bytes total)                           |
+  |                                              |
+  |<-- Noise Msg 2: [e, ee, s, es] ------------ |
+  |   [2-byte len][32-byte eph pubkey]           |
+  |   [48-byte encrypted static pubkey]          |
+  |   [encrypted payload + 16-byte tag]          |
+  |   Payload contains:                          |
+  |     - Bob's libp2p identity key (protobuf)   |
+  |     - Signature over Noise static key        |
+  |     - Extensions: supported muxers (optional)|
+  |                                              |
+  |-- Noise Msg 3: [s, se] ------------------->|
+  |   [2-byte len]                               |
+  |   [48-byte encrypted static pubkey]          |
+  |   [encrypted payload + 16-byte tag]          |
+  |   Payload contains:                          |
+  |     - Alice's libp2p identity key (protobuf) |
+  |     - Signature over Noise static key        |
+  |     - Extensions: supported muxers (optional)|
+  |                                              |
+  |  Secure channel established                  |
+  |  (Two CipherState objects for each direction)|
+```
+
+**Message sizes (approximate):**
+
+| Message | Direction | Size |
+|---------|-----------|------|
+| Msg 1 | Alice -> Bob | 2 + 32 = 34 bytes |
+| Msg 2 | Bob -> Alice | 2 + 32 + 48 + (payload + 16) bytes |
+| Msg 3 | Alice -> Bob | 2 + 48 + (payload + 16) bytes |
+
+The payload in Messages 2 and 3 is a protobuf-encoded `NoiseHandshakePayload`:
+
+```protobuf
+message NoiseHandshakePayload {
+    optional bytes identity_key = 1;   // serialized PublicKey protobuf
+    optional bytes identity_sig = 2;   // signature of "noise-libp2p-static-key:" || static_pubkey
+    optional NoiseExtensions extensions = 4;
+}
+```
+
+For an Ed25519 identity key, the payload is approximately 100-120 bytes. After
+encryption and the authentication tag, Messages 2 and 3 are each roughly
+200-250 bytes.
+
+After the handshake, each peer validates the other's identity:
+
+1. Decode `identity_key` into a public key
+2. Verify `identity_sig` against the Noise static public key
+3. Derive the Peer ID from `identity_key`
+4. If dialing a specific peer, verify the Peer ID matches the expected value
+
+From this point, all data is encrypted with ChaCha20-Poly1305. Each encrypted
+message is framed as `[2-byte length][ciphertext || 16-byte auth tag]`.
+
+**Cost: 1.5 RTT** (3 messages).
+
+### Step 4: multistream-select for Stream Multiplexer
+
+The muxer negotiation happens over the now-encrypted channel. The wire format
+is the same as Step 2, but all bytes are encrypted before transmission.
+
+```
+Alice                                          Bob
+  |                                              |
+  |== encrypted ================================ |
+  |                                              |
+  |-- "/multistream/1.0.0\n" ------------------>|
+  |                                              |
+  |<-- "/multistream/1.0.0\n" ------------------ |
+  |                                              |
+  |-- "/yamux/1.0.0\n" ----------------------->|
+  |                                              |
+  |<-- "/yamux/1.0.0\n" ----------------------- |
+  |                                              |
+  |  Muxer agreed: Yamux                         |
+```
+
+**Wire bytes for `/yamux/1.0.0\n` (before encryption):**
+
+```
+0d 2f 79 61 6d 75 78 2f 31 2e 30 2e 30 0a
+^^                                      ^^
+varint(13)   "/yamux/1.0.0"             \n
+```
+
+Again, both sides can pipeline. With pipelining, this adds roughly 1 RTT.
+
+**Cost: 1 RTT** (with pipelining).
+
+### Step 5: Yamux Session Established
+
+The Yamux session is now active. No explicit session-setup message is needed;
+Yamux starts immediately. Streams are opened by sending a frame with the SYN
+flag set.
+
+- Alice (initiator/client) uses **odd** stream IDs: 1, 3, 5, ...
+- Bob (responder/server) uses **even** stream IDs: 2, 4, 6, ...
+
+### Step 6: Identify Exchange
+
+Immediately after the connection is upgraded, both peers typically open a
+stream to perform the Identify protocol exchange. The initiator usually opens
+stream 1 for this purpose.
+
+```
+Alice                                          Bob
+  |                                              |
+  |== Yamux Stream 1: Identify ================ |
+  |                                              |
+  |-- Yamux [SYN, StreamID=1, Data] ----------->|
+  |   multistream-select: "/multistream/1.0.0\n"|
+  |   protocol: "/ipfs/id/1.0.0\n"              |
+  |                                              |
+  |<-- Yamux [ACK, StreamID=1, Data] ----------- |
+  |   multistream-select: "/multistream/1.0.0\n"|
+  |   protocol: "/ipfs/id/1.0.0\n"              |
+  |                                              |
+  |<-- Yamux [Data, StreamID=1] ---------------- |
+  |   Identify message (protobuf):               |
+  |     - publicKey: Bob's public key            |
+  |     - listenAddrs: Bob's listen addresses    |
+  |     - observedAddr: Alice's address as       |
+  |       seen by Bob                            |
+  |     - protocols: ["/ipfs/id/1.0.0",          |
+  |       "/ipfs/id/push/1.0.0", "/ipfs/ping/   |
+  |       1.0.0", ...]                           |
+  |     - protocolVersion: "ipfs/0.1.0"          |
+  |     - agentVersion: "go-libp2p/0.30.0"       |
+  |                                              |
+  |<-- Yamux [FIN, StreamID=1] ----------------- |
+  |   Bob closes his side of the stream          |
+  |                                              |
+  |-- Yamux [FIN, StreamID=1] ----------------->|
+  |   Alice closes her side                      |
+```
+
+The Identify message is a single protobuf:
+
+```protobuf
+message Identify {
+    optional string protocolVersion = 5;
+    optional string agentVersion = 6;
+    optional bytes publicKey = 1;
+    repeated bytes listenAddrs = 2;
+    optional bytes observedAddr = 4;
+    repeated string protocols = 3;
+}
+```
+
+The responder sends the Identify message and closes the stream. The initiator
+reads the message and closes its side. Both peers now know each other's
+capabilities and addresses.
+
+**Note:** In practice, Bob also opens stream 2 to query Alice's Identify
+information, so both peers learn about each other.
+
+### Step 7: Application Streams
+
+After the Identify exchange, the connection is fully operational. Either peer
+can open new streams for application protocols:
+
+```
+Alice                                          Bob
+  |                                              |
+  |== Yamux Stream 3: Application Protocol ===== |
+  |                                              |
+  |-- Yamux [SYN, StreamID=3, Data] ----------->|
+  |   multistream-select for /my-app/1.0.0       |
+  |                                              |
+  |<-- Yamux [ACK, StreamID=3, Data] ----------- |
+  |   multistream-select echo /my-app/1.0.0      |
+  |                                              |
+  |<============ application data =============>|
+```
+
+## Complete Sequence Diagram: TCP + Noise + Yamux
+
+The following diagram shows every message in chronological order for a complete
+connection from TCP SYN to the first application data exchange.
+
+```
+Alice (Initiator)                                            Bob (Responder)
+  |                                                              |
+  |  ===== TCP Three-Way Handshake =====                         |
+  |                                                              |
+  |-------- TCP SYN ------------------------------------------>|  RTT 0.5
+  |<------- TCP SYN-ACK ----------------------------------------|  RTT 1.0
+  |-------- TCP ACK ------------------------------------------->|  RTT 1.5
+  |                                                              |
+  |  ===== multistream-select: Security Protocol =====           |
+  |  (pipelined: both messages in one TCP segment)               |
+  |                                                              |
+  |-- varint|"/multistream/1.0.0\n" + varint|"/noise\n" ------>|  RTT 1.5
+  |<-- varint|"/multistream/1.0.0\n" + varint|"/noise\n" ------|  RTT 2.0
+  |                                                              |
+  |  ===== Noise XX Handshake =====                              |
+  |                                                              |
+  |-- [len][ephemeral_pubkey_alice]  (Noise msg 1) ----------->|  RTT 2.0
+  |<-- [len][eph_bob|enc(s_bob)|enc(payload_bob)]  (msg 2) ----|  RTT 2.5
+  |-- [len][enc(s_alice)|enc(payload_alice)]  (Noise msg 3) -->|  RTT 3.0
+  |                                                              |
+  |  ===== Encrypted from here on =====                          |
+  |                                                              |
+  |  ===== multistream-select: Muxer Protocol =====              |
+  |  (pipelined: both messages in one encrypted frame)           |
+  |                                                              |
+  |-- ENC(varint|"/multistream/1.0.0\n"                         |
+  |       + varint|"/yamux/1.0.0\n") ------------------------->|  RTT 3.0
+  |<-- ENC(varint|"/multistream/1.0.0\n"                        |
+  |       + varint|"/yamux/1.0.0\n") --------------------------|  RTT 3.5
+  |                                                              |
+  |  ===== Yamux Session Active =====                            |
+  |                                                              |
+  |  ===== Stream 1: Identify =====                              |
+  |                                                              |
+  |-- Yamux[SYN,ID=1] + mss(/ipfs/id/1.0.0) ----------------->|  RTT 3.5
+  |<-- Yamux[ACK,ID=1] + mss(/ipfs/id/1.0.0)                   |
+  |    + Yamux[Data,ID=1](Identify protobuf)                    |
+  |    + Yamux[FIN,ID=1] --------------------------------------|  RTT 4.0
+  |-- Yamux[FIN,ID=1] ---------------------------------------->|  RTT 4.5
+  |                                                              |
+  |  ===== Stream 3: Application Protocol =====                 |
+  |                                                              |
+  |-- Yamux[SYN,ID=3] + mss(/my-app/1.0.0) ------------------>|  RTT 4.5
+  |<-- Yamux[ACK,ID=3] + mss echo + first app data ------------|  RTT 5.0
+  |                                                              |
+  |  ===== Application data flowing =====                        |
+```
+
+**Total RTT to first application data: ~5 RTT** (with aggressive pipelining).
+Without pipelining, this can be 7-8 RTT.
+
+Note that Noise message 1 can be pipelined with the multistream-select
+messages for security negotiation, reducing the effective cost. Smart
+implementations combine messages into as few TCP segments as possible.
+
+## Early Muxer Negotiation Optimization
+
+The standard flow requires a full multistream-select round trip for muxer
+negotiation after the Noise handshake completes. The **inlined muxer
+negotiation** optimization eliminates this by embedding muxer preferences in
+the Noise handshake payloads.
+
+### How It Works
+
+The `NoiseExtensions` protobuf has a `stream_muxers` field:
+
+```protobuf
+message NoiseExtensions {
+    repeated bytes webtransport_certhashes = 1;
+    repeated string stream_muxers = 2;
+}
+```
+
+During the Noise XX handshake:
+
+1. **Message 2** (Responder -> Initiator): The responder includes its
+   supported muxers in `extensions.stream_muxers`, ordered by preference.
+2. **Message 3** (Initiator -> Responder): The initiator includes its
+   supported muxers (or a single chosen muxer from the responder's list),
+   ordered by preference.
+
+The selected muxer is the first entry in the initiator's list that both peers
+support.
+
+```
+Noise XX with inlined muxer negotiation:
+
+  -> e
+  <- e, ee, s, es, [ "/mplex/6.7.0", "/yamux/1.0.0" ]
+  -> s, se, [ "/yamux/1.0.0" ]
+
+  Result: /yamux/1.0.0
+```
+
+### Sequence Diagram with Optimization
+
+```
+Alice (Initiator)                                    Bob (Responder)
+  |                                                      |
+  |  (TCP handshake + security mss omitted)              |
+  |                                                      |
+  |-- Noise Msg 1: [e] ------------------------------>|
+  |                                                      |
+  |<-- Noise Msg 2: [e, ee, s, es] -------------------|
+  |   payload.extensions.stream_muxers =                 |
+  |     ["/yamux/1.0.0", "/mplex/6.7.0"]                |
+  |                                                      |
+  |-- Noise Msg 3: [s, se] --------------------------->|
+  |   payload.extensions.stream_muxers =                 |
+  |     ["/yamux/1.0.0"]                                 |
+  |                                                      |
+  |  Secure channel + Yamux ready immediately            |
+  |  (no separate muxer negotiation needed)              |
+  |                                                      |
+  |-- Yamux[SYN,ID=1] + mss(/ipfs/id/1.0.0) -------->|
+  |  ...                                                 |
+```
+
+**Savings: 1 RTT** (the entire multistream-select muxer negotiation step is
+eliminated).
+
+### Backward Compatibility
+
+If the remote peer does not include `stream_muxers` in its Noise extensions,
+the initiator falls back to the standard multistream-select muxer negotiation.
+This makes the optimization fully backward compatible.
+
+### Privacy Note
+
+Unlike TLS ALPN (which exposes the muxer list in the unencrypted ClientHello),
+Noise extensions are sent inside encrypted Noise handshake messages (Messages 2
+and 3). An on-path observer cannot see which muxers are being negotiated.
+
+## QUIC Connection Example
+
+QUIC dramatically simplifies connection establishment. TLS 1.3 provides
+security, and QUIC itself provides native stream multiplexing. There is no need
+for multistream-select at the connection level.
+
+### Connection Flow
+
+```
+Alice (Initiator)                                    Bob (Responder)
+  |                                                      |
+  |  ===== QUIC Handshake (over UDP) =====               |
+  |                                                      |
+  |-- QUIC Initial ---------------------------------->|
+  |   (TLS ClientHello with ALPN: "libp2p")              |
+  |   (crypto + connection parameters)                   |
+  |                                                      |
+  |<-- QUIC Handshake --------------------------------|
+  |   (TLS ServerHello + EncryptedExtensions)            |
+  |   (server certificate with libp2p identity key)      |
+  |   (TLS Finished)                                     |
+  |                                                      |
+  |-- QUIC Handshake Complete ----------------------->|
+  |   (TLS Finished + client certificate)                |
+  |                                                      |
+  |  Connection established: 1 RTT                       |
+  |  Security: TLS 1.3 (verified identity keys)          |
+  |  Multiplexing: QUIC native streams                   |
+  |                                                      |
+  |  ===== Stream 0: Identify =====                      |
+  |                                                      |
+  |-- QUIC stream + mss(/ipfs/id/1.0.0) ------------->|
+  |<-- mss echo + Identify protobuf + FIN ------------|
+  |                                                      |
+  |  ===== Stream 4: Application =====                   |
+  |                                                      |
+  |-- QUIC stream + mss(/my-app/1.0.0) -------------->|
+  |<-- mss echo + app data ---------------------------|
+```
+
+### Key Differences from TCP
+
+| Aspect | TCP + Noise + Yamux | QUIC |
+|--------|-------------------|------|
+| Transport protocol | TCP (reliable stream) | UDP (QUIC packets) |
+| Security setup | multistream-select + Noise XX | TLS 1.3 built into QUIC |
+| Muxer setup | multistream-select + Yamux | Native QUIC streams |
+| Connection-level negotiation | 2 x multistream-select | None (ALPN only) |
+| Stream-level negotiation | multistream-select per stream | multistream-select per stream |
+| RTT to first app data | ~5 RTT | ~2.5 RTT |
+| Head-of-line blocking | Yes (TCP-level) | No (per-stream) |
+
+### ALPN
+
+QUIC uses the TLS ALPN extension with the protocol ID `libp2p` to identify
+itself as a libp2p connection. This is set during the TLS ClientHello. No
+further connection-level protocol negotiation is needed.
+
+### Peer Authentication in QUIC
+
+Each peer generates a self-signed X.509 certificate that contains:
+
+1. A standard TLS key pair (e.g., ECDSA P-256)
+2. A custom X.509 extension (OID `1.3.6.1.4.1.53594.1.1`) containing:
+   - The libp2p public key
+   - A signature binding the TLS key to the libp2p identity key
+
+After the TLS handshake, each peer extracts the libp2p identity from the
+remote certificate extension and derives the Peer ID.
+
+### Stream-Level Protocol Negotiation
+
+Even in QUIC, individual streams still use multistream-select for protocol
+negotiation. This is because QUIC provides the raw multiplexed streams, but
+does not know about libp2p application protocols.
+
+```
+QUIC Stream:
+  [multistream-select header exchange]
+  [protocol proposal and agreement]
+  [application data]
+```
+
+## Stream Lifecycle
+
+Streams within a Yamux session follow a well-defined lifecycle. Each stream
+passes through the following states:
+
+### Open: SYN
+
+A stream is opened by sending a frame (Data or Window Update) with the SYN
+flag set. The frame includes the new stream ID.
+
+```hex
+Yamux header (12 bytes):
+00       Version: 0
+00       Type: Data (0x00)
+00 01    Flags: SYN (0x0001)
+00 00 00 03  StreamID: 3
+00 00 00 00  Length: 0
+```
+
+The responder acknowledges with a frame carrying the ACK flag:
+
+```hex
+00       Version: 0
+01       Type: Window Update (0x01)
+00 02    Flags: ACK (0x0002)
+00 00 00 03  StreamID: 3
+00 04 00 00  Length: 262144 (initial window)
+```
+
+### Negotiate: multistream-select
+
+After the stream is open, both sides perform multistream-select to agree on
+the protocol for this stream:
+
+```
+Initiator                          Responder
+  |                                    |
+  |-- "/multistream/1.0.0\n" -------->|
+  |<-- "/multistream/1.0.0\n" --------|
+  |-- "/my-protocol/1.0.0\n" -------->|
+  |<-- "/my-protocol/1.0.0\n" --------|
+  |                                    |
+  |  Protocol agreed, data flows       |
+```
+
+### Data Exchange
+
+Application data is sent in Yamux Data frames:
+
+```hex
+00       Version: 0
+00       Type: Data (0x00)
+00 00    Flags: none
+00 00 00 03  StreamID: 3
+00 00 00 0c  Length: 12
+[12 bytes of application data]
+```
+
+Each Data frame can carry up to the available send window worth of bytes.
+The maximum Noise message is 65535 bytes (2-byte length prefix), so practical
+Yamux data frames are bounded by both the Yamux length field and the Noise
+encryption frame size.
+
+### Half-Close: FIN
+
+When one side is done sending, it sends a frame with the FIN flag:
+
+```hex
+00       Version: 0
+00       Type: Data (0x00)
+00 04    Flags: FIN (0x0004)
+00 00 00 03  StreamID: 3
+00 00 00 00  Length: 0
+```
+
+After sending FIN, the peer can still **receive** data on this stream. The
+stream is "half-closed" from the sender's perspective.
+
+### Full Close
+
+When both sides have sent FIN, the stream is fully closed:
+
+```
+Initiator                          Responder
+  |                                    |
+  |-- Data [FIN, StreamID=3] -------->|  Initiator done sending
+  |                                    |
+  |<-- Data [FIN, StreamID=3] --------|  Responder done sending
+  |                                    |
+  |  Stream fully closed               |
+```
+
+Both peers can now reclaim the stream's resources.
+
+### Reset: RST
+
+A stream can be abruptly terminated by sending a frame with the RST flag:
+
+```hex
+00       Version: 0
+00       Type: Data (0x00)
+00 08    Flags: RST (0x0008)
+00 00 00 03  StreamID: 3
+00 00 00 00  Length: 0
+```
+
+RST is used for abnormal termination: protocol errors, timeouts, or
+application-level cancellation. After RST, no more data may be sent or received
+on the stream.
+
+### Stream Lifecycle State Machine
+
+```
+           SYN sent/received
+                  |
+                  v
+            +-----------+
+            |   Open    |
+            +-----------+
+              /       \
+      FIN sent/     RST sent/
+      FIN rcvd      RST rcvd
+            /           \
+           v             v
+  +---------------+  +----------+
+  |  Half-Closed  |  |  Reset   |
+  +---------------+  +----------+
+         |
+    FIN from other side
+         |
+         v
+  +---------------+
+  |    Closed     |
+  +---------------+
+```
+
+## Identify Exchange After Connection
+
+The Identify protocol (`/ipfs/id/1.0.0`) is automatically run on every new
+connection. It serves three purposes:
+
+### 1. Exchange Peer Information
+
+Each peer learns the other's:
+- Public key and Peer ID (confirmation of the security handshake)
+- Listen addresses (multiaddrs where the peer can be reached)
+- Supported protocols (what the peer can handle)
+- Agent version (implementation name and version)
+
+### 2. Observed Address Discovery
+
+The `observedAddr` field tells the initiator what source address the responder
+sees. This is critical for NAT discovery:
+
+```
+Alice is behind NAT. Her local address is 192.168.1.100:12345.
+She dials Bob at 203.0.113.5:4001.
+
+Bob sees Alice's connection coming from 198.51.100.50:54321
+(the NAT's external address and mapped port).
+
+Bob sends observedAddr = /ip4/198.51.100.50/tcp/54321 in Identify.
+```
+
+Alice now knows her external address as seen by Bob. She can:
+- Advertise this address to other peers
+- Use it for hole-punching coordination
+- Confirm whether she is behind a NAT
+
+Multiple Identify exchanges with different peers help build confidence in the
+observed address. If multiple peers report the same external address, it is
+likely correct.
+
+### 3. Protocol Discovery
+
+The `protocols` field lists all protocols the remote peer supports. This
+allows the local peer to know in advance which protocols will succeed on
+this connection, without trial and error.
+
+### Identify Push
+
+When a peer's information changes (e.g., new listen address, new protocol
+support), it can proactively notify connected peers using `identify/push`
+(`/ipfs/id/push/1.0.0`). The pushing peer opens a stream, sends an Identify
+message with the updated fields, and closes the stream.
+
+## Simultaneous Open
+
+When both peers dial each other at the same time (common during NAT hole
+punching), both sides believe they are the initiator. This creates a conflict
+in multistream-select, which assumes a clear initiator/responder distinction.
+
+### The Problem
+
+```
+Alice dials Bob         Bob dials Alice
+     |                        |
+     v                        v
+  Both send "/multistream/1.0.0\n" as initiator
+  Both send "/noise\n" as initiator
+  --> Deadlock: no one is acting as responder
+```
+
+### Historical Approach: multistream-select Simultaneous Open Extension (Deprecated)
+
+The original solution used a `/libp2p/simultaneous-connect` protocol extension
+in multistream-select, where both peers would exchange random 64-bit integers
+to break the tie. The peer with the higher integer became the initiator.
+
+This extension is **deprecated** as of September 2023 (see libp2p/specs #573).
+
+### Current Approach: Coordination via DCUtR
+
+Modern libp2p implementations handle simultaneous open through the **Direct
+Connection Upgrade through Relay** (DCUtR) protocol. Instead of both peers
+blindly dialing each other, they coordinate via a relay connection:
+
+1. Both peers are connected to a relay
+2. One peer (A) sends a `CONNECT` message through the relay to peer B
+3. Peer B responds with a `CONNECT` message containing its observed addresses
+4. Both peers simultaneously attempt direct connections with **coordinated
+   roles**: the peer that initiated the DCUtR exchange acts as the dialer
+   (initiator), and the other acts as the listener (responder)
+
+This avoids the need for tie-breaking in multistream-select entirely.
+
+### Peer ID-Based Tie Breaking
+
+In cases where simultaneous connections do occur (e.g., both peers happen to
+dial each other independently), implementations typically compare Peer IDs.
+The peer with the lexicographically smaller Peer ID keeps its outbound
+connection (acts as initiator), and the other peer's connection is closed or
+repurposed as the responder side.
+
+## Connection Establishment Timing
+
+### RTT Count Comparison
+
+```
+                        TCP + Noise + Yamux          QUIC
+                        ─────────────────────        ─────────
+TCP/UDP handshake:       1.5 RTT (SYN/SYN-ACK/ACK)  0 RTT (UDP, no handshake)
+Security negotiation:    1.0 RTT (mss for /noise)    0 RTT (built into QUIC)
+Security handshake:      1.5 RTT (Noise XX: 3 msgs)  1.0 RTT (TLS 1.3: 2 msgs)
+Muxer negotiation:       1.0 RTT (mss for /yamux)    0 RTT (native)
+                        ─────────────────────        ─────────
+Subtotal (connection):   5.0 RTT                      1.0 RTT
+                        ─────────────────────        ─────────
+First stream open +
+ protocol negotiation:   1.0 RTT                      1.0 RTT
+                        ─────────────────────        ─────────
+Total to first app data: 6.0 RTT                      2.0 RTT
+```
+
+**With optimizations:**
+
+| Optimization | Savings |
+|-------------|---------|
+| Pipelining mss + Noise msg 1 | -0.5 RTT |
+| Pipelining mss muxer + Noise msg 3 | -0.5 RTT |
+| Inlined muxer negotiation (Noise extensions) | -1.0 RTT |
+| **TCP optimized total** | **~4.0 RTT** |
+
+QUIC achieves **~2.0 RTT** to first application data with no special
+optimizations needed, since the protocol was designed with minimal round trips
+in mind.
+
+### Latency Examples
+
+| Network | RTT | TCP+Noise+Yamux (naive) | TCP (optimized) | QUIC |
+|---------|-----|------------------------|-----------------|------|
+| Same datacenter | 0.5 ms | 3.0 ms | 2.0 ms | 1.0 ms |
+| Same region | 10 ms | 60 ms | 40 ms | 20 ms |
+| Cross-continent | 100 ms | 600 ms | 400 ms | 200 ms |
+| Satellite | 300 ms | 1800 ms | 1200 ms | 600 ms |
+
+These numbers demonstrate why QUIC is strongly preferred for latency-sensitive
+applications.
+
+## Haskell Implementation Notes
+
+### Connection Upgrade as a Composed Function
+
+The connection upgrade pipeline maps naturally to function composition in
+Haskell. Each stage transforms the connection:
+
+```haskell
+-- Type aliases for clarity
+type RawConn     = Connection     -- raw TCP socket
+type SecureConn  = Connection     -- encrypted via Noise
+type MuxedConn   = YamuxSession   -- multiplexed via Yamux
+
+-- The upgrade pipeline
+upgradeConnection
+    :: PeerId             -- expected remote peer (optional)
+    -> RawConn            -- raw TCP connection
+    -> IO MuxedConn       -- fully upgraded connection
+upgradeConnection expectedPeer raw = do
+    -- Step 1: Negotiate and establish security
+    secureConn <- negotiateSecurity raw >>= performHandshake expectedPeer
+    -- Step 2: Negotiate and establish muxer
+    negotiateMuxer secureConn >>= initYamux
+```
+
+### Type Signature for the Upgrader
+
+A more general type signature that captures the modularity:
+
+```haskell
+data Upgrader = Upgrader
+    { securityProtocols :: [(ProtocolId, SecurityUpgrade)]
+    , muxerProtocols    :: [(ProtocolId, MuxerUpgrade)]
+    }
+
+type SecurityUpgrade = RawConn -> IO SecureConn
+type MuxerUpgrade    = SecureConn -> IO MuxedConn
+
+-- Security upgrade includes negotiation + handshake
+type SecurityUpgrade = Connection -> IO (Connection, PeerId)
+
+-- Muxer upgrade includes negotiation + initialization
+type MuxerUpgrade = Connection -> IO YamuxSession
+
+-- The full pipeline
+upgrade :: Upgrader -> Connection -> IO (YamuxSession, PeerId)
+upgrade cfg conn = do
+    -- multistream-select for security
+    (secProtoId, secUpgrade) <- negotiate (securityProtocols cfg) conn
+    (secConn, remotePeer)    <- secUpgrade conn
+
+    -- multistream-select for muxer (or use inlined negotiation)
+    (muxProtoId, muxUpgrade) <- negotiate (muxerProtocols cfg) secConn
+    session                  <- muxUpgrade secConn
+
+    pure (session, remotePeer)
+```
+
+### multistream-select Implementation
+
+```haskell
+-- Encode a multistream-select message
+encodeMsg :: ByteString -> ByteString
+encodeMsg proto =
+    let withNewline = proto <> "\n"
+        len = BS.length withNewline
+    in encodeVarint (fromIntegral len) <> withNewline
+
+-- The negotiation protocol
+negotiate
+    :: [(ProtocolId, a)]    -- supported protocols with handlers
+    -> Connection           -- connection to negotiate over
+    -> IO (ProtocolId, a)   -- selected protocol and its handler
+negotiate supported conn = do
+    -- Send and receive "/multistream/1.0.0\n"
+    send conn (encodeMsg "/multistream/1.0.0")
+    header <- recv conn
+    when (header /= "/multistream/1.0.0") $
+        throwIO NegotiationFailed
+
+    -- Propose protocols in order of preference
+    tryProtocols supported
+  where
+    tryProtocols [] = throwIO NoProtocolMatch
+    tryProtocols ((proto, handler) : rest) = do
+        send conn (encodeMsg proto)
+        response <- recv conn
+        if response == proto
+            then pure (proto, handler)
+            else tryProtocols rest  -- got "na", try next
+```
+
+### Stream Opener
+
+```haskell
+-- Open a new stream with protocol negotiation
+openStream
+    :: YamuxSession
+    -> ProtocolId
+    -> IO Stream
+openStream session proto = do
+    stream <- yamuxOpen session  -- sends SYN, gets ACK
+    negotiate [(proto, ())] (streamToConn stream)
+    pure stream
+```
+
+## Spec References
+
+- Connection establishment: https://github.com/libp2p/specs/blob/master/connections/README.md
+- Inlined muxer negotiation: https://github.com/libp2p/specs/blob/master/connections/inlined-muxer-negotiation.md
+- Simultaneous open (deprecated): https://github.com/libp2p/specs/blob/master/connections/simopen.md
+- Identify protocol: https://github.com/libp2p/specs/blob/master/identify/README.md
+- Noise spec: https://github.com/libp2p/specs/tree/master/noise
+- Yamux spec: https://github.com/hashicorp/yamux/blob/master/spec.md
+- QUIC transport: https://github.com/libp2p/specs/tree/master/quic
+- multistream-select: https://github.com/multiformats/multistream-select
+- DCUtR (Direct Connection Upgrade through Relay): https://github.com/libp2p/specs/blob/master/relay/DCUtR.md

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,119 @@
+# libp2p Implementation Textbook
+
+## Project: libp2p-hs — A Haskell Implementation of libp2p
+
+This textbook provides implementation-level documentation for the libp2p networking
+stack. It is designed as the authoritative reference for building a Haskell
+implementation of libp2p from scratch, covering wire formats, protobuf definitions,
+handshake sequences, byte-level structures, and architectural decisions.
+
+Every chapter includes enough detail to write conformant code without needing to
+reverse-engineer existing implementations.
+
+---
+
+## Reading Order
+
+### Foundation (Read First)
+1. **[Chapter 1: Overview](01-overview.md)** — Architecture, design principles, layer stack
+2. **[Chapter 2: Peer Identity](02-peer-identity.md)** — Key types, Peer ID derivation, protobuf encoding
+3. **[Chapter 3: Addressing](03-addressing.md)** — Multiaddr format, protocol codes, encoding
+
+### Core Protocols (Read Second)
+4. **[Chapter 7: Protocol Negotiation](07-protocols.md)** — multistream-select, Identify, Ping
+5. **[Chapter 5: Secure Channels](05-secure-channels.md)** — Noise XX handshake, TLS 1.3
+6. **[Chapter 6: Stream Multiplexing](06-multiplexing.md)** — Yamux frames, mplex wire format
+
+### Transport & Connection Layer
+7. **[Chapter 4: Transports](04-transports.md)** — TCP, QUIC, WebSocket, WebRTC
+8. **[Chapter 8: Switch / Swarm](08-switch.md)** — Connection upgrading, lifecycle, resource management
+9. **[Chapter 12: Connection Flow](12-connection-flow.md)** — End-to-end walkthrough with diagrams
+
+### Higher-Level Protocols
+10. **[Chapter 9: Distributed Hash Table](09-dht.md)** — Kademlia, routing, RPCs
+11. **[Chapter 10: NAT Traversal](10-nat-traversal.md)** — AutoNAT, Circuit Relay v2, Hole Punching
+12. **[Chapter 11: Publish/Subscribe](11-pubsub.md)** — GossipSub, message propagation
+
+---
+
+## Recommended Haskell Implementation Order
+
+After reading this textbook, implement in this order:
+
+| Step | Component | Key Chapter |
+|------|-----------|-------------|
+| 1 | Multiaddr parsing/encoding | Ch 3 |
+| 2 | Peer ID generation (Ed25519 first) | Ch 2 |
+| 3 | multistream-select negotiation | Ch 7 |
+| 4 | Noise XX handshake | Ch 5 |
+| 5 | Yamux multiplexer | Ch 6 |
+| 6 | TCP transport + Switch | Ch 4, 8 |
+| 7 | Identify protocol | Ch 7 |
+| 8 | Ping protocol | Ch 7 |
+| 9 | Kademlia DHT | Ch 9 |
+| 10 | Circuit Relay + NAT traversal | Ch 10 |
+| 11 | GossipSub | Ch 11 |
+
+---
+
+## Specification References
+
+| Spec | URL |
+|------|-----|
+| libp2p specs (all) | https://github.com/libp2p/specs |
+| Peer IDs | https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md |
+| Addressing | https://github.com/multiformats/multiaddr |
+| Connections | https://github.com/libp2p/specs/blob/master/connections/README.md |
+| Noise | https://github.com/libp2p/specs/tree/master/noise |
+| Yamux | https://github.com/hashicorp/yamux/blob/master/spec.md |
+| mplex | https://github.com/libp2p/specs/tree/master/mplex |
+| Identify | https://github.com/libp2p/specs/blob/master/identify/README.md |
+| Kademlia DHT | https://github.com/libp2p/specs/blob/master/kad-dht/README.md |
+| Circuit Relay v2 | https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md |
+| DCUtR | https://github.com/libp2p/specs/blob/master/relay/DCUtR.md |
+| AutoNAT | https://github.com/libp2p/specs/blob/master/autonat/README.md |
+| GossipSub v1.1 | https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md |
+| Hole Punching | https://github.com/libp2p/specs/blob/master/relay/hole-punching.md |
+
+---
+
+## Reference Implementations
+
+| Language | Repository | Notes |
+|----------|------------|-------|
+| Go | https://github.com/libp2p/go-libp2p | Most mature, reference implementation |
+| Rust | https://github.com/libp2p/rust-libp2p | Strong type system, good reference for Haskell |
+| JavaScript | https://github.com/libp2p/js-libp2p | Browser-compatible |
+| Nim | https://github.com/vacp2p/nim-libp2p | Smaller, easier to read |
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| **Peer** | A participant in the libp2p network, identified by a Peer ID |
+| **Peer ID** | A cryptographic hash of a peer's public key, used as a unique identifier |
+| **Multiaddr** | A self-describing network address format supporting protocol composition |
+| **Multihash** | A self-describing hash format: `<hash-function-code><digest-size><digest>` |
+| **Multicodec** | A self-describing codec identifier used in multiaddr, CID, etc. |
+| **CID** | Content Identifier — a self-describing content-addressed identifier |
+| **Transport** | The underlying network protocol (TCP, QUIC, WebSocket, etc.) |
+| **Secure Channel** | An encrypted communication layer (Noise, TLS 1.3) |
+| **Muxer** | Stream multiplexer allowing multiple logical streams over one connection |
+| **Stream** | A bidirectional byte channel within a multiplexed connection |
+| **Switch / Swarm** | The central component coordinating transports, security, and muxing |
+| **Protocol ID** | A string identifier for a libp2p protocol (e.g., `/noise`, `/yamux/1.0.0`) |
+| **multistream-select** | Protocol negotiation mechanism used before security and muxer upgrades |
+| **Varint** | Variable-length integer encoding (unsigned LEB128) |
+| **Protobuf** | Protocol Buffers — Google's binary serialization format, used extensively in libp2p |
+| **DHT** | Distributed Hash Table — decentralized key-value store |
+| **Kademlia** | The DHT algorithm used by libp2p, based on XOR distance metric |
+| **GossipSub** | libp2p's pub/sub protocol using gossip-based message propagation |
+| **NAT** | Network Address Translation — a barrier to direct peer-to-peer connectivity |
+| **Circuit Relay** | A protocol allowing peers to communicate through an intermediary relay node |
+| **Hole Punching** | Technique to establish direct connections through NATs |
+| **DCUtR** | Direct Connection Upgrade through Relay — coordinates hole punching |
+| **AutoNAT** | Protocol for detecting whether a peer is behind a NAT |
+| **Prologue** | Context data mixed into a Noise handshake for channel binding |
+| **Upgrader** | Component that transforms a raw connection into a secure, multiplexed one |


### PR DESCRIPTION
## Summary

Complete reference documentation (12 chapters, 7,270 lines) for implementing libp2p in Haskell. Every chapter provides implementation-depth detail: wire formats, protobuf definitions, handshake sequences, byte-level structures, hex dump examples, and Haskell implementation notes.

### Chapters
- **INDEX.md** — Table of contents, reading guide, glossary
- **01-overview.md** — Architecture, design principles, layer stack
- **02-peer-identity.md** — Key types, Peer ID derivation, protobuf encoding, test vectors
- **03-addressing.md** — Multiaddr binary format, protocol codes, encoding/decoding
- **04-transports.md** — TCP, QUIC, WebSocket, WebRTC, WebTransport
- **05-secure-channels.md** — Noise XX handshake (verbatim protobuf), TLS 1.3
- **06-multiplexing.md** — Yamux frame format (verified against spec), mplex wire format
- **07-protocols.md** — multistream-select (hex wire examples), Identify, Ping
- **08-switch.md** — Connection upgrading pipeline, lifecycle, resource management
- **09-dht.md** — Kademlia (verbatim protobuf), XOR distance, iterative lookup
- **10-nat-traversal.md** — AutoNAT v1/v2, Circuit Relay v2, DCUtR (all verbatim protobuf)
- **11-pubsub.md** — GossipSub v1.1 (scoring, mesh management, heartbeat)
- **12-connection-flow.md** — End-to-end TCP/QUIC walkthrough with byte-level detail

### Key features
- Protobuf definitions copied verbatim from upstream specs
- Hex wire dump examples for multistream-select, Yamux, Noise
- ASCII sequence diagrams for all handshakes and protocol flows
- Haskell implementation notes with type sketches in every chapter
- Cross-references to original libp2p spec documents

## Test plan
- [ ] Review all protobuf definitions match upstream specs
- [ ] Verify hex wire examples are correct
- [ ] Check all spec reference links resolve
- [ ] Review Haskell type sketches for consistency across chapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)