### PR TITLE
Implement GossipSub peer scoring P1-P7 (Phase 9b)

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -78,6 +78,7 @@ library
     Network.LibP2P.Protocol.GossipSub.Types
     Network.LibP2P.Protocol.GossipSub.Message
     Network.LibP2P.Protocol.GossipSub.Router
+    Network.LibP2P.Protocol.GossipSub.Score
   build-depends:
     base        >= 4.18 && < 5,
     bytestring  >= 0.10 && < 0.13,
@@ -137,6 +138,7 @@ test-suite libp2p-hs-test
     Test.Network.LibP2P.Protocol.GossipSub.TypesSpec
     Test.Network.LibP2P.Protocol.GossipSub.MessageSpec
     Test.Network.LibP2P.Protocol.GossipSub.RouterSpec
+    Test.Network.LibP2P.Protocol.GossipSub.ScoreSpec
   build-depends:
     base       >= 4.18 && < 5,
     bytestring >= 0.10 && < 0.13,

--- a/src/Network/LibP2P/Protocol/GossipSub/Score.hs
+++ b/src/Network/LibP2P/Protocol/GossipSub/Score.hs
@@ -1,0 +1,198 @@
+-- | GossipSub peer scoring (P1-P7) per docs/11-pubsub.md.
+--
+-- Score formula:
+--   Score(p) = TopicCap(Sum(t_i * (w1*P1 + w2*P2 + w3*P3 + w3b*P3b + w4*P4)))
+--              + w5*P5 + w6*P6 + w7*P7
+--
+-- All penalty parameters (P3, P3b, P4, P6, P7) use quadratic escalation:
+-- the score contribution is the square of the deficit/counter, mixed with
+-- a negative weight. This makes small deficits tolerable but large ones
+-- devastating.
+module Network.LibP2P.Protocol.GossipSub.Score
+  ( -- * Individual score components
+    computeP1
+  , computeP2
+  , computeP3
+  , computeP3b
+  , computeP4
+  , computeP6
+  , computeP7
+    -- * Aggregate score
+  , computeScore
+    -- * Decay
+  , decayCounter
+  , decayPeerCounters
+    -- * Counter recording
+  , recordFirstDelivery
+  , recordMeshDelivery
+  , recordInvalidMessage
+  , recordMeshFailure
+  , addP7Penalty
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Time (UTCTime, diffUTCTime)
+import Network.LibP2P.Crypto.PeerId (PeerId)
+import Network.LibP2P.Protocol.GossipSub.Types
+
+-- | P1: Time in Mesh. Returns min(meshTime/quantum, cap).
+-- Only counts when peer is actually in mesh.
+computeP1 :: TopicScoreParams -> TopicPeerState -> Double
+computeP1 tsp tps
+  | not (tpsInMesh tps) = 0
+  | otherwise =
+      let meshTime = realToFrac (tpsMeshTime tps) :: Double
+          quantum = realToFrac (tspTimeInMeshQuantum tsp) :: Double
+          raw = if quantum > 0 then meshTime / quantum else 0
+      in min raw (tspTimeInMeshCap tsp)
+
+-- | P2: First Message Deliveries. Returns min(counter, cap).
+computeP2 :: TopicScoreParams -> TopicPeerState -> Double
+computeP2 tsp tps = min (tpsFirstMessageDeliveries tps) (tspFirstMessageDeliveriesCap tsp)
+
+-- | P3: Mesh Message Deliveries. Returns deficit^2 when activated and below threshold.
+-- The weight (negative) is applied externally in computeScore.
+computeP3 :: TopicScoreParams -> TopicPeerState -> UTCTime -> Double
+computeP3 tsp tps now
+  | not (tpsInMesh tps) = 0
+  | not activated = 0
+  | deficit <= 0 = 0
+  | otherwise = deficit * deficit
+  where
+    activated = case tpsGraftTime tps of
+      Nothing -> False
+      Just gt ->
+        let elapsed = diffUTCTime now gt
+        in elapsed >= tspMeshMessageDeliveriesActivation tsp
+    threshold = tspMeshMessageDeliveriesThreshold tsp
+    deliveries = min (tpsMeshMessageDeliveries tps) (tspMeshMessageDeliveriesCap tsp)
+    deficit = threshold - deliveries
+
+-- | P3b: Mesh Failure Penalty. Returns the stored penalty value (already squared at capture time).
+computeP3b :: TopicPeerState -> Double
+computeP3b = tpsMeshFailurePenalty
+
+-- | P4: Invalid Messages. Returns counter^2.
+computeP4 :: TopicPeerState -> Double
+computeP4 tps = tpsInvalidMessages tps * tpsInvalidMessages tps
+
+-- | P6: IP Colocation Factor. Returns (count - threshold)^2 if count > threshold, else 0.
+computeP6 :: PeerScoreParams -> PeerState -> Map.Map ByteString (Set.Set PeerId) -> Double
+computeP6 params ps ipMap = case psIPAddress ps of
+  Nothing -> 0
+  Just ip ->
+    let count = maybe 0 Set.size (Map.lookup ip ipMap)
+        threshold = pspIPColocationFactorThreshold params
+        excess = count - threshold
+    in if excess > 0
+       then fromIntegral (excess * excess)
+       else 0
+
+-- | P7: Behavioral Penalty. Returns counter^2.
+computeP7 :: PeerState -> Double
+computeP7 ps = psBehaviorPenalty ps * psBehaviorPenalty ps
+
+-- | Compute full peer score per the formula in docs/11-pubsub.md.
+-- Takes explicit PeerId for the P5 application-specific callback.
+computeScore :: PeerScoreParams -> PeerState -> Map.Map ByteString (Set.Set PeerId) -> UTCTime -> Double
+computeScore params ps ipMap now =
+  let -- Topic score: sum over topics
+      topicScore = Map.foldlWithKey' (\acc topic tps ->
+        case Map.lookup topic (pspTopicParams params) of
+          Nothing -> acc  -- no params for this topic, skip
+          Just tsp ->
+            let p1 = tspTimeInMeshWeight tsp * computeP1 tsp tps
+                p2 = tspFirstMessageDeliveriesWeight tsp * computeP2 tsp tps
+                p3 = tspMeshMessageDeliveriesWeight tsp * computeP3 tsp tps now
+                p3b = tspMeshFailurePenaltyWeight tsp * computeP3b tps
+                p4 = tspInvalidMessageDeliveriesWeight tsp * computeP4 tps
+                topicContribution = tspTopicWeight tsp * (p1 + p2 + p3 + p3b + p4)
+            in acc + topicContribution
+        ) 0 (psTopicState ps)
+
+      -- Apply TopicScoreCap
+      cappedTopicScore =
+        let cap = pspTopicScoreCap params
+        in if cap > 0 && topicScore > cap
+           then cap
+           else topicScore
+
+      -- P5: not computed here (requires PeerId from router context).
+      -- Use computeScoreForPeer in Router for full P5 support.
+
+      -- P6: IP colocation
+      p6 = pspIPColocationFactorWeight params * computeP6 params ps ipMap
+
+      -- P7: behavioral penalty
+      p7 = pspBehaviorPenaltyWeight params * computeP7 ps
+
+  in cappedTopicScore + p6 + p7
+
+-- Decay
+
+-- | Decay a single counter by a factor.
+decayCounter :: Double -> Double -> Double
+decayCounter factor value = value * factor
+
+-- | Apply counter decay to all scoring counters in a PeerState.
+decayPeerCounters :: PeerScoreParams -> PeerState -> PeerState
+decayPeerCounters params ps =
+  let decayToZero = pspDecayToZero params
+      zeroCheck v = if abs v < decayToZero then 0 else v
+
+      -- Decay topic-level counters
+      decayedTopicState = Map.mapWithKey (\topic tps ->
+        case Map.lookup topic (pspTopicParams params) of
+          Nothing -> tps
+          Just tsp -> tps
+            { tpsFirstMessageDeliveries =
+                zeroCheck $ decayCounter (tspFirstMessageDeliveriesDecay tsp) (tpsFirstMessageDeliveries tps)
+            , tpsMeshMessageDeliveries =
+                zeroCheck $ decayCounter (tspMeshMessageDeliveriesDecay tsp) (tpsMeshMessageDeliveries tps)
+            , tpsMeshFailurePenalty =
+                zeroCheck $ decayCounter (tspMeshFailurePenaltyDecay tsp) (tpsMeshFailurePenalty tps)
+            , tpsInvalidMessages =
+                zeroCheck $ decayCounter (tspInvalidMessageDeliveriesDecay tsp) (tpsInvalidMessages tps)
+            }
+        ) (psTopicState ps)
+
+      -- Decay P7 (behavioral penalty)
+      decayedP7 = zeroCheck $ decayCounter (pspBehaviorPenaltyDecay params) (psBehaviorPenalty ps)
+
+  in ps { psTopicState = decayedTopicState, psBehaviorPenalty = decayedP7 }
+
+-- Counter recording
+
+-- | Record a first message delivery for a topic (P2 increment, capped).
+recordFirstDelivery :: TopicScoreParams -> TopicPeerState -> TopicPeerState
+recordFirstDelivery tsp tps =
+  let current = tpsFirstMessageDeliveries tps
+      cap = tspFirstMessageDeliveriesCap tsp
+  in tps { tpsFirstMessageDeliveries = min (current + 1) cap }
+
+-- | Record a mesh message delivery (P3 increment, capped).
+recordMeshDelivery :: TopicScoreParams -> TopicPeerState -> TopicPeerState
+recordMeshDelivery tsp tps =
+  let current = tpsMeshMessageDeliveries tps
+      cap = tspMeshMessageDeliveriesCap tsp
+  in tps { tpsMeshMessageDeliveries = min (current + 1) cap }
+
+-- | Record an invalid message delivery (P4 increment).
+recordInvalidMessage :: TopicPeerState -> TopicPeerState
+recordInvalidMessage tps =
+  tps { tpsInvalidMessages = tpsInvalidMessages tps + 1 }
+
+-- | Record a mesh failure (P3b): capture deficit^2 at prune time.
+-- deficit = threshold - deliveries (clamped to >= 0).
+recordMeshFailure :: TopicScoreParams -> TopicPeerState -> TopicPeerState
+recordMeshFailure tsp tps =
+  let threshold = tspMeshMessageDeliveriesThreshold tsp
+      deliveries = tpsMeshMessageDeliveries tps
+      deficit = max 0 (threshold - deliveries)
+  in tps { tpsMeshFailurePenalty = tpsMeshFailurePenalty tps + deficit * deficit }
+
+-- | Increment P7 behavioral penalty counter by 1.
+addP7Penalty :: PeerState -> PeerState
+addP7Penalty ps = ps { psBehaviorPenalty = psBehaviorPenalty ps + 1 }

--- a/test/Test/Network/LibP2P/Protocol/GossipSub/ScoreSpec.hs
+++ b/test/Test/Network/LibP2P/Protocol/GossipSub/ScoreSpec.hs
@@ -1,0 +1,273 @@
+module Test.Network.LibP2P.Protocol.GossipSub.ScoreSpec (spec) where
+
+import Test.Hspec
+
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Time (UTCTime, addUTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+
+import Network.LibP2P.Crypto.PeerId (PeerId (..))
+import Network.LibP2P.Protocol.GossipSub.Types
+import Network.LibP2P.Protocol.GossipSub.Score
+
+-- | Fixed reference time for deterministic tests.
+fixedTime :: UTCTime
+fixedTime = posixSecondsToUTCTime 1000000
+
+-- | Helper to create a dummy PeerId from a byte.
+mkPeerId :: Int -> PeerId
+mkPeerId n = PeerId (BS.pack [fromIntegral n])
+
+-- | Helper to create a PeerState with specific topic state.
+mkPeerState :: Map.Map Topic TopicPeerState -> PeerState
+mkPeerState topicState = PeerState
+  { psProtocol        = GossipSubPeer
+  , psTopics          = Map.keysSet topicState
+  , psIsOutbound      = False
+  , psConnectedAt     = fixedTime
+  , psTopicState      = topicState
+  , psBehaviorPenalty = 0
+  , psIPAddress       = Nothing
+  , psCachedScore     = 0
+  }
+
+-- | Helper: default peer score params with topic params for a given topic.
+mkScoreParams :: Topic -> TopicScoreParams -> PeerScoreParams
+mkScoreParams topic tsp = defaultPeerScoreParams
+  { pspTopicParams = Map.singleton topic tsp }
+
+-- | No-op IP peer count map (empty).
+emptyIPMap :: Map.Map BS.ByteString (Set.Set PeerId)
+emptyIPMap = Map.empty
+
+spec :: Spec
+spec = do
+  describe "GossipSub.Score" $ do
+
+    -- P1: Time in Mesh
+    describe "P1 (Time in Mesh)" $ do
+      it "returns 0 when peer is not in mesh" $ do
+        let tps = defaultTopicPeerState { tpsInMesh = False, tpsMeshTime = 10 }
+        computeP1 defaultTopicScoreParams tps `shouldBe` 0
+
+      it "increases linearly with mesh time up to cap" $ do
+        -- quantum=1s, so meshTime 5s => min(5, cap=100) = 5
+        let tps = defaultTopicPeerState { tpsInMesh = True, tpsMeshTime = 5 }
+        computeP1 defaultTopicScoreParams tps `shouldBe` 5
+
+      it "is capped at TimeInMeshCap" $ do
+        let tps = defaultTopicPeerState { tpsInMesh = True, tpsMeshTime = 200 }
+        computeP1 defaultTopicScoreParams tps `shouldBe` 100  -- cap=100
+
+    -- P2: First Message Deliveries
+    describe "P2 (First Message Deliveries)" $ do
+      it "returns 0 with no deliveries" $ do
+        let tps = defaultTopicPeerState
+        computeP2 defaultTopicScoreParams tps `shouldBe` 0
+
+      it "returns counter value when below cap" $ do
+        let tps = defaultTopicPeerState { tpsFirstMessageDeliveries = 10 }
+        computeP2 defaultTopicScoreParams tps `shouldBe` 10
+
+      it "is capped at FirstMessageDeliveriesCap" $ do
+        let tps = defaultTopicPeerState { tpsFirstMessageDeliveries = 200 }
+        computeP2 defaultTopicScoreParams tps `shouldBe` 100  -- cap=100
+
+      it "decays correctly" $ do
+        -- decay=0.5 => 10*0.5 = 5
+        decayCounter 0.5 10 `shouldBe` 5
+
+    -- P3: Mesh Message Deliveries
+    describe "P3 (Mesh Message Deliveries)" $ do
+      it "returns 0 when above threshold" $ do
+        -- threshold=1, deliveries=5 => deficit=0 => P3=0
+        let tps = defaultTopicPeerState
+              { tpsInMesh = True
+              , tpsMeshMessageDeliveries = 5
+              , tpsGraftTime = Just (addUTCTime (-10) fixedTime)  -- 10s ago
+              }
+        -- activation=5s, been in mesh 10s => activated
+        computeP3 defaultTopicScoreParams tps fixedTime `shouldBe` 0
+
+      it "returns negative squared deficit when below threshold" $ do
+        -- threshold=1, deliveries=0 => deficit=1 => P3 = -(1^2) = -1
+        let tps = defaultTopicPeerState
+              { tpsInMesh = True
+              , tpsMeshMessageDeliveries = 0
+              , tpsGraftTime = Just (addUTCTime (-10) fixedTime)
+              }
+        computeP3 defaultTopicScoreParams tps fixedTime `shouldBe` 1  -- deficit^2 (weight applied elsewhere)
+
+      it "returns 0 before activation period" $ do
+        -- graftTime only 2s ago, activation=5s => not activated => P3=0
+        let tps = defaultTopicPeerState
+              { tpsInMesh = True
+              , tpsMeshMessageDeliveries = 0
+              , tpsGraftTime = Just (addUTCTime (-2) fixedTime)
+              }
+        computeP3 defaultTopicScoreParams tps fixedTime `shouldBe` 0
+
+    -- P3b: Mesh Failure Penalty
+    describe "P3b (Mesh Failure Penalty)" $ do
+      it "captures deficit squared at prune time" $ do
+        -- penalty captured as deficit^2
+        let tps = defaultTopicPeerState { tpsMeshFailurePenalty = 4 }  -- (deficit=2)^2
+        computeP3b tps `shouldBe` 4
+
+      it "decays over time" $ do
+        -- decay factor 0.5: 4 * 0.5 = 2
+        decayCounter 0.5 4 `shouldBe` 2
+
+    -- P4: Invalid Messages
+    describe "P4 (Invalid Messages)" $ do
+      it "returns 0 with no invalid messages" $ do
+        computeP4 defaultTopicPeerState `shouldBe` 0
+
+      it "returns counter squared" $ do
+        let tps = defaultTopicPeerState { tpsInvalidMessages = 3 }
+        computeP4 tps `shouldBe` 9  -- 3^2
+
+      it "decays correctly" $ do
+        decayCounter 0.5 9 `shouldBe` 4.5
+
+    -- P6: IP Colocation
+    describe "P6 (IP Colocation)" $ do
+      it "returns 0 when below threshold" $ do
+        -- threshold=3, only 2 peers on IP => P6=0
+        let ipMap = Map.singleton (BS.pack [1,2,3,4]) (Set.fromList [mkPeerId 1, mkPeerId 2])
+            ps = (mkPeerState Map.empty) { psIPAddress = Just (BS.pack [1,2,3,4]) }
+        computeP6 defaultPeerScoreParams ps ipMap `shouldBe` 0
+
+      it "returns negative squared excess above threshold" $ do
+        -- threshold=3, 5 peers => excess=2, P6 = 2^2 = 4
+        let pids = map mkPeerId [1..5]
+            ipMap = Map.singleton (BS.pack [1,2,3,4]) (Set.fromList pids)
+            ps = (mkPeerState Map.empty) { psIPAddress = Just (BS.pack [1,2,3,4]) }
+        computeP6 defaultPeerScoreParams ps ipMap `shouldBe` 4  -- (5-3)^2
+
+    -- P7: Behavioral Penalty
+    describe "P7 (Behavioral Penalty)" $ do
+      it "returns 0 with no penalty" $ do
+        let ps = mkPeerState Map.empty
+        computeP7 ps `shouldBe` 0
+
+      it "returns counter squared" $ do
+        let ps = (mkPeerState Map.empty) { psBehaviorPenalty = 3 }
+        computeP7 ps `shouldBe` 9  -- 3^2
+
+      it "decays correctly" $ do
+        decayCounter 0.99 3 `shouldSatisfy` (\v -> abs (v - 2.97) < 0.001)
+
+      it "addP7Penalty increments counter" $ do
+        let ps = mkPeerState Map.empty
+            ps' = addP7Penalty ps
+        psBehaviorPenalty ps' `shouldBe` 1
+        let ps'' = addP7Penalty ps'
+        psBehaviorPenalty ps'' `shouldBe` 2
+
+    -- Aggregate score computation
+    describe "Aggregate score" $ do
+      it "returns 0 for all-zero counters" $ do
+        let ps = mkPeerState (Map.singleton "t" defaultTopicPeerState)
+            params = mkScoreParams "t" defaultTopicScoreParams
+        computeScore params ps emptyIPMap fixedTime `shouldBe` 0
+
+      it "computes positive score for first deliveries" $ do
+        let tps = defaultTopicPeerState
+              { tpsFirstMessageDeliveries = 10
+              , tpsInMesh = True
+              , tpsMeshTime = 5
+              }
+            ps = mkPeerState (Map.singleton "t" tps)
+            params = mkScoreParams "t" defaultTopicScoreParams
+        -- P1 = min(5/1, 100) = 5, w1=0.01 => 0.05
+        -- P2 = min(10, 100) = 10, w2=1.0 => 10
+        -- Topic score = 1.0 * (0.05 + 10) = 10.05
+        let score = computeScore params ps emptyIPMap fixedTime
+        score `shouldSatisfy` (> 0)
+        abs (score - 10.05) `shouldSatisfy` (< 0.01)
+
+      it "computes negative score for invalid messages" $ do
+        let tps = defaultTopicPeerState { tpsInvalidMessages = 2 }
+            ps = mkPeerState (Map.singleton "t" tps)
+            tsp = defaultTopicScoreParams
+            params = mkScoreParams "t" tsp
+        -- P4 = 2^2 = 4, w4=-100 => -400
+        -- Topic score = 1.0 * (-400) = -400
+        let score = computeScore params ps emptyIPMap fixedTime
+        score `shouldSatisfy` (< 0)
+
+      it "applies TopicScoreCap to topic portion" $ do
+        let tps = defaultTopicPeerState { tpsFirstMessageDeliveries = 100 }
+            ps = mkPeerState (Map.singleton "t" tps)
+            tsp = defaultTopicScoreParams
+            params = (mkScoreParams "t" tsp) { pspTopicScoreCap = 10 }
+        -- P2 = 100, w2=1 => 100, but TopicCap=10
+        let score = computeScore params ps emptyIPMap fixedTime
+        score `shouldSatisfy` (<= 10)
+
+    -- Decay
+    describe "decayScores" $ do
+      it "decays P2 counter" $ do
+        let tps = defaultTopicPeerState { tpsFirstMessageDeliveries = 10 }
+            ps = mkPeerState (Map.singleton "t" tps)
+            tsp = defaultTopicScoreParams { tspFirstMessageDeliveriesDecay = 0.5 }
+            params = mkScoreParams "t" tsp
+            ps' = decayPeerCounters params ps
+        case Map.lookup "t" (psTopicState ps') of
+          Just tps' -> tpsFirstMessageDeliveries tps' `shouldBe` 5
+          Nothing -> expectationFailure "topic state not found"
+
+      it "decays P7 counter" $ do
+        let ps = (mkPeerState Map.empty)
+              { psBehaviorPenalty = 10 }
+            params = defaultPeerScoreParams { pspBehaviorPenaltyDecay = 0.5 }
+            ps' = decayPeerCounters params ps
+        psBehaviorPenalty ps' `shouldBe` 5
+
+      it "zeros counters below DecayToZero threshold" $ do
+        let tps = defaultTopicPeerState { tpsFirstMessageDeliveries = 0.005 }
+            ps = mkPeerState (Map.singleton "t" tps)
+            tsp = defaultTopicScoreParams { tspFirstMessageDeliveriesDecay = 0.9 }
+            params = (mkScoreParams "t" tsp) { pspDecayToZero = 0.01 }
+            ps' = decayPeerCounters params ps
+        -- 0.005 * 0.9 = 0.0045, which is < 0.01, so should be zeroed
+        case Map.lookup "t" (psTopicState ps') of
+          Just tps' -> tpsFirstMessageDeliveries tps' `shouldBe` 0
+          Nothing -> expectationFailure "topic state not found"
+
+    -- Counter recording helpers
+    describe "Counter recording" $ do
+      it "recordFirstDelivery increments P2" $ do
+        let tps = defaultTopicPeerState { tpsFirstMessageDeliveries = 5 }
+            tps' = recordFirstDelivery defaultTopicScoreParams tps
+        tpsFirstMessageDeliveries tps' `shouldBe` 6
+
+      it "recordFirstDelivery respects cap" $ do
+        let tps = defaultTopicPeerState { tpsFirstMessageDeliveries = 100 }
+            tps' = recordFirstDelivery defaultTopicScoreParams tps
+        tpsFirstMessageDeliveries tps' `shouldBe` 100  -- cap=100
+
+      it "recordMeshDelivery increments P3" $ do
+        let tps = defaultTopicPeerState { tpsMeshMessageDeliveries = 5 }
+            tps' = recordMeshDelivery defaultTopicScoreParams tps
+        tpsMeshMessageDeliveries tps' `shouldBe` 6
+
+      it "recordInvalidMessage increments P4" $ do
+        let tps = defaultTopicPeerState { tpsInvalidMessages = 2 }
+            tps' = recordInvalidMessage tps
+        tpsInvalidMessages tps' `shouldBe` 3
+
+      it "recordMeshFailure captures deficit squared" $ do
+        -- threshold=1, deliveries=0 => deficit=1, P3b += 1^2 = 1
+        let tps = defaultTopicPeerState { tpsMeshMessageDeliveries = 0 }
+            tps' = recordMeshFailure defaultTopicScoreParams tps
+        tpsMeshFailurePenalty tps' `shouldBe` 1  -- (1-0)^2
+
+      it "recordMeshFailure with partial delivery" $ do
+        -- threshold=1, deliveries=0.5 => deficit=0.5, P3b += 0.5^2 = 0.25
+        let tps = defaultTopicPeerState { tpsMeshMessageDeliveries = 0.5 }
+            tps' = recordMeshFailure defaultTopicScoreParams tps
+        tpsMeshFailurePenalty tps' `shouldBe` 0.25


### PR DESCRIPTION
## Summary
- Implement peer scoring formula P1-P7 with quadratic penalty escalation
- Add `Score.hs` with pure scoring computation (P1: time in mesh, P2: first message deliveries, P3/P3b: mesh message delivery deficit, P4: invalid messages, P5: app-specific, P6: IP colocation, P7: behavior penalty)
- Add scoring types to `Types.hs` (TopicScoreParams, PeerScoreParams, TopicPeerState, ScoreThresholds)
- Integrate real scoring into Router (GRAFT rejection for negative score, P7 penalty for backoff violation, P3b recording on PRUNE)
- 38 new tests (34 Score + 4 Router integration)

## Test plan
- [x] All 496 tests pass (458 existing + 38 new)
- [x] Individual P1-P7 computation tests
- [x] Aggregate score computation
- [x] Counter decay verification
- [x] Router integration: GRAFT rejection, backoff penalty, mesh failure recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)