### PR TITLE
Implement GossipSub heartbeat and message cache (Phase 9c)

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -79,6 +79,8 @@ library
     Network.LibP2P.Protocol.GossipSub.Message
     Network.LibP2P.Protocol.GossipSub.Router
     Network.LibP2P.Protocol.GossipSub.Score
+    Network.LibP2P.Protocol.GossipSub.MessageCache
+    Network.LibP2P.Protocol.GossipSub.Heartbeat
   build-depends:
     base        >= 4.18 && < 5,
     bytestring  >= 0.10 && < 0.13,
@@ -139,6 +141,8 @@ test-suite libp2p-hs-test
     Test.Network.LibP2P.Protocol.GossipSub.MessageSpec
     Test.Network.LibP2P.Protocol.GossipSub.RouterSpec
     Test.Network.LibP2P.Protocol.GossipSub.ScoreSpec
+    Test.Network.LibP2P.Protocol.GossipSub.MessageCacheSpec
+    Test.Network.LibP2P.Protocol.GossipSub.HeartbeatSpec
   build-depends:
     base       >= 4.18 && < 5,
     bytestring >= 0.10 && < 0.13,

--- a/src/Network/LibP2P/Protocol/GossipSub/Heartbeat.hs
+++ b/src/Network/LibP2P/Protocol/GossipSub/Heartbeat.hs
@@ -1,0 +1,233 @@
+-- | GossipSub heartbeat procedure (docs/11-pubsub.md).
+--
+-- The heartbeat runs periodically and performs:
+-- 1. Mesh maintenance: prune negative-score, fill undersubscribed, trim oversubscribed
+-- 2. Fanout maintenance: expire old, fill undersubscribed
+-- 3. Gossip emission: send IHAVE to non-mesh peers, rotate cache
+-- 4. Score decay: decay all counters for all peers
+-- 5. Seen cache cleanup: remove expired entries
+-- 6. Heartbeat counter increment (for opportunistic graft timing)
+module Network.LibP2P.Protocol.GossipSub.Heartbeat
+  ( heartbeatOnce
+  , runHeartbeat
+  ) where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (Async, async)
+import Control.Concurrent.STM
+import Control.Monad (forM_, unless, when)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Time (UTCTime, addUTCTime, diffUTCTime)
+import Data.Word (Word64)
+import List.Shuffle (sampleIO)
+import Network.LibP2P.Crypto.PeerId (PeerId)
+import Network.LibP2P.Protocol.GossipSub.Types
+import Network.LibP2P.Protocol.GossipSub.MessageCache (cacheGetGossipIds, cacheShift)
+import Network.LibP2P.Protocol.GossipSub.Score (computeScore, decayPeerCounters)
+
+-- | Run a single heartbeat cycle. Exported for testing.
+heartbeatOnce :: GossipSubRouter -> IO ()
+heartbeatOnce router = do
+  meshMaintenance router
+  fanoutMaintenance router
+  emitGossip router
+  decayAllScores router
+  cleanSeenCache router
+  -- Increment heartbeat counter
+  atomically $ modifyTVar' (gsHeartbeatCount router) (+ 1)
+
+-- | Start the heartbeat background thread.
+runHeartbeat :: GossipSubRouter -> IO (Async ())
+runHeartbeat router = async $ heartbeatLoop router
+
+heartbeatLoop :: GossipSubRouter -> IO ()
+heartbeatLoop router = do
+  let intervalUs = round (paramHeartbeatInterval (gsParams router) * 1000000) :: Int
+  threadDelay intervalUs
+  heartbeatOnce router
+  heartbeatLoop router
+
+-- Mesh maintenance
+
+meshMaintenance :: GossipSubRouter -> IO ()
+meshMaintenance router = do
+  now <- gsGetTime router
+  meshMap <- readTVarIO (gsMesh router)
+  forM_ (Map.toList meshMap) $ \(topic, meshPeers) -> do
+    -- Step 1: Remove negative-score peers
+    remaining <- pruneNegativeScore router topic meshPeers now
+    -- Step 2: Fill if undersubscribed (< D_lo)
+    filled <- fillUndersubscribed router topic remaining now
+    -- Step 3: Trim if oversubscribed (> D_hi)
+    trimOversubscribed router topic filled
+
+-- | Remove peers with negative score from mesh, send PRUNE.
+pruneNegativeScore :: GossipSubRouter -> Topic -> Set.Set PeerId -> UTCTime -> IO (Set.Set PeerId)
+pruneNegativeScore router topic meshPeers now = do
+  let scoreParams = gsScoreParams router
+  ipMap <- readTVarIO (gsIPPeerCount router)
+  peers <- readTVarIO (gsPeers router)
+  let negatives = Set.filter (\pid ->
+        case Map.lookup pid peers of
+          Nothing -> False
+          Just ps -> computeScore scoreParams ps ipMap now < 0
+        ) meshPeers
+  -- Send PRUNE to negative-score peers
+  forM_ (Set.toList negatives) $ \pid -> do
+    let backoffSecs = round (paramPruneBackoff (gsParams router)) :: Word64
+    gsSendRPC router pid emptyRPC
+      { rpcControl = Just emptyControlMessage
+          { ctrlPrune = [Prune topic [] (Just backoffSecs)] }
+      }
+    -- Start backoff
+    atomically $ modifyTVar' (gsBackoff router) $
+      Map.insert (pid, topic) (addUTCTime (paramPruneBackoff (gsParams router)) now)
+  -- Update mesh
+  let remaining = Set.difference meshPeers negatives
+  atomically $ modifyTVar' (gsMesh router) $
+    Map.insert topic remaining
+  pure remaining
+
+-- | Fill mesh if below D_lo with eligible peers (non-negative score, no backoff).
+fillUndersubscribed :: GossipSubRouter -> Topic -> Set.Set PeerId -> UTCTime -> IO (Set.Set PeerId)
+fillUndersubscribed router topic meshPeers now = do
+  let params = gsParams router
+      dlo = paramDlo params
+      d   = paramD params
+  if Set.size meshPeers >= dlo
+    then pure meshPeers
+    else do
+      -- Find eligible peers: subscribed to topic, not in mesh, not in backoff, score >= 0
+      peersMap <- readTVarIO (gsPeers router)
+      backoffMap <- readTVarIO (gsBackoff router)
+      ipMap <- readTVarIO (gsIPPeerCount router)
+      let eligible = [ pid | (pid, ps) <- Map.toList peersMap
+                           , Set.member topic (psTopics ps)
+                           , not (Set.member pid meshPeers)
+                           , not (isInBackoff backoffMap pid topic now)
+                           , computeScore (gsScoreParams router) ps ipMap now >= 0
+                           ]
+      let needed = d - Set.size meshPeers
+      selected <- sampleIO (min needed (length eligible)) eligible
+      -- Send GRAFT and add to mesh
+      forM_ selected $ \pid ->
+        gsSendRPC router pid emptyRPC
+          { rpcControl = Just emptyControlMessage { ctrlGraft = [Graft topic] } }
+      let newMesh = Set.union meshPeers (Set.fromList selected)
+      atomically $ modifyTVar' (gsMesh router) $
+        Map.insert topic newMesh
+      pure newMesh
+
+-- | Trim mesh if above D_hi by randomly removing excess peers, send PRUNE.
+trimOversubscribed :: GossipSubRouter -> Topic -> Set.Set PeerId -> IO ()
+trimOversubscribed router topic meshPeers = do
+  let params = gsParams router
+      dhi = paramDhi params
+      d   = paramD params
+  when (Set.size meshPeers > dhi) $ do
+    now <- gsGetTime router
+    -- Keep D peers: select D random peers to keep
+    let meshList = Set.toList meshPeers
+    kept <- sampleIO d meshList
+    let keptSet = Set.fromList kept
+        toRemove = Set.difference meshPeers keptSet
+    -- Send PRUNE to removed peers
+    forM_ (Set.toList toRemove) $ \pid -> do
+      let backoffSecs = round (paramPruneBackoff params) :: Word64
+      gsSendRPC router pid emptyRPC
+        { rpcControl = Just emptyControlMessage
+            { ctrlPrune = [Prune topic [] (Just backoffSecs)] }
+        }
+      atomically $ modifyTVar' (gsBackoff router) $
+        Map.insert (pid, topic) (addUTCTime (paramPruneBackoff params) now)
+    -- Update mesh
+    atomically $ modifyTVar' (gsMesh router) $
+      Map.insert topic keptSet
+
+-- Fanout maintenance
+
+fanoutMaintenance :: GossipSubRouter -> IO ()
+fanoutMaintenance router = do
+  now <- gsGetTime router
+  let ttl = paramFanoutTTL (gsParams router)
+  fanoutMap <- readTVarIO (gsFanout router)
+  fanoutPubMap <- readTVarIO (gsFanoutPub router)
+  forM_ (Map.toList fanoutMap) $ \(topic, fanoutPeers) -> do
+    let lastPub = Map.findWithDefault now topic fanoutPubMap
+    if diffUTCTime now lastPub > ttl
+      then -- Expire fanout entry
+        atomically $ do
+          modifyTVar' (gsFanout router) (Map.delete topic)
+          modifyTVar' (gsFanoutPub router) (Map.delete topic)
+      else do
+        -- Fill if below D
+        let d = paramD (gsParams router)
+        when (Set.size fanoutPeers < d) $ do
+          peersMap <- readTVarIO (gsPeers router)
+          let eligible = [ pid | (pid, ps) <- Map.toList peersMap
+                               , Set.member topic (psTopics ps)
+                               , not (Set.member pid fanoutPeers)
+                               ]
+          let needed = d - Set.size fanoutPeers
+          selected <- sampleIO (min needed (length eligible)) eligible
+          let newFanout = Set.union fanoutPeers (Set.fromList selected)
+          atomically $ modifyTVar' (gsFanout router) $
+            Map.insert topic newFanout
+
+-- Gossip emission
+
+emitGossip :: GossipSubRouter -> IO ()
+emitGossip router = do
+  meshMap <- readTVarIO (gsMesh router)
+  cache <- readTVarIO (gsMessageCache router)
+  peersMap <- readTVarIO (gsPeers router)
+  let params = gsParams router
+
+  -- For each topic in mesh, send IHAVE to non-mesh peers
+  forM_ (Map.keys meshMap) $ \topic -> do
+    let gossipIds = cacheGetGossipIds topic cache
+    unless (null gossipIds) $ do
+      let meshPeers = Map.findWithDefault Set.empty topic meshMap
+          -- Eligible: subscribed to topic, not in mesh
+          nonMeshPeers = [ pid | (pid, ps) <- Map.toList peersMap
+                               , Set.member topic (psTopics ps)
+                               , not (Set.member pid meshPeers)
+                               ]
+          -- Select max(D_lazy, |eligible| * gossipFactor) targets
+          dlazy = paramDlazy params
+          factor = paramGossipFactor params
+          targetCount = max dlazy (ceiling (factor * fromIntegral (length nonMeshPeers)))
+      targets <- sampleIO (min targetCount (length nonMeshPeers)) nonMeshPeers
+      forM_ targets $ \pid ->
+        gsSendRPC router pid emptyRPC
+          { rpcControl = Just emptyControlMessage
+              { ctrlIHave = [IHave topic gossipIds] }
+          }
+
+  -- Rotate cache
+  atomically $ modifyTVar' (gsMessageCache router) cacheShift
+
+-- Score decay
+
+decayAllScores :: GossipSubRouter -> IO ()
+decayAllScores router = atomically $
+  modifyTVar' (gsPeers router) $
+    Map.map (decayPeerCounters (gsScoreParams router))
+
+-- Seen cache cleanup
+
+cleanSeenCache :: GossipSubRouter -> IO ()
+cleanSeenCache router = do
+  now <- gsGetTime router
+  let ttl = paramSeenTTL (gsParams router)
+  atomically $ modifyTVar' (gsSeen router) $
+    Map.filter (\ts -> diffUTCTime now ts <= ttl)
+
+-- Helpers
+
+isInBackoff :: Map.Map (PeerId, Topic) UTCTime -> PeerId -> Topic -> UTCTime -> Bool
+isInBackoff backoffMap pid topic now =
+  case Map.lookup (pid, topic) backoffMap of
+    Nothing -> False
+    Just expires -> now < expires

--- a/src/Network/LibP2P/Protocol/GossipSub/MessageCache.hs
+++ b/src/Network/LibP2P/Protocol/GossipSub/MessageCache.hs
@@ -1,0 +1,79 @@
+-- | GossipSub sliding-window message cache operations (docs/11-pubsub.md).
+--
+-- Stores recently seen messages in circular windows for IWANT responses
+-- and IHAVE gossip emission. Each heartbeat calls 'cacheShift' to rotate
+-- windows; messages older than 'mcLen' windows are evicted.
+--
+-- For gossip emission, only the 'mcGossip' most recent windows are
+-- consulted (subset of full cache).
+--
+-- Pure operations — the MessageCache and CacheEntry types are defined
+-- in Types.hs to avoid circular imports with Router.hs.
+module Network.LibP2P.Protocol.GossipSub.MessageCache
+  ( newMessageCache
+  , cachePut
+  , cacheGet
+  , cacheGetGossipIds
+  , cacheShift
+  ) where
+
+import Data.Foldable (toList)
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence as Seq
+import Network.LibP2P.Protocol.GossipSub.Types
+  ( Topic, MessageId, PubSubMessage (..)
+  , CacheEntry (..), MessageCache (..)
+  )
+
+-- | Create an empty message cache with given window count and gossip window count.
+newMessageCache :: Int -> Int -> MessageCache
+newMessageCache len gossip = MessageCache
+  { mcWindows = Seq.replicate len []
+  , mcIndex   = Map.empty
+  , mcLen     = len
+  , mcGossip  = gossip
+  }
+
+-- | Add a message to the current (newest) window.
+cachePut :: MessageId -> PubSubMessage -> MessageCache -> MessageCache
+cachePut mid msg mc =
+  let entry = CacheEntry mid msg (msgTopic msg)
+      -- Prepend entry to the newest window (index 0)
+      windows = case Seq.viewl (mcWindows mc) of
+        Seq.EmptyL -> Seq.singleton [entry]
+        newest Seq.:< rest -> (entry : newest) Seq.<| rest
+  in mc
+    { mcWindows = windows
+    , mcIndex   = Map.insert mid entry (mcIndex mc)
+    }
+
+-- | Look up a message by ID.
+cacheGet :: MessageId -> MessageCache -> Maybe PubSubMessage
+cacheGet mid mc = ceMessage <$> Map.lookup mid (mcIndex mc)
+
+-- | Get message IDs for gossip emission (IHAVE) — only from the gossip windows.
+-- Filters by topic.
+cacheGetGossipIds :: Topic -> MessageCache -> [MessageId]
+cacheGetGossipIds topic mc =
+  let gossipWindows = Seq.take (mcGossip mc) (mcWindows mc)
+      entries = concatMap id (toList gossipWindows)
+  in [ ceMessageId e | e <- entries, ceTopic e == topic ]
+
+-- | Rotate windows: prepend a new empty window, drop the oldest.
+-- Entries in the dropped window are removed from the index.
+cacheShift :: MessageCache -> MessageCache
+cacheShift mc =
+  let windows = mcWindows mc
+      -- Drop the oldest window
+      (kept, dropped) = case Seq.viewr windows of
+        Seq.EmptyR -> (Seq.empty, [])
+        rest Seq.:> oldest -> (rest, oldest)
+      -- Add new empty window at front
+      newWindows = (Seq.empty Seq.|> []) Seq.>< kept
+      -- Remove dropped entries from index
+      droppedIds = map ceMessageId dropped
+      newIndex = foldl' (\idx mid -> Map.delete mid idx) (mcIndex mc) droppedIds
+  in mc
+    { mcWindows = newWindows
+    , mcIndex   = newIndex
+    }

--- a/test/Test/Network/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
+++ b/test/Test/Network/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
@@ -1,0 +1,309 @@
+module Test.Network.LibP2P.Protocol.GossipSub.HeartbeatSpec (spec) where
+
+import Test.Hspec
+
+import Control.Concurrent.STM
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.IORef
+import Data.Time (UTCTime, addUTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Network.LibP2P.Crypto.PeerId (PeerId (..))
+import Network.LibP2P.Protocol.GossipSub.Types
+import Network.LibP2P.Protocol.GossipSub.Router (newRouter, addPeer, peerScore)
+import Network.LibP2P.Protocol.GossipSub.MessageCache (newMessageCache, cachePut, cacheGetGossipIds)
+import Network.LibP2P.Protocol.GossipSub.Heartbeat
+
+-- Test helpers
+
+mkPeerId :: Int -> PeerId
+mkPeerId n = PeerId (BS.pack [fromIntegral n])
+
+fixedTime :: UTCTime
+fixedTime = posixSecondsToUTCTime 1000000
+
+newSendLog :: IO (IORef [(PeerId, RPC)], PeerId -> RPC -> IO ())
+newSendLog = do
+  ref <- newIORef []
+  let sendFn pid rpc = modifyIORef' ref (++ [(pid, rpc)])
+  pure (ref, sendFn)
+
+-- | Create a test router with adjustable time and topic score params.
+mkHeartbeatRouter :: PeerId -> UTCTime -> IO (GossipSubRouter, IORef [(PeerId, RPC)], IORef UTCTime)
+mkHeartbeatRouter localPid t = do
+  (logRef, sendFn) <- newSendLog
+  timeRef <- newIORef t
+  let getTime = readIORef timeRef
+  router <- newRouter defaultGossipSubParams localPid sendFn getTime
+  pure (router, logRef, timeRef)
+
+-- | Add peer that's subscribed and in mesh for a topic.
+addMeshPeer :: GossipSubRouter -> PeerId -> Topic -> UTCTime -> IO ()
+addMeshPeer router pid topic now = do
+  addPeer router pid GossipSubPeer False now
+  atomically $ do
+    modifyTVar' (gsPeers router) $
+      Map.adjust (\ps -> ps { psTopics = Set.singleton topic }) pid
+    modifyTVar' (gsMesh router) $
+      Map.insertWith Set.union topic (Set.singleton pid)
+
+-- | Add peer that's subscribed but NOT in mesh.
+addSubscribedPeer :: GossipSubRouter -> PeerId -> Topic -> UTCTime -> IO ()
+addSubscribedPeer router pid topic now = do
+  addPeer router pid GossipSubPeer False now
+  atomically $ modifyTVar' (gsPeers router) $
+    Map.adjust (\ps -> ps { psTopics = Set.singleton topic }) pid
+
+localPid :: PeerId
+localPid = mkPeerId 0
+
+spec :: Spec
+spec = do
+  describe "GossipSub.Heartbeat" $ do
+
+    describe "Mesh maintenance" $ do
+      it "prunes negative-score peers from mesh" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        let routerWithParams = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspTopicParams = Map.singleton "t" defaultTopicScoreParams }
+              }
+        -- Add a peer with negative score (high invalid message count)
+        let pid = mkPeerId 1
+        addMeshPeer routerWithParams pid "t" fixedTime
+        atomically $ modifyTVar' (gsPeers routerWithParams) $
+          Map.adjust (\ps -> ps
+            { psTopicState = Map.singleton "t"
+                (defaultTopicPeerState { tpsInvalidMessages = 10 })
+            }) pid
+        -- Run heartbeat
+        heartbeatOnce routerWithParams
+        -- Peer should be removed from mesh
+        mesh <- readTVarIO (gsMesh routerWithParams)
+        Set.member pid (Map.findWithDefault Set.empty "t" mesh) `shouldBe` False
+        -- Should have sent PRUNE
+        sent <- readIORef logRef
+        let pruneMsgs = filter (\(p, rpc) ->
+              p == pid && case rpcControl rpc of
+                Just ctrl -> not (null (ctrlPrune ctrl))
+                Nothing -> False) sent
+        length pruneMsgs `shouldSatisfy` (>= 1)
+
+      it "GRAFTs when mesh is undersubscribed (< D_lo)" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        -- D=6, D_lo=4: add 2 mesh peers + 4 more subscribed but not in mesh
+        let meshPeers = map mkPeerId [1, 2]
+            otherPeers = map mkPeerId [3, 4, 5, 6]
+        mapM_ (\pid -> addMeshPeer router pid "t" fixedTime) meshPeers
+        mapM_ (\pid -> addSubscribedPeer router pid "t" fixedTime) otherPeers
+        -- Make sure mesh entry exists
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insertWith Set.union "t" Set.empty
+        heartbeatOnce router
+        -- Mesh should have grown toward D=6
+        mesh <- readTVarIO (gsMesh router)
+        let meshSize = Set.size (Map.findWithDefault Set.empty "t" mesh)
+        meshSize `shouldSatisfy` (>= 4)  -- at least D_lo
+        -- Should have sent GRAFT messages
+        sent <- readIORef logRef
+        let graftMsgs = filter (\(_, rpc) ->
+              case rpcControl rpc of
+                Just ctrl -> not (null (ctrlGraft ctrl))
+                Nothing -> False) sent
+        length graftMsgs `shouldSatisfy` (>= 1)
+
+      it "skips peers in backoff during undersubscribed fill" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        let meshPeer = mkPeerId 1
+            backoffPeer = mkPeerId 2
+            availPeer = mkPeerId 3
+        addMeshPeer router meshPeer "t" fixedTime
+        addSubscribedPeer router backoffPeer "t" fixedTime
+        addSubscribedPeer router availPeer "t" fixedTime
+        -- Put backoffPeer in backoff
+        atomically $ modifyTVar' (gsBackoff router) $
+          Map.insert (backoffPeer, "t") (addUTCTime 60 fixedTime)
+        heartbeatOnce router
+        -- backoffPeer should NOT be in mesh
+        mesh <- readTVarIO (gsMesh router)
+        let meshPeers = Map.findWithDefault Set.empty "t" mesh
+        Set.member backoffPeer meshPeers `shouldBe` False
+
+      it "PRUNEs when mesh is oversubscribed (> D_hi)" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        -- D_hi=12: add 15 mesh peers
+        let pids = map mkPeerId [1..15]
+        mapM_ (\pid -> addMeshPeer router pid "t" fixedTime) pids
+        heartbeatOnce router
+        -- Mesh should be trimmed to D=6
+        mesh <- readTVarIO (gsMesh router)
+        let meshSize = Set.size (Map.findWithDefault Set.empty "t" mesh)
+        meshSize `shouldBe` 6  -- trimmed to D
+        -- Should have sent PRUNE to excess peers
+        sent <- readIORef logRef
+        let pruneMsgs = filter (\(_, rpc) ->
+              case rpcControl rpc of
+                Just ctrl -> not (null (ctrlPrune ctrl))
+                Nothing -> False) sent
+        length pruneMsgs `shouldBe` 9  -- 15 - 6 = 9
+
+    describe "Fanout maintenance" $ do
+      it "expires old fanout entries" $ do
+        (router, _, timeRef) <- mkHeartbeatRouter localPid fixedTime
+        let pid = mkPeerId 1
+        addSubscribedPeer router pid "t" fixedTime
+        -- Add fanout entry with old timestamp
+        atomically $ do
+          modifyTVar' (gsFanout router) $
+            Map.insert "t" (Set.singleton pid)
+          modifyTVar' (gsFanoutPub router) $
+            Map.insert "t" fixedTime
+        -- Advance time past fanout_ttl (60s)
+        writeIORef timeRef (addUTCTime 61 fixedTime)
+        heartbeatOnce router
+        -- Fanout should be expired
+        fanout <- readTVarIO (gsFanout router)
+        Map.member "t" fanout `shouldBe` False
+
+      it "fills fanout when < D" $ do
+        (router, _, _) <- mkHeartbeatRouter localPid fixedTime
+        let pids = map mkPeerId [1..8]
+        mapM_ (\pid -> addSubscribedPeer router pid "t" fixedTime) pids
+        -- Add fanout entry with 1 peer (recent, so won't expire)
+        atomically $ do
+          modifyTVar' (gsFanout router) $
+            Map.insert "t" (Set.singleton (mkPeerId 1))
+          modifyTVar' (gsFanoutPub router) $
+            Map.insert "t" fixedTime
+        heartbeatOnce router
+        -- Fanout should be filled toward D=6
+        fanout <- readTVarIO (gsFanout router)
+        let fanoutSize = Set.size (Map.findWithDefault Set.empty "t" fanout)
+        fanoutSize `shouldSatisfy` (>= 2)  -- at least grew
+
+    describe "Gossip emission" $ do
+      it "sends IHAVE to non-mesh peers" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        -- Need D=6 mesh peers so mesh maintenance doesn't steal our non-mesh peer
+        let meshPeers = map mkPeerId [1..6]
+            nonMeshPeer = mkPeerId 10
+        mapM_ (\pid -> addMeshPeer router pid "t" fixedTime) meshPeers
+        addSubscribedPeer router nonMeshPeer "t" fixedTime
+        -- Put a message in the cache
+        let mid = BS.pack [42]
+            msg = PubSubMessage (Just (BS.pack [1])) (BS.pack [1]) (Just mid) "t" Nothing Nothing
+        atomically $ modifyTVar' (gsMessageCache router) $
+          cachePut mid msg
+        heartbeatOnce router
+        -- nonMeshPeer should receive IHAVE
+        sent <- readIORef logRef
+        let ihaveMsgs = filter (\(pid, rpc) ->
+              pid == nonMeshPeer && case rpcControl rpc of
+                Just ctrl -> not (null (ctrlIHave ctrl))
+                Nothing -> False) sent
+        length ihaveMsgs `shouldSatisfy` (>= 1)
+
+      it "does not send IHAVE to mesh peers" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        -- Need D=6 mesh peers so mesh maintenance doesn't modify mesh
+        let meshPeers = map mkPeerId [1..6]
+        mapM_ (\pid -> addMeshPeer router pid "t" fixedTime) meshPeers
+        let mid = BS.pack [42]
+            msg = PubSubMessage (Just (BS.pack [1])) (BS.pack [1]) (Just mid) "t" Nothing Nothing
+        atomically $ modifyTVar' (gsMessageCache router) $
+          cachePut mid msg
+        heartbeatOnce router
+        -- Mesh peers should NOT receive IHAVE (only GRAFTs from maintenance)
+        sent <- readIORef logRef
+        let ihaveMsgs = filter (\(pid, rpc) ->
+              Set.member pid (Set.fromList meshPeers) &&
+              case rpcControl rpc of
+                Just ctrl -> not (null (ctrlIHave ctrl))
+                Nothing -> False) sent
+        length ihaveMsgs `shouldBe` 0
+
+      it "rotates message cache after gossip" $ do
+        (router, _, _) <- mkHeartbeatRouter localPid fixedTime
+        let mid = BS.pack [42]
+            msg = PubSubMessage (Just (BS.pack [1])) (BS.pack [1]) (Just mid) "t" Nothing Nothing
+        atomically $ modifyTVar' (gsMessageCache router) $
+          cachePut mid msg
+        -- After mcLen=5 heartbeats, message should be evicted
+        mapM_ (\_ -> heartbeatOnce router) [1..5 :: Int]
+        cache <- readTVarIO (gsMessageCache router)
+        cacheGetGossipIds "t" cache `shouldBe` []
+
+    describe "Score decay" $ do
+      it "decays P2 counter" $ do
+        (router, _, _) <- mkHeartbeatRouter localPid fixedTime
+        let routerWithParams = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspTopicParams = Map.singleton "t"
+                      (defaultTopicScoreParams { tspFirstMessageDeliveriesDecay = 0.5 })
+                  }
+              }
+        let pid = mkPeerId 1
+        addPeer routerWithParams pid GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsPeers routerWithParams) $
+          Map.adjust (\ps -> ps
+            { psTopicState = Map.singleton "t"
+                (defaultTopicPeerState { tpsFirstMessageDeliveries = 10 })
+            }) pid
+        heartbeatOnce routerWithParams
+        peers <- readTVarIO (gsPeers routerWithParams)
+        case Map.lookup pid peers of
+          Just ps -> case Map.lookup "t" (psTopicState ps) of
+            Just tps -> tpsFirstMessageDeliveries tps `shouldBe` 5
+            Nothing -> expectationFailure "topic state not found"
+          Nothing -> expectationFailure "peer not found"
+
+      it "decays P7 counter" $ do
+        (router, _, _) <- mkHeartbeatRouter localPid fixedTime
+        let routerWithParams = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspBehaviorPenaltyDecay = 0.5 }
+              }
+        let pid = mkPeerId 1
+        addPeer routerWithParams pid GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsPeers routerWithParams) $
+          Map.adjust (\ps -> ps { psBehaviorPenalty = 10 }) pid
+        heartbeatOnce routerWithParams
+        peers <- readTVarIO (gsPeers routerWithParams)
+        case Map.lookup pid peers of
+          Just ps -> psBehaviorPenalty ps `shouldBe` 5
+          Nothing -> expectationFailure "peer not found"
+
+    describe "Seen cache cleanup" $ do
+      it "cleans expired entries from seen cache" $ do
+        (router, _, timeRef) <- mkHeartbeatRouter localPid fixedTime
+        -- Add seen entry at fixedTime
+        atomically $ modifyTVar' (gsSeen router) $
+          Map.insert (BS.pack [1]) fixedTime
+        -- Advance time past SeenTTL (120s)
+        writeIORef timeRef (addUTCTime 121 fixedTime)
+        heartbeatOnce router
+        seen <- readTVarIO (gsSeen router)
+        Map.member (BS.pack [1]) seen `shouldBe` False
+
+      it "preserves unexpired entries" $ do
+        (router, _, timeRef) <- mkHeartbeatRouter localPid fixedTime
+        atomically $ modifyTVar' (gsSeen router) $
+          Map.insert (BS.pack [1]) fixedTime
+        -- Only 10s later — still within TTL
+        writeIORef timeRef (addUTCTime 10 fixedTime)
+        heartbeatOnce router
+        seen <- readTVarIO (gsSeen router)
+        Map.member (BS.pack [1]) seen `shouldBe` True
+
+    describe "Heartbeat counter" $ do
+      it "increments on each heartbeat" $ do
+        (router, _, _) <- mkHeartbeatRouter localPid fixedTime
+        count0 <- readTVarIO (gsHeartbeatCount router)
+        count0 `shouldBe` 0
+        heartbeatOnce router
+        count1 <- readTVarIO (gsHeartbeatCount router)
+        count1 `shouldBe` 1
+        heartbeatOnce router
+        count2 <- readTVarIO (gsHeartbeatCount router)
+        count2 `shouldBe` 2

--- a/test/Test/Network/LibP2P/Protocol/GossipSub/MessageCacheSpec.hs
+++ b/test/Test/Network/LibP2P/Protocol/GossipSub/MessageCacheSpec.hs
@@ -1,0 +1,119 @@
+module Test.Network.LibP2P.Protocol.GossipSub.MessageCacheSpec (spec) where
+
+import Test.Hspec
+
+import qualified Data.ByteString as BS
+import Network.LibP2P.Protocol.GossipSub.Types (Topic, MessageId, PubSubMessage (..), MessageCache (..))
+import Network.LibP2P.Protocol.GossipSub.MessageCache
+
+-- | Helper to create a simple PubSubMessage.
+mkMsg :: Int -> Topic -> PubSubMessage
+mkMsg n topic = PubSubMessage
+  { msgFrom      = Just (BS.pack [fromIntegral n])
+  , msgData      = BS.pack [fromIntegral n]
+  , msgSeqNo     = Just (BS.pack [0, 0, 0, 0, 0, 0, 0, fromIntegral n])
+  , msgTopic     = topic
+  , msgSignature = Nothing
+  , msgKey       = Nothing
+  }
+
+-- | Helper to create a message ID from an int.
+mkMid :: Int -> MessageId
+mkMid n = BS.pack [fromIntegral n]
+
+spec :: Spec
+spec = do
+  describe "GossipSub.MessageCache" $ do
+
+    describe "newMessageCache" $ do
+      it "creates cache with correct number of empty windows" $ do
+        let mc = newMessageCache 5 3
+        mcLen mc `shouldBe` 5
+        mcGossip mc `shouldBe` 3
+
+    describe "cachePut" $ do
+      it "adds entry to current window" $ do
+        let mc = newMessageCache 5 3
+            mc' = cachePut (mkMid 1) (mkMsg 1 "t") mc
+        cacheGet (mkMid 1) mc' `shouldBe` Just (mkMsg 1 "t")
+
+      it "supports multiple entries" $ do
+        let mc = newMessageCache 5 3
+            mc' = cachePut (mkMid 1) (mkMsg 1 "t") $
+                  cachePut (mkMid 2) (mkMsg 2 "t") mc
+        cacheGet (mkMid 1) mc' `shouldBe` Just (mkMsg 1 "t")
+        cacheGet (mkMid 2) mc' `shouldBe` Just (mkMsg 2 "t")
+
+    describe "cacheGet" $ do
+      it "returns Nothing for unknown message ID" $ do
+        let mc = newMessageCache 5 3
+        cacheGet (mkMid 99) mc `shouldBe` Nothing
+
+      it "retrieves entry after shift" $ do
+        let mc = newMessageCache 5 3
+            mc' = cacheShift $ cachePut (mkMid 1) (mkMsg 1 "t") mc
+        -- Message should still be accessible after one shift
+        cacheGet (mkMid 1) mc' `shouldBe` Just (mkMsg 1 "t")
+
+    describe "cacheGetGossipIds" $ do
+      it "returns IDs from gossip windows only" $ do
+        let mc = newMessageCache 5 3
+            mc' = cachePut (mkMid 1) (mkMsg 1 "blocks") mc
+        -- mcGossip=3, message in window 0 (newest), within gossip range
+        cacheGetGossipIds "blocks" mc' `shouldBe` [mkMid 1]
+
+      it "filters by topic" $ do
+        let mc = newMessageCache 5 3
+            mc' = cachePut (mkMid 1) (mkMsg 1 "blocks") $
+                  cachePut (mkMid 2) (mkMsg 2 "tx") mc
+        cacheGetGossipIds "blocks" mc' `shouldBe` [mkMid 1]
+        cacheGetGossipIds "tx" mc' `shouldBe` [mkMid 2]
+
+      it "excludes messages outside gossip window" $ do
+        -- mcGossip=2, shift 3 times → message should be outside gossip range
+        let mc = newMessageCache 5 2
+            mc' = cacheShift $ cacheShift $ cacheShift $
+                  cachePut (mkMid 1) (mkMsg 1 "t") mc
+        -- Message is in window 3, but gossip only covers windows 0-1
+        cacheGetGossipIds "t" mc' `shouldBe` []
+        -- But cacheGet should still find it (within mcLen=5)
+        cacheGet (mkMid 1) mc' `shouldBe` Just (mkMsg 1 "t")
+
+    describe "cacheShift" $ do
+      it "rotates windows and drops oldest when full" $ do
+        -- mcLen=3: after 3 shifts, oldest window is dropped
+        let mc = newMessageCache 3 2
+            mc' = cachePut (mkMid 1) (mkMsg 1 "t") mc
+            mc'' = cacheShift $ cacheShift $ cacheShift mc'
+        -- Message was in the first window, 3 shifts = evicted
+        cacheGet (mkMid 1) mc'' `shouldBe` Nothing
+
+      it "preserves entries within window range" $ do
+        -- mcLen=5: after 2 shifts, message still accessible
+        let mc = newMessageCache 5 3
+            mc' = cacheShift $ cacheShift $
+                  cachePut (mkMid 1) (mkMsg 1 "t") mc
+        cacheGet (mkMid 1) mc' `shouldBe` Just (mkMsg 1 "t")
+
+    describe "lifecycle" $ do
+      it "put + shift + gossipIds + get" $ do
+        let mc = newMessageCache 3 2
+            -- Put messages in different windows
+            mc1 = cachePut (mkMid 1) (mkMsg 1 "t") mc
+            mc2 = cacheShift mc1
+            mc3 = cachePut (mkMid 2) (mkMsg 2 "t") mc2
+            mc4 = cacheShift mc3
+            mc5 = cachePut (mkMid 3) (mkMsg 3 "t") mc4
+        -- All three should be accessible
+        cacheGet (mkMid 1) mc5 `shouldBe` Just (mkMsg 1 "t")
+        cacheGet (mkMid 2) mc5 `shouldBe` Just (mkMsg 2 "t")
+        cacheGet (mkMid 3) mc5 `shouldBe` Just (mkMsg 3 "t")
+        -- Gossip (2 windows) should only include mid2 and mid3
+        let gossipIds = cacheGetGossipIds "t" mc5
+        mkMid 3 `elem` gossipIds `shouldBe` True
+        mkMid 2 `elem` gossipIds `shouldBe` True
+        mkMid 1 `elem` gossipIds `shouldBe` False
+        -- One more shift should evict mid1
+        let mc6 = cacheShift mc5
+        cacheGet (mkMid 1) mc6 `shouldBe` Nothing
+        cacheGet (mkMid 2) mc6 `shouldBe` Just (mkMsg 2 "t")


### PR DESCRIPTION
## Summary
- Implement sliding-window `MessageCache` with put/get/gossipIds/shift operations
- Implement 6-step heartbeat cycle: mesh maintenance, fanout maintenance, gossip emission (IHAVE), score decay, seen cache cleanup, counter increment
- Integrate message cache into Router (cachePut on publish, real handleIWant via cacheGet)
- Add `runHeartbeat` for background async execution with configurable interval
- 25 new tests (11 MessageCache + 14 Heartbeat)

## Test plan
- [x] All 521 tests pass (496 existing + 25 new)
- [x] MessageCache: put/get/gossipIds/shift lifecycle tests
- [x] Heartbeat mesh maintenance: prune negative scores, fill undersubscribed, trim oversubscribed
- [x] Heartbeat fanout maintenance: TTL expiration, peer filling
- [x] Gossip emission: IHAVE to non-mesh peers, cache rotation
- [x] Score decay and seen cache cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)