### PR TITLE
Replace error calls with Either in Crypto modules

### DIFF
--- a/src/Network/LibP2P/Crypto/Ed25519.hs
+++ b/src/Network/LibP2P/Crypto/Ed25519.hs
@@ -13,12 +13,11 @@ import qualified Data.ByteString as BS
 import Network.LibP2P.Crypto.Key
 
 -- | Generate a new random Ed25519 key pair.
-generateKeyPair :: IO KeyPair
+-- Returns Left on cryptographic failure (should not occur with proper RNG).
+generateKeyPair :: IO (Either String KeyPair)
 generateKeyPair = do
   seed <- getRandomBytes 32 :: IO ByteString
-  case keyPairFromSeed seed of
-    Right kp -> pure kp
-    Left err -> error $ "generateKeyPair: " <> err
+  pure (keyPairFromSeed seed)
 
 -- | Create an Ed25519 key pair from a 32-byte seed.
 keyPairFromSeed :: ByteString -> Either String KeyPair

--- a/src/Network/LibP2P/Crypto/Key.hs
+++ b/src/Network/LibP2P/Crypto/Key.hs
@@ -43,14 +43,15 @@ publicKey :: KeyPair -> PublicKey
 publicKey = kpPublic
 
 -- | Sign a message with a private key.
-sign :: PrivateKey -> ByteString -> ByteString
+-- Returns Left on invalid key bytes.
+sign :: PrivateKey -> ByteString -> Either String ByteString
 sign (PrivateKey Ed25519 skRaw) msg =
   case CE.eitherCryptoError (Ed.secretKey skRaw) of
-    Left err -> error $ "sign: invalid secret key: " <> show err
+    Left err -> Left $ "sign: invalid secret key: " <> show err
     Right sk ->
       let pk = Ed.toPublic sk
           sig = Ed.sign sk pk msg
-       in convert sig
+       in Right (convert sig)
 
 -- | Verify a signature against a public key and message.
 verify :: PublicKey -> ByteString -> ByteString -> Bool

--- a/src/Network/LibP2P/Security/Noise/Handshake.hs
+++ b/src/Network/LibP2P/Security/Noise/Handshake.hs
@@ -38,7 +38,7 @@ noiseStaticKeyPrefix = "noise-libp2p-static-key:"
 
 -- | Sign the Noise static public key with the identity private key.
 -- Produces: sign(identity_sk, "noise-libp2p-static-key:" || noise_static_pubkey)
-signStaticKey :: PrivateKey -> ByteString -> ByteString
+signStaticKey :: PrivateKey -> ByteString -> Either String ByteString
 signStaticKey sk noiseStaticPubKey =
   let payload = noiseStaticKeyPrefix <> noiseStaticPubKey
    in sign sk payload


### PR DESCRIPTION
## Summary

- `sign` now returns `Either String ByteString` instead of crashing on invalid keys
- `generateKeyPair` now returns `IO (Either String KeyPair)` instead of crashing
- `signStaticKey` propagates the `Either` from `sign`
- All call sites updated (Handshake.hs, PeerIdSpec.hs, HandshakeSpec.hs)
- New test: `sign` with invalid key returns `Left`

## Test plan

- [x] 103 tests pass (102 existing + 1 new invalid key test)
- [x] No `error` calls remain in Crypto modules

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)