### PR TITLE
Standardize on GHC 9.10.x for cacophony compatibility

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,9 @@
 packages: .
 
+-- Requires GHC 9.10.x (base < 4.22) for cacophony compatibility.
+-- CI: haskell-actions/setup installs ghc-9.10.1 and puts 'ghc' on PATH.
+-- Local: set 'with-compiler' in cabal.project.local if needed.
+
 -- Enable all warnings
 package libp2p-hs
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints

--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -13,7 +13,7 @@ maintainer:      adust09
 category:        Network
 build-type:      Simple
 extra-doc-files: README.md
-tested-with:     GHC == 9.10.1 || == 9.14.1
+tested-with:     GHC == 9.10.1
 
 common warnings
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates


### PR DESCRIPTION
## Summary
- Pin `tested-with` to `GHC == 9.10.1` only (drop 9.14.1)
- Document GHC 9.10.x requirement in `cabal.project` (cacophony needs `base < 4.22`)
- Verified: `cacophony-0.11.0` and `ppad-base58-0.2.3` both resolve on GHC 9.10.x

## Context
GHC 9.14.1 ships `base-4.22` which breaks `these` (dep of `lens`, dep of `cacophony`):
```
these-1.2.1 => base >= 4.12.0.0 && < 4.22
```
GHC 9.10.x ships `base-4.20` which satisfies this constraint.

## Test plan
- [x] `cabal clean && cabal build all` on GHC 9.10.3 — all 16 modules build
- [x] `cabal test all` — 112 tests pass
- [x] `cabal build --dry-run` with `cacophony-0.11.0` resolves
- [x] `cabal build --dry-run` with `ppad-base58-0.2.3` resolves
- [ ] CI green (GHC 9.10.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)