### PR TITLE
Deduplicate Base58 into shared Core.Base58 module

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -30,6 +30,7 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Network.LibP2P
+    Network.LibP2P.Core.Base58
     Network.LibP2P.Core.Varint
     Network.LibP2P.Core.Multihash
     Network.LibP2P.Multiaddr.Multiaddr

--- a/src/Network/LibP2P/Core/Base58.hs
+++ b/src/Network/LibP2P/Core/Base58.hs
@@ -1,0 +1,56 @@
+-- | Base58btc (Bitcoin alphabet) encoding and decoding.
+--
+-- Used for Peer ID display in multiaddr text form and PeerId module.
+module Network.LibP2P.Core.Base58
+  ( base58Encode
+  , base58Decode
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Word (Word8)
+
+-- | Base58btc alphabet (Bitcoin variant).
+base58Alphabet :: String
+base58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+-- | Encode a ByteString to base58btc String.
+base58Encode :: [Word8] -> String
+base58Encode bytes =
+  let leadingZeros = length (takeWhile (== 0) bytes)
+      n = foldl (\acc b -> acc * 256 + toInteger b) 0 bytes
+      encoded = encodeN n
+   in replicate leadingZeros '1' <> encoded
+  where
+    encodeN :: Integer -> String
+    encodeN 0 = ""
+    encodeN m =
+      let (q, r) = m `divMod` 58
+       in encodeN q <> [base58Alphabet !! fromIntegral r]
+
+-- | Decode a base58btc String to ByteString.
+-- Returns Nothing on invalid characters.
+base58Decode :: String -> Maybe ByteString
+base58Decode str =
+  let leadingOnes = length (takeWhile (== '1') str)
+   in do
+        n <- decodeChars str
+        let bytes = decodeN n
+        Just $ BS.pack (replicate leadingOnes 0 <> bytes)
+  where
+    decodeChars :: String -> Maybe Integer
+    decodeChars = foldl step (Just 0)
+      where
+        step Nothing _ = Nothing
+        step (Just acc) c = case charIndex c of
+          Nothing -> Nothing
+          Just i -> Just (acc * 58 + toInteger i)
+
+    charIndex :: Char -> Maybe Int
+    charIndex c = lookup c (zip base58Alphabet [0 ..])
+
+    decodeN :: Integer -> [Word8]
+    decodeN 0 = []
+    decodeN m =
+      let (q, r) = m `divMod` 256
+       in decodeN q <> [fromIntegral r]

--- a/src/Network/LibP2P/Crypto/PeerId.hs
+++ b/src/Network/LibP2P/Crypto/PeerId.hs
@@ -15,7 +15,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Word (Word8)
+import Network.LibP2P.Core.Base58 (base58Decode, base58Encode)
 import Network.LibP2P.Core.Multihash (HashFunction (..), encodeMultihash)
 import Network.LibP2P.Crypto.Key (PublicKey)
 import Network.LibP2P.Crypto.Protobuf (encodePublicKey)
@@ -51,46 +51,3 @@ fromBase58 t = case base58Decode (T.unpack t) of
 -- | Get the raw multihash bytes of a Peer ID.
 peerIdBytes :: PeerId -> ByteString
 peerIdBytes (PeerId bs) = bs
-
--- Base58btc (Bitcoin alphabet) encoding/decoding
-
-base58Alphabet :: String
-base58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-
-base58Encode :: [Word8] -> String
-base58Encode bytes =
-  let leadingZeros = length (takeWhile (== 0) bytes)
-      n = foldl (\acc b -> acc * 256 + toInteger b) 0 bytes
-      encoded = encodeN n
-   in replicate leadingZeros '1' <> encoded
-  where
-    encodeN :: Integer -> String
-    encodeN 0 = ""
-    encodeN m =
-      let (q, r) = m `divMod` 58
-       in encodeN q <> [base58Alphabet !! fromIntegral r]
-
-base58Decode :: String -> Maybe ByteString
-base58Decode str =
-  let leadingOnes = length (takeWhile (== '1') str)
-   in do
-        n <- decodeChars str
-        let bytes = decodeN n
-        Just $ BS.pack (replicate leadingOnes 0 <> bytes)
-  where
-    decodeChars :: String -> Maybe Integer
-    decodeChars = foldl step (Just 0)
-      where
-        step Nothing _ = Nothing
-        step (Just acc) c = case charIndex c of
-          Nothing -> Nothing
-          Just i -> Just (acc * 58 + toInteger i)
-
-    charIndex :: Char -> Maybe Int
-    charIndex c = lookup c (zip base58Alphabet [0 ..])
-
-    decodeN :: Integer -> [Word8]
-    decodeN 0 = []
-    decodeN m =
-      let (q, r) = m `divMod` 256
-       in decodeN q <> [fromIntegral r]


### PR DESCRIPTION
## Summary

- Create `Network.LibP2P.Core.Base58` with shared `base58Encode`/`base58Decode`
- Remove duplicate implementations from `PeerId.hs` (~40 lines) and `Codec.hs` (~40 lines)
- Both modules now import from the shared module

## Test plan

- [x] All 102 tests pass (existing Base58 round-trip and PeerId tests)
- [x] No behavior change — purely structural refactor

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)