### PR TITLE
Project hygiene: GHC version, CLAUDE.md, unused imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ libp2p-hs is a Haskell implementation of the [libp2p](https://libp2p.io/) networ
 
 ## Current State
 
-**No Haskell code exists yet.** The repository contains only documentation. When implementation begins, the project will use Cabal (the `.gitignore` is already configured for Cabal/Stack/GHC artifacts).
+Phases 0–4a are implemented: scaffolding, varint, multihash, multiaddr, peer identity (Ed25519), multistream-select, Yamux frame encoding, and Noise framing/payload/key-signing. 102+ tests pass across all modules. The project uses a single Cabal library (not internal libraries, due to linker issues with shared `hs-source-dirs`).
 
 ## Documentation Reference
 
@@ -66,16 +66,20 @@ Application (GossipSub, DHT, Identify, Ping)
 
 The **Switch** (ch.08) is the central coordinator that manages this pipeline, connection pooling, and protocol handler dispatch.
 
-## Key Haskell Libraries (from textbook recommendations)
+## Key Haskell Libraries
 
-- **Crypto**: `crypton` (Ed25519, X25519, ChaCha20-Poly1305)
-- **Noise protocol**: `cacophony`
-- **Protobuf**: `proto-lens` or manual encoding (libp2p protobufs are small)
-- **Networking**: `network`
+- **Crypto**: `crypton` (Ed25519, X25519, ChaCha20-Poly1305) + `memory` (ByteArray conversion)
+- **Noise protocol**: `crypton` directly (not `cacophony` — incompatible with GHC 9.14.1 due to `lens`→`these`→`base-4.22` chain)
+- **Protobuf**: Manual encoding (libp2p protobufs are small, avoids `proto-lens` dependency)
+- **Networking**: `network`, `iproute` (IPv4/IPv6 address handling)
 - **Concurrency**: `stm`, `async`
 - **Binary parsing**: `binary`, `bytestring`
-- **Base encoding**: `base58-bytestring`
-- **ASN.1**: `asn1-encoding` (for RSA/ECDSA key formats)
+- **Base encoding**: Self-contained Base58btc in `Core.Base58` (no external dependency)
+- **ASN.1**: `asn1-encoding` (for RSA/ECDSA key formats, not yet used)
+
+### Architecture note
+
+Single library pattern in `.cabal` — internal libraries caused linker issues with shared `hs-source-dirs` on GHC 9.14.1.
 
 ## Upstream Specs
 

--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -13,7 +13,7 @@ maintainer:      adust09
 category:        Network
 build-type:      Simple
 extra-doc-files: README.md
-tested-with:     GHC == 9.14.1
+tested-with:     GHC == 9.10.1 || == 9.14.1
 
 common warnings
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates

--- a/src/Network/LibP2P/Core/Varint.hs
+++ b/src/Network/LibP2P/Core/Varint.hs
@@ -12,7 +12,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
-import Data.Word (Word64, Word8)
+import Data.Word (Word64)
 
 -- | Maximum number of bytes for a valid unsigned varint (ceil(64/7) = 10).
 maxVarintBytes :: Int
@@ -37,8 +37,8 @@ decodeUvarint bs
   | otherwise = go bs 0 0
   where
     go :: ByteString -> Int -> Word64 -> Either String (Word64, ByteString)
-    go input shift acc
-      | shift >= maxVarintBytes * 7 =
+    go input bitShift acc
+      | bitShift >= maxVarintBytes * 7 =
           Left "decodeUvarint: varint too long (exceeds 10 bytes)"
       | BS.null input =
           Left "decodeUvarint: unexpected end of input"
@@ -46,7 +46,7 @@ decodeUvarint bs
           let byte = BS.head input
               rest = BS.tail input
               val = fromIntegral (byte .&. 0x7f) :: Word64
-              acc' = acc .|. (val `shiftL` shift)
+              acc' = acc .|. (val `shiftL` bitShift)
            in if byte .&. 0x80 == 0
                 then Right (acc', rest)
-                else go rest (shift + 7) acc'
+                else go rest (bitShift + 7) acc'

--- a/src/Network/LibP2P/MultistreamSelect/Wire.hs
+++ b/src/Network/LibP2P/MultistreamSelect/Wire.hs
@@ -12,7 +12,6 @@ module Network.LibP2P.MultistreamSelect.Wire
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Text (Text)
-import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Network.LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 


### PR DESCRIPTION
## Summary

- **M1**: Fix `tested-with` to list both GHC 9.10.1 (CI) and 9.14.1 (local)
- **M2**: Update CLAUDE.md to reflect implementation reality (Phases 0-4a complete, crypton over cacophony, single library pattern)
- **M3**: Remove unused `Word8` import and fix `shift` parameter shadowing in Varint.hs; remove unused `Data.Text as T` import in Wire.hs

## Test plan

- [x] All 102 tests pass
- [x] No new compiler warnings introduced

Closes #47, closes #48, closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)