### PR TITLE
Implement k-bucket routing table + XOR distance (Phase 7a)

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -58,6 +58,9 @@ library
     Network.LibP2P.Protocol.Identify.Message
     Network.LibP2P.Protocol.Identify.Identify
     Network.LibP2P.Protocol.Ping.Ping
+    Network.LibP2P.DHT.Types
+    Network.LibP2P.DHT.Distance
+    Network.LibP2P.DHT.RoutingTable
     Network.LibP2P.Security.Noise.Framing
     Network.LibP2P.Security.Noise.Handshake
     Network.LibP2P.Security.Noise.Session
@@ -103,6 +106,8 @@ test-suite libp2p-hs-test
     Test.Network.LibP2P.Protocol.Identify.IdentifySpec
     Test.Network.LibP2P.Protocol.Ping.PingSpec
     Test.Network.LibP2P.Security.Noise.HandshakeSpec
+    Test.Network.LibP2P.DHT.DistanceSpec
+    Test.Network.LibP2P.DHT.RoutingTableSpec
   build-depends:
     base       >= 4.18 && < 5,
     bytestring >= 0.10 && < 0.13,

--- a/src/Network/LibP2P/DHT/Distance.hs
+++ b/src/Network/LibP2P/DHT/Distance.hs
@@ -1,0 +1,71 @@
+-- | XOR distance metric for the Kademlia DHT.
+--
+-- All distance computations operate on 256-bit SHA-256 keys.
+-- Distance is the XOR of two keys interpreted as a 256-bit unsigned integer.
+module Network.LibP2P.DHT.Distance
+  ( peerIdToKey
+  , xorDistance
+  , commonPrefixLength
+  , compareDistance
+  , sortByDistance
+  ) where
+
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.ByteArray (convert)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Bits (xor, testBit)
+import Data.List (sortBy)
+import Data.Word (Word8)
+import Network.LibP2P.Crypto.PeerId (PeerId, peerIdBytes)
+import Network.LibP2P.DHT.Types (BucketEntry (..), DHTKey (..))
+
+-- | Convert a Peer ID to its DHT key by hashing with SHA-256.
+peerIdToKey :: PeerId -> DHTKey
+peerIdToKey pid =
+  let digest = hash (peerIdBytes pid) :: Digest SHA256
+  in DHTKey (convert digest)
+
+-- | Compute XOR distance between two DHT keys.
+xorDistance :: DHTKey -> DHTKey -> DHTKey
+xorDistance (DHTKey a) (DHTKey b) =
+  DHTKey (BS.pack (BS.zipWith xor a b))
+
+-- | Count the number of leading zero bits (common prefix length).
+-- Same key → 256. First bit differs → 0.
+commonPrefixLength :: DHTKey -> DHTKey -> Int
+commonPrefixLength a b =
+  let (DHTKey d) = xorDistance a b
+  in countLeadingZeros d
+
+-- | Count leading zero bits in a ByteString (big-endian).
+countLeadingZeros :: ByteString -> Int
+countLeadingZeros bs = go 0
+  where
+    len = BS.length bs
+    go i
+      | i >= len  = i * 8
+      | byte == 0 = go (i + 1)
+      | otherwise = i * 8 + clzByte byte
+      where byte = BS.index bs i
+
+-- | Count leading zeros of a single byte (0-8).
+clzByte :: Word8 -> Int
+clzByte 0 = 8
+clzByte w = go 7
+  where
+    go (-1) = 8
+    go bit
+      | testBit w bit = 7 - bit
+      | otherwise     = go (bit - 1)
+
+-- | Compare two keys by distance to a target.
+-- Returns LT if a is closer to target than b, GT if farther, EQ if equal.
+compareDistance :: DHTKey -> DHTKey -> DHTKey -> Ordering
+compareDistance target a b =
+  compare (xorDistance target a) (xorDistance target b)
+
+-- | Sort bucket entries by ascending XOR distance to a target key.
+sortByDistance :: DHTKey -> [BucketEntry] -> [BucketEntry]
+sortByDistance target =
+  sortBy (\a b -> compareDistance target (entryKey a) (entryKey b))

--- a/src/Network/LibP2P/DHT/RoutingTable.hs
+++ b/src/Network/LibP2P/DHT/RoutingTable.hs
@@ -1,0 +1,150 @@
+-- | k-Bucket routing table for the Kademlia DHT.
+--
+-- Organizes peers into 256 buckets by XOR distance prefix length.
+-- Each bucket holds up to k=20 peers, ordered by last-seen time
+-- (head = least-recently-seen, tail = most-recently-seen).
+module Network.LibP2P.DHT.RoutingTable
+  ( KBucket (..)
+  , RoutingTable (..)
+  , newRoutingTable
+  , emptyBucket
+  , insertPeer
+  , removePeer
+  , closestPeers
+  , bucketForPeer
+  , bucketSize
+  , allPeers
+  ) where
+
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
+import Data.Sequence (Seq (..))
+import qualified Data.Sequence as Seq
+import Network.LibP2P.Crypto.PeerId (PeerId)
+import Network.LibP2P.DHT.Distance (commonPrefixLength, peerIdToKey, sortByDistance)
+import Network.LibP2P.DHT.Types
+  ( BucketEntry (..)
+  , DHTKey (..)
+  , InsertResult (..)
+  , kValue
+  , numBuckets
+  )
+
+-- | A k-bucket holding up to k peers.
+-- Ordered by last-seen: head = LRS (least recently seen), tail = MRS.
+data KBucket = KBucket
+  { bucketEntries :: !(Seq BucketEntry)
+  } deriving (Show)
+
+-- | Full routing table: 256 k-buckets indexed by prefix length.
+-- Uses sparse IntMap — only non-empty buckets are stored.
+data RoutingTable = RoutingTable
+  { rtSelfKey :: !DHTKey
+  , rtBuckets :: !(IntMap KBucket)
+  , rtK       :: !Int
+  } deriving (Show)
+
+-- | Create a new empty routing table for the given local peer.
+newRoutingTable :: PeerId -> RoutingTable
+newRoutingTable localPeer = RoutingTable
+  { rtSelfKey = peerIdToKey localPeer
+  , rtBuckets = IntMap.empty
+  , rtK       = kValue
+  }
+
+-- | An empty k-bucket.
+emptyBucket :: KBucket
+emptyBucket = KBucket Seq.empty
+
+-- | Insert a peer into the routing table.
+--
+-- Rules:
+-- 1. Self is never inserted (returns Updated as no-op).
+-- 2. If peer already exists in the bucket, move it to tail → Updated.
+-- 3. If bucket has space, append to tail → Inserted.
+-- 4. If bucket is full, return BucketFull with the LRS peer ID.
+insertPeer :: BucketEntry -> RoutingTable -> (RoutingTable, InsertResult)
+insertPeer entry rt
+  -- Reject self-insertion
+  | entryKey entry == rtSelfKey rt = (rt, Updated)
+  | otherwise =
+    let idx = bucketIndex (rtSelfKey rt) (entryKey entry)
+        bucket = IntMap.findWithDefault emptyBucket idx (rtBuckets rt)
+        entries = bucketEntries bucket
+    in case findEntryIndex (entryPeerId entry) entries of
+         -- Peer already in bucket: remove from current position, append to tail
+         Just i ->
+           let entries' = Seq.deleteAt i entries Seq.|> entry
+               rt' = rt { rtBuckets = IntMap.insert idx (KBucket entries') (rtBuckets rt) }
+           in (rt', Updated)
+         -- Peer not in bucket
+         Nothing
+           | Seq.length entries < rtK rt ->
+             -- Space available: append to tail
+             let entries' = entries Seq.|> entry
+                 rt' = rt { rtBuckets = IntMap.insert idx (KBucket entries') (rtBuckets rt) }
+             in (rt', Inserted)
+           | otherwise ->
+             -- Bucket full: return LRS peer for potential eviction
+             case entries of
+               lrs :<| _ -> (rt, BucketFull (entryPeerId lrs))
+               _         -> (rt, BucketFull (entryPeerId entry)) -- should not happen
+
+-- | Remove a peer from the routing table.
+removePeer :: PeerId -> RoutingTable -> RoutingTable
+removePeer pid rt =
+  let key = peerIdToKey pid
+      idx = bucketIndex (rtSelfKey rt) key
+      bucket = IntMap.findWithDefault emptyBucket idx (rtBuckets rt)
+      entries = bucketEntries bucket
+  in case findEntryIndex pid entries of
+       Nothing -> rt  -- not found, no-op
+       Just i ->
+         let entries' = Seq.deleteAt i entries
+             buckets' = if Seq.null entries'
+                        then IntMap.delete idx (rtBuckets rt)
+                        else IntMap.insert idx (KBucket entries') (rtBuckets rt)
+         in rt { rtBuckets = buckets' }
+
+-- | Find the n closest peers to a target key, sorted by XOR distance.
+-- Searches across all buckets.
+closestPeers :: DHTKey -> Int -> RoutingTable -> [BucketEntry]
+closestPeers target n rt =
+  let allEntries = concatMap (toList . bucketEntries) (IntMap.elems (rtBuckets rt))
+      sorted = sortByDistance target allEntries
+  in take n sorted
+  where
+    toList = foldr (:) []
+
+-- | Compute the bucket index for a peer key relative to the local key.
+-- This is the common prefix length (0-255).
+bucketForPeer :: DHTKey -> RoutingTable -> Int
+bucketForPeer key rt =
+  bucketIndex (rtSelfKey rt) key
+
+-- | Get the number of entries in a specific bucket.
+bucketSize :: Int -> RoutingTable -> Int
+bucketSize idx rt =
+  case IntMap.lookup idx (rtBuckets rt) of
+    Nothing -> 0
+    Just bucket -> Seq.length (bucketEntries bucket)
+
+-- | Get all peers across all buckets.
+allPeers :: RoutingTable -> [BucketEntry]
+allPeers rt =
+  concatMap (toList . bucketEntries) (IntMap.elems (rtBuckets rt))
+  where
+    toList = foldr (:) []
+
+-- Internal helpers
+
+-- | Compute bucket index: common prefix length, clamped to [0, numBuckets-1].
+bucketIndex :: DHTKey -> DHTKey -> Int
+bucketIndex selfKey peerKey =
+  let cpl = commonPrefixLength selfKey peerKey
+  in min cpl (numBuckets - 1)
+
+-- | Find the index of a peer in a sequence by PeerId.
+findEntryIndex :: PeerId -> Seq BucketEntry -> Maybe Int
+findEntryIndex pid entries =
+  Seq.findIndexL (\e -> entryPeerId e == pid) entries

--- a/src/Network/LibP2P/DHT/Types.hs
+++ b/src/Network/LibP2P/DHT/Types.hs
@@ -1,0 +1,58 @@
+-- | Core types for the Kademlia DHT.
+--
+-- Defines the DHT keyspace (256-bit SHA-256 keys), routing table entry
+-- structure, and protocol constants (k=20, alpha=10).
+module Network.LibP2P.DHT.Types
+  ( DHTKey (..)
+  , BucketEntry (..)
+  , ConnectionType (..)
+  , InsertResult (..)
+  , kValue
+  , alphaValue
+  , numBuckets
+  ) where
+
+import Data.ByteString (ByteString)
+import Data.Time (UTCTime)
+import Network.LibP2P.Crypto.PeerId (PeerId)
+import Network.LibP2P.Multiaddr.Multiaddr (Multiaddr)
+
+-- | 256-bit key in the DHT keyspace (always exactly 32 bytes, SHA-256 output).
+newtype DHTKey = DHTKey ByteString
+  deriving (Eq, Ord, Show)
+
+-- | Replication parameter: each k-bucket holds up to k peers.
+kValue :: Int
+kValue = 20
+
+-- | Concurrency parameter for iterative lookups.
+alphaValue :: Int
+alphaValue = 10
+
+-- | Number of buckets (one per bit of the 256-bit keyspace).
+numBuckets :: Int
+numBuckets = 256
+
+-- | Connection status of a peer (from DHT protobuf spec).
+data ConnectionType
+  = NotConnected  -- ^ 0: no connection, no extra info
+  | Connected     -- ^ 1: live connection
+  | CanConnect    -- ^ 2: recently connected
+  | CannotConnect -- ^ 3: recently failed to connect
+  deriving (Show, Eq, Enum, Bounded)
+
+-- | A single entry in a k-bucket.
+data BucketEntry = BucketEntry
+  { entryPeerId   :: !PeerId
+  , entryKey      :: !DHTKey        -- ^ Cached SHA-256 of peer ID
+  , entryAddrs    :: ![Multiaddr]
+  , entryLastSeen :: !UTCTime
+  , entryConnType :: !ConnectionType
+  } deriving (Show, Eq)
+
+-- | Result of attempting to insert a peer into the routing table.
+data InsertResult
+  = Inserted          -- ^ Peer was added to the bucket
+  | Updated           -- ^ Existing peer was moved to tail (most recently seen)
+  | BucketFull !PeerId -- ^ Bucket is full; returns LRS peer ID for pinging
+  deriving (Show, Eq)

--- a/test/Test/Network/LibP2P/DHT/DistanceSpec.hs
+++ b/test/Test/Network/LibP2P/DHT/DistanceSpec.hs
@@ -1,0 +1,115 @@
+module Test.Network.LibP2P.DHT.DistanceSpec (spec) where
+
+import Test.Hspec
+
+import qualified Data.ByteString as BS
+import Network.LibP2P.Crypto.PeerId (PeerId (..))
+import Network.LibP2P.DHT.Distance
+  ( peerIdToKey
+  , xorDistance
+  , commonPrefixLength
+  , compareDistance
+  , sortByDistance
+  )
+import Network.LibP2P.DHT.Types (BucketEntry (..), ConnectionType (..), DHTKey (..))
+import Data.Time (UTCTime, getCurrentTime)
+
+-- | Helper: create a PeerId from raw bytes (for test determinism).
+mkPeerId :: BS.ByteString -> PeerId
+mkPeerId = PeerId
+
+-- | Helper: create a BucketEntry for testing.
+mkEntry :: PeerId -> DHTKey -> UTCTime -> BucketEntry
+mkEntry pid key t = BucketEntry
+  { entryPeerId   = pid
+  , entryKey      = key
+  , entryAddrs    = []
+  , entryLastSeen = t
+  , entryConnType = NotConnected
+  }
+
+-- | Zero key (all zero bytes).
+zeroKey :: DHTKey
+zeroKey = DHTKey (BS.replicate 32 0)
+
+
+spec :: Spec
+spec = do
+  describe "peerIdToKey" $ do
+    it "produces 32-byte output" $ do
+      let pid = mkPeerId (BS.pack [1, 2, 3, 4])
+          (DHTKey keyBytes) = peerIdToKey pid
+      BS.length keyBytes `shouldBe` 32
+
+    it "is deterministic (same input → same output)" $ do
+      let pid = mkPeerId (BS.pack [10, 20, 30])
+          key1 = peerIdToKey pid
+          key2 = peerIdToKey pid
+      key1 `shouldBe` key2
+
+  describe "xorDistance" $ do
+    it "identity: d(x, x) = 0" $ do
+      let key = peerIdToKey (mkPeerId (BS.pack [42]))
+          dist = xorDistance key key
+      dist `shouldBe` zeroKey
+
+    it "symmetry: d(x, y) = d(y, x)" $ do
+      let keyA = peerIdToKey (mkPeerId (BS.pack [1]))
+          keyB = peerIdToKey (mkPeerId (BS.pack [2]))
+      xorDistance keyA keyB `shouldBe` xorDistance keyB keyA
+
+    it "produces 32-byte output" $ do
+      let keyA = peerIdToKey (mkPeerId (BS.pack [1]))
+          keyB = peerIdToKey (mkPeerId (BS.pack [2]))
+          (DHTKey distBytes) = xorDistance keyA keyB
+      BS.length distBytes `shouldBe` 32
+
+  describe "commonPrefixLength" $ do
+    it "same key → 256" $ do
+      let key = peerIdToKey (mkPeerId (BS.pack [99]))
+      commonPrefixLength key key `shouldBe` 256
+
+    it "different keys → correct bit position" $ do
+      -- Construct keys that differ at a known bit position
+      -- key1 = 0x00 0x00 ... (32 bytes of 0)
+      -- key2 = 0x00 0x01 ... (byte 1 has bit 0 set → differ at bit 15)
+      let key1 = DHTKey (BS.replicate 32 0)
+          key2 = DHTKey (BS.pack (0 : 1 : replicate 30 0))
+      -- XOR = 0x00 0x01 0x00... → 8 zero bits + 7 zero bits in byte 1 = 15
+      commonPrefixLength key1 key2 `shouldBe` 15
+
+    it "max-distance keys (first bit differs) → 0" $ do
+      -- key1 starts with 0x00, key2 starts with 0x80 → first bit differs
+      let key1 = DHTKey (BS.replicate 32 0)
+          key2 = DHTKey (BS.pack (0x80 : replicate 31 0))
+      commonPrefixLength key1 key2 `shouldBe` 0
+
+  describe "compareDistance" $ do
+    it "orders correctly (closer < farther)" $ do
+      -- Use constructed keys where we control distance to zeroKey
+      let closer = DHTKey (BS.pack (0 : 1 : replicate 30 0))  -- small XOR to zero
+          farther = DHTKey (BS.pack (0xFF : replicate 31 0))   -- large XOR to zero
+          target = zeroKey
+      -- d(0, closer) = 0x0001... < d(0, farther) = 0xFF00...
+      compareDistance target closer farther `shouldBe` LT
+      compareDistance target farther closer `shouldBe` GT
+      compareDistance target closer closer  `shouldBe` EQ
+
+  describe "sortByDistance" $ do
+    it "sorts ascending by XOR distance" $ do
+      now <- getCurrentTime
+      -- Use constructed keys with known distances to zeroKey
+      let target = zeroKey
+          -- Create entries with keys at known distances
+          nearKey  = DHTKey (BS.pack (0 : 0 : 1 : replicate 29 0))   -- distance 0x000001...
+          midKey   = DHTKey (BS.pack (0 : 1 : replicate 30 0))       -- distance 0x0001...
+          farKey   = DHTKey (BS.pack (1 : replicate 31 0))            -- distance 0x01...
+          nearPid  = mkPeerId (BS.pack [10])
+          midPid   = mkPeerId (BS.pack [20])
+          farPid   = mkPeerId (BS.pack [30])
+          entries = [ mkEntry farPid farKey now
+                    , mkEntry nearPid nearKey now
+                    , mkEntry midPid midKey now
+                    ]
+          sorted = sortByDistance target entries
+      map (entryPeerId) sorted `shouldBe` [nearPid, midPid, farPid]

--- a/test/Test/Network/LibP2P/DHT/RoutingTableSpec.hs
+++ b/test/Test/Network/LibP2P/DHT/RoutingTableSpec.hs
@@ -1,0 +1,264 @@
+module Test.Network.LibP2P.DHT.RoutingTableSpec (spec) where
+
+import Test.Hspec
+
+import Data.Bits (xor, testBit)
+import qualified Data.ByteString as BS
+import Data.List (sort)
+import Data.Time (UTCTime, getCurrentTime, addUTCTime)
+import Data.Word (Word8)
+import Network.LibP2P.Crypto.PeerId (PeerId (..))
+import Network.LibP2P.DHT.Distance (peerIdToKey)
+import Network.LibP2P.DHT.RoutingTable
+  ( newRoutingTable
+  , insertPeer
+  , removePeer
+  , closestPeers
+  , bucketForPeer
+  , bucketSize
+  , allPeers
+  )
+import Network.LibP2P.DHT.Types
+  ( BucketEntry (..)
+  , ConnectionType (..)
+  , DHTKey (..)
+  , InsertResult (..)
+  , kValue
+  )
+
+-- | Helper: create a PeerId from raw bytes.
+mkPeerId :: BS.ByteString -> PeerId
+mkPeerId = PeerId
+
+-- | Helper: create a BucketEntry.
+mkEntry :: PeerId -> UTCTime -> BucketEntry
+mkEntry pid t = BucketEntry
+  { entryPeerId   = pid
+  , entryKey      = peerIdToKey pid
+  , entryAddrs    = []
+  , entryLastSeen = t
+  , entryConnType = NotConnected
+  }
+
+-- | Generate a list of unique PeerIds for filling buckets.
+genPeerIds :: Int -> [PeerId]
+genPeerIds n = [mkPeerId (BS.pack [fromIntegral i]) | i <- [1..n]]
+
+-- | The local peer used for the routing table.
+localPeerId :: PeerId
+localPeerId = mkPeerId (BS.pack [0])
+
+spec :: Spec
+spec = do
+  describe "newRoutingTable" $ do
+    it "creates empty table with correct self key" $ do
+      let rt = newRoutingTable localPeerId
+      allPeers rt `shouldBe` []
+
+  describe "insertPeer" $ do
+    it "into empty bucket → Inserted" $ do
+      now <- getCurrentTime
+      let rt = newRoutingTable localPeerId
+          peer = mkEntry (mkPeerId (BS.pack [1])) now
+          (rt', result) = insertPeer peer rt
+      result `shouldBe` Inserted
+      length (allPeers rt') `shouldBe` 1
+
+    it "existing peer → Updated (moved to tail)" $ do
+      now <- getCurrentTime
+      let later = addUTCTime 10 now
+          rt = newRoutingTable localPeerId
+          peer1 = mkEntry (mkPeerId (BS.pack [1])) now
+          peer2 = mkEntry (mkPeerId (BS.pack [2])) now
+          (rt1, _) = insertPeer peer1 rt
+          (rt2, _) = insertPeer peer2 rt1
+          peer1Updated = mkEntry (mkPeerId (BS.pack [1])) later
+          (rt3, result) = insertPeer peer1Updated rt2
+      result `shouldBe` Updated
+      let peers = allPeers rt3
+      length peers `shouldBe` 2
+      entryPeerId (last peers) `shouldBe` mkPeerId (BS.pack [1])
+
+    it "self → rejected (not inserted)" $ do
+      now <- getCurrentTime
+      let rt = newRoutingTable localPeerId
+          selfEntry = mkEntry localPeerId now
+          (rt', result) = insertPeer selfEntry rt
+      result `shouldBe` Updated
+      allPeers rt' `shouldBe` []
+
+    it "fills bucket to k → all Inserted" $ do
+      now <- getCurrentTime
+      let rt0 = newRoutingTable localPeerId
+          allPids = genPeerIds 200
+          entries = map (\pid -> mkEntry pid now) allPids
+          selfKey = peerIdToKey localPeerId
+          bucketed = groupByBucket selfKey entries
+      case filter (\(_, es) -> length es >= kValue) bucketed of
+        [] -> pendingWith "Not enough peers in any single bucket (probabilistic test)"
+        ((bucketIdx, bucketEntries'):_) -> do
+          let toInsert = take kValue bucketEntries'
+              (rtFinal, results) = foldl
+                (\(rt, rs) e -> let (rt', r) = insertPeer e rt in (rt', rs ++ [r]))
+                (rt0, [])
+                toInsert
+          all (== Inserted) results `shouldBe` True
+          bucketSize bucketIdx rtFinal `shouldBe` kValue
+
+    it "into full bucket → BucketFull with LRS peer ID" $ do
+      now <- getCurrentTime
+      let rt0 = newRoutingTable localPeerId
+          selfKey = peerIdToKey localPeerId
+          allPids = genPeerIds 200
+          entries = map (\pid -> mkEntry pid now) allPids
+          bucketed = groupByBucket selfKey entries
+      case filter (\(_, es) -> length es > kValue) bucketed of
+        [] -> pendingWith "Not enough peers in any single bucket (probabilistic test)"
+        ((_, bucketEntries'):_) -> do
+          let toInsert = take (kValue + 1) bucketEntries'
+              firstK = take kValue toInsert
+              extra = toInsert !! kValue
+              (rtFull, _) = foldl
+                (\(rt, rs) e -> let (rt', r) = insertPeer e rt in (rt', rs ++ [r]))
+                (rt0, [])
+                firstK
+              (_, result) = insertPeer extra rtFull
+          case result of
+            BucketFull lrsPid ->
+              case firstK of
+                (firstEntry:_) -> lrsPid `shouldBe` entryPeerId firstEntry
+                [] -> expectationFailure "firstK should not be empty"
+            other -> expectationFailure $ "Expected BucketFull, got " ++ show other
+
+  describe "removePeer" $ do
+    it "existing → peer gone from table" $ do
+      now <- getCurrentTime
+      let rt = newRoutingTable localPeerId
+          pid = mkPeerId (BS.pack [1])
+          entry = mkEntry pid now
+          (rt1, _) = insertPeer entry rt
+          rt2 = removePeer pid rt1
+      allPeers rt2 `shouldBe` []
+
+    it "non-existent → no-op" $ do
+      now <- getCurrentTime
+      let rt = newRoutingTable localPeerId
+          pid = mkPeerId (BS.pack [1])
+          entry = mkEntry pid now
+          (rt1, _) = insertPeer entry rt
+          rt2 = removePeer (mkPeerId (BS.pack [99])) rt1
+      length (allPeers rt2) `shouldBe` 1
+
+  describe "closestPeers" $ do
+    it "returns up to n nearest peers sorted by distance" $ do
+      now <- getCurrentTime
+      let rt0 = newRoutingTable localPeerId
+          pids = genPeerIds 10
+          entries = map (\pid -> mkEntry pid now) pids
+          (rtFinal, _) = foldl
+            (\(rt, rs) e -> let (rt', r) = insertPeer e rt in (rt', rs ++ [r]))
+            (rt0, [])
+            entries
+          target = peerIdToKey (mkPeerId (BS.pack [42]))
+          closest = closestPeers target 5 rtFinal
+      length closest `shouldBe` 5
+      let dists = map (\e -> xorDist target (entryKey e)) closest
+      dists `shouldBe` sort dists
+
+    it "from empty table → empty list" $ do
+      let rt = newRoutingTable localPeerId
+          target = peerIdToKey (mkPeerId (BS.pack [1]))
+      closestPeers target 10 rt `shouldBe` []
+
+    it "spans multiple buckets when needed" $ do
+      now <- getCurrentTime
+      let rt0 = newRoutingTable localPeerId
+          pids = genPeerIds 50
+          entries = map (\pid -> mkEntry pid now) pids
+          (rtFinal, _) = foldl
+            (\(rt, rs) e -> let (rt', r) = insertPeer e rt in (rt', rs ++ [r]))
+            (rt0, [])
+            entries
+          target = peerIdToKey (mkPeerId (BS.pack [200]))
+          closest = closestPeers target 20 rtFinal
+      length closest `shouldSatisfy` (> 0)
+      length closest `shouldSatisfy` (<= 20)
+      let dists = map (\e -> xorDist target (entryKey e)) closest
+      dists `shouldBe` sort dists
+
+  describe "bucketForPeer" $ do
+    it "computes correct bucket index" $ do
+      let rt = newRoutingTable localPeerId
+          peerKey = peerIdToKey (mkPeerId (BS.pack [1]))
+          idx = bucketForPeer peerKey rt
+      idx `shouldSatisfy` (>= 0)
+      idx `shouldSatisfy` (< 256)
+
+  describe "bucket placement" $ do
+    it "peers go to correct buckets based on prefix length" $ do
+      now <- getCurrentTime
+      let rt0 = newRoutingTable localPeerId
+          pids = genPeerIds 30
+          entries = map (\pid -> mkEntry pid now) pids
+          (rtFinal, _) = foldl
+            (\(rt, rs) e -> let (rt', r) = insertPeer e rt in (rt', rs ++ [r]))
+            (rt0, [])
+            entries
+      mapM_ (\e -> do
+        let expectedIdx = bucketForPeer (entryKey e) rtFinal
+            sz = bucketSize expectedIdx rtFinal
+        sz `shouldSatisfy` (> 0)
+        ) entries
+
+  describe "allPeers" $ do
+    it "returns all entries across all buckets" $ do
+      now <- getCurrentTime
+      let rt0 = newRoutingTable localPeerId
+          pids = genPeerIds 15
+          entries = map (\pid -> mkEntry pid now) pids
+          (rtFinal, _) = foldl
+            (\(rt, rs) e -> let (rt', r) = insertPeer e rt in (rt', rs ++ [r]))
+            (rt0, [])
+            entries
+      length (allPeers rtFinal) `shouldBe` 15
+
+-- Helpers
+
+-- | XOR distance as raw ByteString for sorting comparison.
+xorDist :: DHTKey -> DHTKey -> BS.ByteString
+xorDist (DHTKey a) (DHTKey b) = BS.pack (BS.zipWith xor a b)
+
+-- | Group entries by their bucket index relative to a self key.
+groupByBucket :: DHTKey -> [BucketEntry] -> [(Int, [BucketEntry])]
+groupByBucket selfKey entries =
+  let indexed = map (\e -> (computeBucketIdx selfKey (entryKey e), e)) entries
+  in foldl (\acc (idx, e) ->
+       case lookup idx acc of
+         Nothing -> acc ++ [(idx, [e])]
+         Just _  -> map (\(i, es) -> if i == idx then (i, es ++ [e]) else (i, es)) acc
+     ) [] indexed
+
+-- | Compute bucket index (common prefix length clamped to [0,255]).
+computeBucketIdx :: DHTKey -> DHTKey -> Int
+computeBucketIdx (DHTKey a) (DHTKey b) =
+  let d = BS.pack (BS.zipWith xor a b)
+  in min (countLeadingZeroBits d) 255
+
+countLeadingZeroBits :: BS.ByteString -> Int
+countLeadingZeroBits bs = go 0
+  where
+    len = BS.length bs
+    go i
+      | i >= len  = i * 8
+      | byte == 0 = go (i + 1)
+      | otherwise = i * 8 + clzByte byte
+      where byte = BS.index bs i
+
+clzByte :: Word8 -> Int
+clzByte 0 = 8
+clzByte w = go' 7
+  where
+    go' (-1) = 8
+    go' bit
+      | testBit w bit = 7 - bit
+      | otherwise     = go' (bit - 1)


### PR DESCRIPTION
## Summary
- Implements Kademlia DHT Phase 7a (#22): k-bucket routing table and XOR distance metric
- Adds `DHT.Types` (DHTKey, BucketEntry, ConnectionType, constants k=20/alpha=10)
- Adds `DHT.Distance` (peerIdToKey via SHA-256, xorDistance, commonPrefixLength, compareDistance, sortByDistance)
- Adds `DHT.RoutingTable` (sparse IntMap of 256 k-buckets with Seq entries for O(1) LRS eviction)
- Insert handles: self-rejection, move-to-tail for existing peers, BucketFull returns LRS peer ID for ping-based eviction
- 24 new tests (10 distance + 14 routing table), 278 total passing

## Test plan
- [x] `cabal build` — compiles with no warnings
- [x] `cabal test` — 278 tests pass (254 existing + 24 new)
- [x] Distance tests: peerIdToKey output size/determinism, XOR identity/symmetry, commonPrefixLength edge cases, compareDistance ordering, sortByDistance
- [x] RoutingTable tests: empty table, insert/update/reject-self, bucket fill to k, BucketFull eviction signal, remove, closestPeers sorted across buckets, bucket placement correctness

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)