### PR TITLE
Implement Identify protocol (Phase 6a)

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -55,6 +55,8 @@ library
     Network.LibP2P.Switch.Listen
     Network.LibP2P.Switch.Upgrade
     Network.LibP2P.Switch.ResourceManager
+    Network.LibP2P.Protocol.Identify.Message
+    Network.LibP2P.Protocol.Identify.Identify
     Network.LibP2P.Security.Noise.Framing
     Network.LibP2P.Security.Noise.Handshake
     Network.LibP2P.Security.Noise.Session
@@ -72,7 +74,8 @@ library
     time        >= 1.9  && < 2,
     stm         >= 2.4  && < 2.6,
     async       >= 2.2  && < 2.3,
-    containers  >= 0.6  && < 0.8
+    containers  >= 0.6  && < 0.8,
+    proto3-wire >= 1.4  && < 1.5
 
 test-suite libp2p-hs-test
   import:          warnings, lang
@@ -95,6 +98,8 @@ test-suite libp2p-hs-test
     Test.Network.LibP2P.Switch.ListenSpec
     Test.Network.LibP2P.Switch.UpgradeSpec
     Test.Network.LibP2P.Switch.ResourceManagerSpec
+    Test.Network.LibP2P.Protocol.Identify.MessageSpec
+    Test.Network.LibP2P.Protocol.Identify.IdentifySpec
     Test.Network.LibP2P.Security.Noise.HandshakeSpec
   build-depends:
     base       >= 4.18 && < 5,

--- a/src/Network/LibP2P/Protocol/Identify/Identify.hs
+++ b/src/Network/LibP2P/Protocol/Identify/Identify.hs
@@ -1,0 +1,146 @@
+-- | Identify protocol implementation (docs/07-protocols.md).
+--
+-- Protocol ID: /ipfs/id/1.0.0
+--
+-- After a connection is established, both sides exchange IdentifyInfo
+-- messages to learn about each other's capabilities, listen addresses,
+-- and agent version. The message has no length prefix — the boundary
+-- is determined by stream closure.
+--
+-- Also implements Identify Push (/ipfs/id/push/1.0.0) for proactive
+-- updates when local state changes.
+module Network.LibP2P.Protocol.Identify.Identify
+  ( -- * Protocol IDs
+    identifyProtocolId
+  , identifyPushProtocolId
+    -- * Protocol logic
+  , handleIdentify
+  , requestIdentify
+  , handleIdentifyPush
+    -- * Building local info
+  , buildLocalIdentify
+    -- * Registration
+  , registerIdentifyHandlers
+    -- * Helpers
+  , readUntilEOF
+  ) where
+
+import Control.Concurrent.STM (atomically, readTVar, writeTVar)
+import Control.Exception (SomeException, catch)
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import Network.LibP2P.Crypto.PeerId (PeerId)
+import Network.LibP2P.Crypto.Protobuf (encodePublicKey)
+import Network.LibP2P.Crypto.Key (kpPublic)
+import Network.LibP2P.MultistreamSelect.Negotiation
+  ( ProtocolId
+  , StreamIO (..)
+  , negotiateInitiator
+  , NegotiationResult (..)
+  )
+import Network.LibP2P.Protocol.Identify.Message
+  ( IdentifyInfo (..)
+  , decodeIdentify
+  , encodeIdentify
+  , maxIdentifySize
+  )
+import Network.LibP2P.Switch.Types
+  ( Connection (..)
+  , MuxerSession (..)
+  , Switch (..)
+  , StreamHandler
+  )
+
+-- | Identify protocol ID.
+identifyProtocolId :: ProtocolId
+identifyProtocolId = "/ipfs/id/1.0.0"
+
+-- | Identify Push protocol ID.
+identifyPushProtocolId :: ProtocolId
+identifyPushProtocolId = "/ipfs/id/push/1.0.0"
+
+-- | Handle an inbound Identify request (responder side).
+--
+-- Sends our local IdentifyInfo as protobuf to the stream, then closes.
+-- The remote side reads until EOF.
+handleIdentify :: Switch -> StreamIO -> PeerId -> IO ()
+handleIdentify sw stream _remotePeerId = do
+  info <- buildLocalIdentify sw Nothing
+  let encoded = encodeIdentify info
+  streamWrite stream encoded
+  -- Stream closure (by muxer) signals end of message
+
+-- | Request Identify from a remote peer (initiator side).
+--
+-- Opens a new stream, negotiates /ipfs/id/1.0.0, reads until EOF,
+-- then decodes the protobuf message.
+requestIdentify :: Connection -> IO (Either String IdentifyInfo)
+requestIdentify conn = do
+  stream <- muxOpenStream (connSession conn)
+  result <- negotiateInitiator stream [identifyProtocolId]
+  case result of
+    Accepted _ -> do
+      bytesOrErr <- readUntilEOF stream maxIdentifySize
+      case bytesOrErr of
+        Left err -> pure (Left err)
+        Right bs -> case decodeIdentify bs of
+          Left parseErr -> pure (Left (show parseErr))
+          Right info -> pure (Right info)
+    NoProtocol -> pure (Left "remote does not support identify")
+
+-- | Handle an inbound Identify Push (responder side).
+--
+-- Reads the pushed IdentifyInfo from the remote peer.
+handleIdentifyPush :: Switch -> StreamIO -> PeerId -> IO ()
+handleIdentifyPush sw stream remotePeerId = do
+  bytesOrErr <- readUntilEOF stream maxIdentifySize
+  case bytesOrErr of
+    Left _ -> pure ()
+    Right bs -> case decodeIdentify bs of
+      Left _ -> pure ()
+      Right info -> atomically $ do
+        store <- readTVar (swPeerStore sw)
+        writeTVar (swPeerStore sw) (Map.insert remotePeerId info store)
+
+-- | Build our local IdentifyInfo from Switch state.
+buildLocalIdentify :: Switch -> Maybe Connection -> IO IdentifyInfo
+buildLocalIdentify sw _mConn = do
+  protocols <- atomically $ Map.keys <$> readTVar (swProtocols sw)
+  pure IdentifyInfo
+    { idProtocolVersion = Just "ipfs/0.1.0"
+    , idAgentVersion    = Just "libp2p-hs/0.1.0"
+    , idPublicKey       = Just (encodePublicKey (kpPublic (swIdentityKey sw)))
+    , idListenAddrs     = []  -- TODO: populate from transport listeners
+    , idObservedAddr    = Nothing  -- TODO: populate from connection remote addr
+    , idProtocols       = protocols
+    }
+
+-- | Register Identify protocol handlers on the Switch.
+--
+-- Registers:
+--   /ipfs/id/1.0.0      — respond to Identify requests
+--   /ipfs/id/push/1.0.0 — handle Identify Push from remote
+registerIdentifyHandlers :: Switch -> IO ()
+registerIdentifyHandlers sw = do
+  atomically $ do
+    protos <- readTVar (swProtocols sw)
+    let protos' = Map.insert identifyProtocolId (handleIdentify sw) protos
+        protos'' = Map.insert identifyPushProtocolId (handleIdentifyPush sw) protos'
+    writeTVar (swProtocols sw) protos''
+
+-- | Read bytes from a StreamIO until EOF, up to a maximum size.
+--
+-- Identify uses stream closure as message boundary (no length prefix).
+-- Accumulates bytes until streamReadByte throws (EOF/stream closed).
+readUntilEOF :: StreamIO -> Int -> IO (Either String BS.ByteString)
+readUntilEOF stream maxSize = go []  0
+  where
+    go acc size
+      | size >= maxSize = pure (Left "message exceeds maximum size")
+      | otherwise = do
+          result <- (Right <$> streamReadByte stream) `catch`
+                    (\(_ :: SomeException) -> pure (Left ()))
+          case result of
+            Left () -> pure (Right (BS.pack (reverse acc)))
+            Right b -> go (b : acc) (size + 1)

--- a/src/Network/LibP2P/Protocol/Identify/Message.hs
+++ b/src/Network/LibP2P/Protocol/Identify/Message.hs
@@ -1,0 +1,79 @@
+-- | Identify protocol message encoding/decoding (protobuf).
+--
+-- Wire format from docs/07-protocols.md and specs/identify/README.md:
+--   Field 1: publicKey       (bytes, optional)
+--   Field 2: listenAddrs     (repeated bytes)
+--   Field 3: protocols       (repeated string)
+--   Field 4: observedAddr    (bytes, optional)
+--   Field 5: protocolVersion (string, optional)
+--   Field 6: agentVersion    (string, optional)
+--
+-- Uses proto3-wire for protobuf encoding/decoding. No length prefix;
+-- the message boundary is determined by stream closure.
+module Network.LibP2P.Protocol.Identify.Message
+  ( IdentifyInfo (..)
+  , encodeIdentify
+  , decodeIdentify
+  , maxIdentifySize
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as BL
+import Data.Text (Text)
+import qualified Data.Text.Lazy as TL
+import Proto3.Wire.Decode (Parser, RawMessage, ParseError, at, optional, repeated, parse)
+import qualified Proto3.Wire.Decode as Decode
+import Proto3.Wire.Encode (MessageBuilder)
+import qualified Proto3.Wire.Encode as Encode
+import Proto3.Wire.Types (FieldNumber (..))
+
+-- | Identify message payload.
+data IdentifyInfo = IdentifyInfo
+  { idProtocolVersion :: !(Maybe Text)       -- ^ e.g. "ipfs/0.1.0"
+  , idAgentVersion    :: !(Maybe Text)       -- ^ e.g. "libp2p-hs/0.1.0"
+  , idPublicKey       :: !(Maybe ByteString) -- ^ Serialized PublicKey protobuf
+  , idListenAddrs     :: ![ByteString]       -- ^ Binary-encoded multiaddrs
+  , idObservedAddr    :: !(Maybe ByteString) -- ^ Binary-encoded observed multiaddr
+  , idProtocols       :: ![Text]             -- ^ Supported protocol IDs
+  } deriving (Show, Eq)
+
+-- | Maximum Identify message size: 64 KiB.
+maxIdentifySize :: Int
+maxIdentifySize = 64 * 1024
+
+-- | Encode an Identify message to protobuf wire format.
+encodeIdentify :: IdentifyInfo -> ByteString
+encodeIdentify info = BL.toStrict $ Encode.toLazyByteString $
+     optBytes 1 (idPublicKey info)
+  <> repBytes 2 (idListenAddrs info)
+  <> repText 3 (idProtocols info)
+  <> optBytes 4 (idObservedAddr info)
+  <> optText 5 (idProtocolVersion info)
+  <> optText 6 (idAgentVersion info)
+  where
+    optBytes :: Word -> Maybe ByteString -> MessageBuilder
+    optBytes _ Nothing  = mempty
+    optBytes n (Just v) = Encode.byteString (FieldNumber (fromIntegral n)) v
+
+    optText :: Word -> Maybe Text -> MessageBuilder
+    optText _ Nothing  = mempty
+    optText n (Just v) = Encode.text (FieldNumber (fromIntegral n)) (TL.fromStrict v)
+
+    repBytes :: Word -> [ByteString] -> MessageBuilder
+    repBytes n = foldMap (Encode.byteString (FieldNumber (fromIntegral n)))
+
+    repText :: Word -> [Text] -> MessageBuilder
+    repText n = foldMap (Encode.text (FieldNumber (fromIntegral n)) . TL.fromStrict)
+
+-- | Decode an Identify message from protobuf wire format.
+decodeIdentify :: ByteString -> Either ParseError IdentifyInfo
+decodeIdentify = parse identifyParser
+
+identifyParser :: Parser RawMessage IdentifyInfo
+identifyParser = IdentifyInfo
+  <$> at (optional (TL.toStrict <$> Decode.text)) (FieldNumber 5)  -- protocolVersion
+  <*> at (optional (TL.toStrict <$> Decode.text)) (FieldNumber 6)  -- agentVersion
+  <*> at (optional Decode.byteString)              (FieldNumber 1)  -- publicKey
+  <*> at (repeated Decode.byteString)              (FieldNumber 2)  -- listenAddrs
+  <*> at (optional Decode.byteString)              (FieldNumber 4)  -- observedAddr
+  <*> at (repeated (TL.toStrict <$> Decode.text))  (FieldNumber 3)  -- protocols

--- a/src/Network/LibP2P/Switch/Switch.hs
+++ b/src/Network/LibP2P/Switch/Switch.hs
@@ -39,6 +39,8 @@ newSwitch pid kp = do
     { dlSystemLimits = defaultSystemLimits
     , dlPeerLimits   = defaultPeerLimits
     }
+  peerStoreVar <- newTVarIO Map.empty
+  notifiersVar <- newTVarIO []
   pure Switch
     { swLocalPeerId  = pid
     , swIdentityKey  = kp
@@ -50,6 +52,8 @@ newSwitch pid kp = do
     , swDialBackoffs = backoffsVar
     , swPendingDials = pendingDialsVar
     , swResourceMgr  = resMgr
+    , swPeerStore    = peerStoreVar
+    , swNotifiers    = notifiersVar
     }
 
 -- | Register a transport with the switch.

--- a/src/Network/LibP2P/Switch/Types.hs
+++ b/src/Network/LibP2P/Switch/Types.hs
@@ -23,6 +23,7 @@ import Network.LibP2P.Crypto.Key (KeyPair)
 import Network.LibP2P.Crypto.PeerId (PeerId)
 import Network.LibP2P.Multiaddr.Multiaddr (Multiaddr)
 import Network.LibP2P.MultistreamSelect.Negotiation (ProtocolId, StreamIO)
+import Network.LibP2P.Protocol.Identify.Message (IdentifyInfo)
 import Network.LibP2P.Switch.ResourceManager (Direction (..), ResourceError (..), ResourceManager)
 import Network.LibP2P.Transport.Transport (Transport)
 
@@ -104,4 +105,6 @@ data Switch = Switch
   , swDialBackoffs :: !(TVar (Map PeerId BackoffEntry))                  -- ^ Per-peer dial backoff state
   , swPendingDials :: !(TVar (Map PeerId (TMVar (Either DialError Connection)))) -- ^ In-flight dials for dedup
   , swResourceMgr  :: !ResourceManager                                   -- ^ Hierarchical resource manager
+  , swPeerStore    :: !(TVar (Map PeerId IdentifyInfo))                  -- ^ Identify info per peer
+  , swNotifiers    :: !(TVar [Connection -> IO ()])                      -- ^ Callbacks on new connection
   }

--- a/test/Test/Network/LibP2P/Protocol/Identify/IdentifySpec.hs
+++ b/test/Test/Network/LibP2P/Protocol/Identify/IdentifySpec.hs
@@ -1,0 +1,138 @@
+module Test.Network.LibP2P.Protocol.Identify.IdentifySpec (spec) where
+
+import Control.Concurrent.Async (async, wait)
+import Control.Concurrent.STM
+  ( TQueue
+  , TMVar
+  , atomically
+  , newEmptyTMVarIO
+  , newTQueueIO
+  , putTMVar
+  , readTQueue
+  , readTVar
+  , tryReadTMVar
+  , writeTQueue
+  )
+import Control.Exception (throwIO)
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Network.LibP2P.Crypto.Ed25519 (generateKeyPair)
+import Network.LibP2P.Crypto.Key (kpPublic)
+import Network.LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
+import Network.LibP2P.Crypto.Protobuf (encodePublicKey)
+import Network.LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import Network.LibP2P.Protocol.Identify.Identify
+import Network.LibP2P.Protocol.Identify.Message (IdentifyInfo (..), decodeIdentify, encodeIdentify)
+import Network.LibP2P.Switch.Switch (newSwitch, setStreamHandler)
+import Network.LibP2P.Switch.Types (Switch (..))
+import Data.Word (Word8)
+import System.IO.Error (mkIOError, eofErrorType)
+import Test.Hspec
+
+-- | Create a test Switch with a key pair.
+mkTestSwitch :: IO Switch
+mkTestSwitch = do
+  Right kp <- generateKeyPair
+  let pid = fromPublicKey (kpPublic kp)
+  sw <- newSwitch pid kp
+  setStreamHandler sw "/test/1.0.0" (\_ _ -> pure ())
+  setStreamHandler sw "/test/2.0.0" (\_ _ -> pure ())
+  pure sw
+
+-- | Create a stream pair where the writer can signal EOF.
+-- After close is called, reads on the other side throw an IOError.
+mkClosableStreamPair :: IO (StreamIO, IO (), StreamIO)
+mkClosableStreamPair = do
+  qAtoB <- newTQueueIO :: IO (TQueue (Maybe Word8))
+  qBtoA <- newTQueueIO :: IO (TQueue (Maybe Word8))
+  closedA <- newEmptyTMVarIO :: IO (TMVar ())
+  closedB <- newEmptyTMVarIO :: IO (TMVar ())
+  let writeQ q closed bs = do
+        c <- atomically $ tryReadTMVar closed
+        case c of
+          Just () -> throwIO (mkIOError eofErrorType "stream closed" Nothing Nothing)
+          Nothing -> mapM_ (\b -> atomically $ writeTQueue q (Just b)) (BS.unpack bs)
+      readQ q = do
+        mv <- atomically $ readTQueue q
+        case mv of
+          Just b  -> pure b
+          Nothing -> throwIO (mkIOError eofErrorType "EOF" Nothing Nothing)
+      closeWriter q closed = atomically $ do
+        putTMVar closed ()
+        writeTQueue q Nothing  -- sentinel for EOF
+      streamA = StreamIO (writeQ qAtoB closedA) (readQ qBtoA)
+      streamB = StreamIO (writeQ qBtoA closedB) (readQ qAtoB)
+  pure (streamA, closeWriter qAtoB closedA, streamB)
+
+spec :: Spec
+spec = do
+  describe "Identify protocol" $ do
+    it "buildLocalIdentify includes version strings" $ do
+      sw <- mkTestSwitch
+      info <- buildLocalIdentify sw Nothing
+      idProtocolVersion info `shouldBe` Just "ipfs/0.1.0"
+      idAgentVersion info `shouldBe` Just "libp2p-hs/0.1.0"
+
+    it "buildLocalIdentify includes registered protocols" $ do
+      sw <- mkTestSwitch
+      info <- buildLocalIdentify sw Nothing
+      let protos = idProtocols info
+      protos `shouldSatisfy` (\ps -> "/test/1.0.0" `elem` ps)
+      protos `shouldSatisfy` (\ps -> "/test/2.0.0" `elem` ps)
+
+    it "buildLocalIdentify includes public key" $ do
+      sw <- mkTestSwitch
+      info <- buildLocalIdentify sw Nothing
+      let expectedPubKey = encodePublicKey (kpPublic (swIdentityKey sw))
+      idPublicKey info `shouldBe` Just expectedPubKey
+
+    it "handleIdentify sends decodable protobuf over stream" $ do
+      sw <- mkTestSwitch
+      (streamA, closeA, streamB) <- mkClosableStreamPair
+      -- handleIdentify writes protobuf to streamA, then we close it
+      writer <- async $ do
+        handleIdentify sw streamA (PeerId "remote")
+        closeA
+      -- Read all bytes from streamB until EOF
+      bytesOrErr <- readUntilEOF streamB 65536
+      wait writer
+      case bytesOrErr of
+        Left err -> expectationFailure $ "readUntilEOF failed: " ++ err
+        Right bs -> case decodeIdentify bs of
+          Left parseErr -> expectationFailure $ "Decode failed: " ++ show parseErr
+          Right info -> do
+            idProtocolVersion info `shouldBe` Just "ipfs/0.1.0"
+            idAgentVersion info `shouldBe` Just "libp2p-hs/0.1.0"
+
+    it "handleIdentifyPush stores info in peer store" $ do
+      sw <- mkTestSwitch
+      let remotePeerId = PeerId "push-peer"
+      (streamA, closeA, streamB) <- mkClosableStreamPair
+      let testInfo = IdentifyInfo
+            { idProtocolVersion = Just "test/1.0"
+            , idAgentVersion    = Just "test-agent/0.1"
+            , idPublicKey       = Nothing
+            , idListenAddrs     = []
+            , idObservedAddr    = Nothing
+            , idProtocols       = ["/test/proto"]
+            }
+      -- Write encoded message then signal EOF
+      let encoded = encodeIdentify testInfo
+      streamWrite streamA encoded
+      closeA
+      -- handleIdentifyPush reads from streamB
+      handleIdentifyPush sw streamB remotePeerId
+      -- Check peer store
+      store <- atomically $ readTVar (swPeerStore sw)
+      case Map.lookup remotePeerId store of
+        Nothing -> expectationFailure "Expected peer in store"
+        Just storedInfo -> do
+          idProtocolVersion storedInfo `shouldBe` Just "test/1.0"
+          idAgentVersion storedInfo `shouldBe` Just "test-agent/0.1"
+
+    it "registerIdentifyHandlers registers both protocol handlers" $ do
+      sw <- mkTestSwitch
+      registerIdentifyHandlers sw
+      protos <- atomically $ readTVar (swProtocols sw)
+      Map.member identifyProtocolId protos `shouldBe` True
+      Map.member identifyPushProtocolId protos `shouldBe` True

--- a/test/Test/Network/LibP2P/Protocol/Identify/MessageSpec.hs
+++ b/test/Test/Network/LibP2P/Protocol/Identify/MessageSpec.hs
@@ -1,0 +1,86 @@
+module Test.Network.LibP2P.Protocol.Identify.MessageSpec (spec) where
+
+import qualified Data.ByteString as BS
+import Network.LibP2P.Protocol.Identify.Message
+import Test.Hspec
+
+-- | A fully populated IdentifyInfo for testing.
+fullInfo :: IdentifyInfo
+fullInfo = IdentifyInfo
+  { idProtocolVersion = Just "ipfs/0.1.0"
+  , idAgentVersion    = Just "libp2p-hs/0.1.0"
+  , idPublicKey       = Just (BS.pack [0x08, 0x01, 0x12, 0x20, 1, 2, 3, 4])
+  , idListenAddrs     = [BS.pack [4, 127, 0, 0, 1, 6, 0x10, 0x01],
+                          BS.pack [4, 10, 0, 0, 1, 6, 0x0F, 0xA1]]
+  , idObservedAddr    = Just (BS.pack [4, 192, 168, 1, 1, 6, 0x1F, 0x90])
+  , idProtocols       = ["/ipfs/id/1.0.0", "/ipfs/ping/1.0.0", "/noise"]
+  }
+
+spec :: Spec
+spec = do
+  describe "Identify Message" $ do
+    it "encode produces non-empty protobuf bytes" $ do
+      let encoded = encodeIdentify fullInfo
+      BS.length encoded `shouldSatisfy` (> 0)
+
+    it "encode → decode round-trip preserves all fields" $ do
+      let encoded = encodeIdentify fullInfo
+          decoded = decodeIdentify encoded
+      decoded `shouldBe` Right fullInfo
+
+    it "decode empty message returns empty IdentifyInfo" $ do
+      let decoded = decodeIdentify BS.empty
+      decoded `shouldBe` Right IdentifyInfo
+        { idProtocolVersion = Nothing
+        , idAgentVersion    = Nothing
+        , idPublicKey       = Nothing
+        , idListenAddrs     = []
+        , idObservedAddr    = Nothing
+        , idProtocols       = []
+        }
+
+    it "decode handles repeated listenAddrs correctly" $ do
+      let info = IdentifyInfo Nothing Nothing Nothing
+                   [BS.pack [1, 2], BS.pack [3, 4], BS.pack [5, 6]]
+                   Nothing []
+          encoded = encodeIdentify info
+          decoded = decodeIdentify encoded
+      case decoded of
+        Right result -> idListenAddrs result `shouldBe` [BS.pack [1, 2], BS.pack [3, 4], BS.pack [5, 6]]
+        Left err -> expectationFailure $ "Decode failed: " ++ show err
+
+    it "decode handles repeated protocols correctly" $ do
+      let info = IdentifyInfo Nothing Nothing Nothing [] Nothing
+                   ["/noise", "/yamux/1.0.0", "/ipfs/id/1.0.0"]
+          encoded = encodeIdentify info
+          decoded = decodeIdentify encoded
+      case decoded of
+        Right result -> idProtocols result `shouldBe` ["/noise", "/yamux/1.0.0", "/ipfs/id/1.0.0"]
+        Left err -> expectationFailure $ "Decode failed: " ++ show err
+
+    it "decode rejects oversized message" $ do
+      -- Create a message larger than maxIdentifySize
+      let bigPubKey = BS.replicate (maxIdentifySize + 100) 0x42
+          info = IdentifyInfo Nothing Nothing (Just bigPubKey) [] Nothing []
+          encoded = encodeIdentify info
+      -- The encoded message should be parseable (proto3-wire doesn't enforce size)
+      -- Size check is done at read time by readUntilEOF, not at decode time
+      BS.length encoded `shouldSatisfy` (> maxIdentifySize)
+
+    it "decode skips unknown fields" $ do
+      -- Encode known fields, then append unknown field bytes
+      let info = IdentifyInfo (Just "ipfs/0.1.0") Nothing Nothing [] Nothing []
+          encoded = encodeIdentify info
+          -- Append unknown field 99 (wire type 0 = varint, tag = 99<<3|0 = 0x318)
+          -- This is a varint-encoded tag + value: field 99, varint 42
+          unknownField = BS.pack [0xF8, 0x06, 0x2A]  -- field 99, wire type 0, value 42
+          withUnknown = encoded <> unknownField
+      case decodeIdentify withUnknown of
+        Right result -> idProtocolVersion result `shouldBe` Just "ipfs/0.1.0"
+        Left err -> expectationFailure $ "Decode failed with unknown field: " ++ show err
+
+    it "encode omits Nothing fields" $ do
+      let info = IdentifyInfo Nothing Nothing Nothing [] Nothing []
+          encoded = encodeIdentify info
+      -- Empty message should encode to empty bytes (no fields set)
+      encoded `shouldBe` BS.empty


### PR DESCRIPTION
## Summary
- Add Identify (`/ipfs/id/1.0.0`) and Identify Push (`/ipfs/id/push/1.0.0`) protocol implementation
- Protobuf encoding/decoding via `proto3-wire` (fields 1-6: publicKey, listenAddrs, protocols, observedAddr, protocolVersion, agentVersion)
- Stream-closure-as-message-boundary pattern with `readUntilEOF` (no length prefix per spec)
- Add `swPeerStore` (TVar Map PeerId IdentifyInfo) and `swNotifiers` (TVar [Connection -> IO ()]) to Switch
- 14 new tests (248 total, 0 failures)

Closes #20

## Test plan
- [x] 8 Message tests: encode/decode round-trip, empty message, repeated fields, unknown fields, Nothing omission
- [x] 6 Identify tests: buildLocalIdentify (version, protocols, pubkey), handleIdentify protobuf output, handleIdentifyPush peer store update, registerIdentifyHandlers
- [x] All 248 tests pass (`cabal test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)