### PR TITLE
Fix Codec.hs: UTF-8, non-exhaustive patterns, IPv6

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -52,6 +52,7 @@ library
     crypton    >= 1.0   && < 1.1,
     memory     >= 0.18  && < 0.19,
     iproute    >= 1.7  && < 1.8,
+    network    >= 3.1  && < 3.3,
     stm        >= 2.4  && < 2.6
 
 test-suite libp2p-hs-test


### PR DESCRIPTION
## Summary

- **C1**: Replace naive `fromEnum`/`toEnum` UTF-8 encoding with `Data.Text.Encoding` — fixes multibyte Unicode characters in DNS names
- **C2**: Replace non-exhaustive `[a,b] = BS.unpack` patterns with safe `BS.index` positional access
- **H2**: Implement proper IPv6 text↔binary conversion using `iproute` (was hardcoded to `::1`)
- Add `network` dependency for `HostAddress6` type

## Test plan

- [x] 9 new tests added (3 UTF-8 multibyte, 6 IPv6 rendering/parsing)
- [x] All 111 tests pass (102 existing + 9 new)
- [x] Zero compiler warnings

Closes #41, closes #42, closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)