### PR TITLE
Replace custom helpers with base/existing library functions

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -31,6 +31,7 @@ library
   exposed-modules:
     Network.LibP2P
     Network.LibP2P.Core.Base58
+    Network.LibP2P.Core.Binary
     Network.LibP2P.Core.Varint
     Network.LibP2P.Core.Multihash
     Network.LibP2P.Multiaddr.Multiaddr

--- a/src/Network/LibP2P/Core/Binary.hs
+++ b/src/Network/LibP2P/Core/Binary.hs
@@ -1,0 +1,32 @@
+-- | Big-endian binary encoding/decoding helpers.
+--
+-- Shared utilities for network byte order (BE) encoding used by
+-- Multiaddr, Noise framing, and other wire-format modules.
+module Network.LibP2P.Core.Binary
+  ( word16BE
+  , word32BE
+  , readWord16BE
+  , readWord32BE
+  ) where
+
+import Data.Binary.Get (getWord16be, getWord32be, runGet)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Builder as Builder
+import qualified Data.ByteString.Lazy as LBS
+import Data.Word (Word16, Word32)
+
+-- | Encode a Word16 as 2-byte big-endian ByteString.
+word16BE :: Word16 -> ByteString
+word16BE = LBS.toStrict . Builder.toLazyByteString . Builder.word16BE
+
+-- | Encode a Word32 as 4-byte big-endian ByteString.
+word32BE :: Word32 -> ByteString
+word32BE = LBS.toStrict . Builder.toLazyByteString . Builder.word32BE
+
+-- | Read a big-endian Word16 from a ByteString (must be >= 2 bytes).
+readWord16BE :: ByteString -> Word16
+readWord16BE = runGet getWord16be . LBS.fromStrict
+
+-- | Read a big-endian Word32 from a ByteString (must be >= 4 bytes).
+readWord32BE :: ByteString -> Word32
+readWord32BE = runGet getWord32be . LBS.fromStrict

--- a/src/Network/LibP2P/Core/Multihash.hs
+++ b/src/Network/LibP2P/Core/Multihash.hs
@@ -13,6 +13,7 @@ import Data.ByteArray (convert)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Word (Word64)
+import Numeric (showHex)
 import Network.LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 
 -- | Supported hash functions for multihash encoding.
@@ -30,16 +31,7 @@ hashCode SHA256 = 0x12
 fromHashCode :: Word64 -> Either String HashFunction
 fromHashCode 0x00 = Right Identity
 fromHashCode 0x12 = Right SHA256
-fromHashCode c = Left $ "decodeMultihash: unknown hash function code 0x" <> showHex c
-  where
-    showHex :: Word64 -> String
-    showHex n
-      | n < 16 = "0" <> [hexDigit n]
-      | otherwise = map hexDigit [n `div` 16, n `mod` 16]
-    hexDigit :: Word64 -> Char
-    hexDigit d
-      | d < 10 = toEnum (fromIntegral d + fromEnum '0')
-      | otherwise = toEnum (fromIntegral d - 10 + fromEnum 'a')
+fromHashCode c = Left $ "decodeMultihash: unknown hash function code 0x" <> showHex c ""
 
 -- | Encode data as a multihash.
 -- For Identity: stores raw bytes. For SHA256: hashes first, stores digest.

--- a/src/Network/LibP2P/Crypto/Protobuf.hs
+++ b/src/Network/LibP2P/Crypto/Protobuf.hs
@@ -12,6 +12,7 @@ module Network.LibP2P.Crypto.Protobuf
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Word (Word64, Word8)
+import Numeric (showHex)
 import Network.LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 import Network.LibP2P.Crypto.Key (KeyType (..), PublicKey (..))
 
@@ -59,13 +60,5 @@ decodePublicKey bs = do
     takeExpectedByte expected input msg
       | BS.null input = Left $ "decodePublicKey: " <> msg <> " (empty input)"
       | BS.head input /= expected =
-          Left $ "decodePublicKey: " <> msg <> " (got 0x" <> showHex (BS.head input) <> ")"
+          Left $ "decodePublicKey: " <> msg <> " (got 0x" <> showHex (BS.head input) ")"
       | otherwise = Right (expected, BS.tail input)
-
-    showHex :: Word8 -> String
-    showHex n = [hexDigit (n `div` 16), hexDigit (n `mod` 16)]
-
-    hexDigit :: Word8 -> Char
-    hexDigit d
-      | d < 10 = toEnum (fromIntegral d + fromEnum '0')
-      | otherwise = toEnum (fromIntegral d - 10 + fromEnum 'a')

--- a/src/Network/LibP2P/Multiaddr/Codec.hs
+++ b/src/Network/LibP2P/Multiaddr/Codec.hs
@@ -6,7 +6,7 @@ module Network.LibP2P.Multiaddr.Codec
   , textToProtocols
   ) where
 
-import Data.Bits (shiftL, shiftR, (.&.), (.|.))
+import Data.Bits (shiftL, shiftR, (.&.))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.IP (IPv6, fromHostAddress6, toHostAddress6)
@@ -14,7 +14,9 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Word (Word16, Word32, Word64)
+import Text.Read (readMaybe)
 import Network.LibP2P.Core.Base58 (base58Decode, base58Encode)
+import Network.LibP2P.Core.Binary (readWord16BE, readWord32BE, word16BE, word32BE)
 import Network.LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 import Network.LibP2P.Multiaddr.Protocol
 
@@ -241,39 +243,6 @@ textToProtocols input
     parseBase58PeerId t = case base58Decode (T.unpack t) of
       Just bs -> Right bs
       Nothing -> Left $ "textToProtocols: invalid base58 peer ID: " <> T.unpack t
-
--- Helpers
-
-word16BE :: Word16 -> ByteString
-word16BE w = BS.pack [fromIntegral (w `shiftR` 8), fromIntegral w]
-
-word32BE :: Word32 -> ByteString
-word32BE w =
-  BS.pack
-    [ fromIntegral (w `shiftR` 24)
-    , fromIntegral (w `shiftR` 16)
-    , fromIntegral (w `shiftR` 8)
-    , fromIntegral w
-    ]
-
--- | Read big-endian Word16 using safe positional access.
-readWord16BE :: ByteString -> Word16
-readWord16BE bs =
-  (fromIntegral (BS.index bs 0) `shiftL` 8)
-    .|. fromIntegral (BS.index bs 1)
-
--- | Read big-endian Word32 using safe positional access.
-readWord32BE :: ByteString -> Word32
-readWord32BE bs =
-  (fromIntegral (BS.index bs 0) `shiftL` 24)
-    .|. (fromIntegral (BS.index bs 1) `shiftL` 16)
-    .|. (fromIntegral (BS.index bs 2) `shiftL` 8)
-    .|. fromIntegral (BS.index bs 3)
-
-readMaybe :: (Read a) => String -> Maybe a
-readMaybe s = case reads s of
-  [(x, "")] -> Just x
-  _ -> Nothing
 
 -- | Safely decode UTF-8 bytes to Text, returning Nothing on invalid input.
 decodeUtf8Safe :: ByteString -> Maybe Text

--- a/src/Network/LibP2P/Security/Noise/Framing.hs
+++ b/src/Network/LibP2P/Security/Noise/Framing.hs
@@ -8,10 +8,9 @@ module Network.LibP2P.Security.Noise.Framing
   , maxNoiseMessageSize
   ) where
 
-import Data.Bits (shiftL, shiftR, (.&.))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import Data.Word (Word16)
+import Network.LibP2P.Core.Binary (readWord16BE, word16BE)
 
 -- | Maximum Noise message size (limited by 2-byte length prefix).
 maxNoiseMessageSize :: Int
@@ -33,10 +32,3 @@ decodeFrame bs
        in if BS.length rest < len
             then Left $ "decodeFrame: expected " <> show len <> " bytes but got " <> show (BS.length rest)
             else Right (BS.take len rest, BS.drop len rest)
-
--- Helpers
-word16BE :: Word16 -> ByteString
-word16BE w = BS.pack [fromIntegral (w `shiftR` 8), fromIntegral (w .&. 0xff)]
-
-readWord16BE :: ByteString -> Word16
-readWord16BE bs = fromIntegral (BS.index bs 0) `shiftL` 8 + fromIntegral (BS.index bs 1)


### PR DESCRIPTION
## Summary
- Replace custom `readMaybe` with `Text.Read.readMaybe` from `base`
- Replace hand-rolled `showHex`/`hexDigit` with `Numeric.showHex` from `base`
- Create shared `Core.Binary` module for big-endian helpers (`word16BE`, `word32BE`, `readWord16BE`, `readWord32BE`) using `bytestring` Builder and `binary` Get — deduplicating code from `Multiaddr/Codec.hs` and `Security/Noise/Framing.hs`

## Follows CLAUDE.md
> 独自実装はなるべくしない。既存の実装やライブラリを優先する

## Files changed
| File | Change |
|------|--------|
| `Core/Binary.hs` | **New** — shared BE encoding/decoding |
| `Core/Multihash.hs` | `showHex` → `Numeric.showHex` |
| `Crypto/Protobuf.hs` | `showHex`/`hexDigit` → `Numeric.showHex` |
| `Multiaddr/Codec.hs` | Remove `readMaybe`, `word{16,32}BE`, `readWord{16,32}BE`; import from `base` and `Core.Binary` |
| `Security/Noise/Framing.hs` | Remove local BE helpers; import from `Core.Binary` |

## Test plan
- [x] `cabal build all` — 17 modules compile
- [x] `cabal test all` — 112 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)