### PR TITLE
Add GossipSub Switch Handler (Phase 10b)

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -81,6 +81,7 @@ library
     Network.LibP2P.Protocol.GossipSub.Score
     Network.LibP2P.Protocol.GossipSub.MessageCache
     Network.LibP2P.Protocol.GossipSub.Heartbeat
+    Network.LibP2P.Protocol.GossipSub.Handler
   build-depends:
     base        >= 4.18 && < 5,
     bytestring  >= 0.10 && < 0.13,
@@ -144,6 +145,7 @@ test-suite libp2p-hs-test
     Test.Network.LibP2P.Protocol.GossipSub.ScoreSpec
     Test.Network.LibP2P.Protocol.GossipSub.MessageCacheSpec
     Test.Network.LibP2P.Protocol.GossipSub.HeartbeatSpec
+    Test.Network.LibP2P.Protocol.GossipSub.HandlerSpec
   build-depends:
     base       >= 4.18 && < 5,
     bytestring >= 0.10 && < 0.13,

--- a/src/Network/LibP2P/Protocol/GossipSub/Handler.hs
+++ b/src/Network/LibP2P/Protocol/GossipSub/Handler.hs
@@ -1,0 +1,220 @@
+-- | GossipSub Switch integration handler (Phase 10b).
+--
+-- Bridges the GossipSub Router with the Switch by:
+-- 1. Registering a StreamHandler for inbound /meshsub/1.1.0 streams
+-- 2. Providing a sendRPC callback that opens/reuses outbound streams
+-- 3. Managing lifecycle (heartbeat start/stop)
+--
+-- GossipSub maintains persistent bidirectional RPC streams, unlike
+-- Identify/Ping which are one-shot. Each peer has at most one cached
+-- outbound stream.
+module Network.LibP2P.Protocol.GossipSub.Handler
+  ( -- * Types
+    GossipSubNode (..)
+    -- * Construction
+  , newGossipSubNode
+    -- * Stream handling
+  , handleGossipSubStream
+    -- * Lifecycle
+  , startGossipSub
+  , stopGossipSub
+    -- * Convenience API
+  , gossipJoin
+  , gossipLeave
+  , gossipPublish
+    -- * Constants
+  , gossipSubProtocolId
+  ) where
+
+import Control.Concurrent.Async (Async, cancel)
+import Control.Concurrent.STM
+  ( TVar
+  , atomically
+  , newTVarIO
+  , readTVar
+  , writeTVar
+  , modifyTVar'
+  )
+import Control.Exception (SomeException, catch)
+import Data.ByteString (ByteString)
+import qualified Data.Map.Strict as Map
+import Data.Time.Clock (getCurrentTime)
+import Network.LibP2P.Crypto.PeerId (PeerId)
+import Network.LibP2P.MultistreamSelect.Negotiation
+  ( NegotiationResult (..)
+  , ProtocolId
+  , StreamIO (..)
+  , negotiateInitiator
+  )
+import Network.LibP2P.Protocol.GossipSub.Heartbeat (runHeartbeat)
+import Network.LibP2P.Protocol.GossipSub.Message (readRPCMessage, writeRPCMessage)
+import Network.LibP2P.Protocol.GossipSub.Router
+  ( addPeer
+  , handleRPC
+  , join
+  , leave
+  , newRouter
+  , publish
+  , removePeer
+  )
+import Network.LibP2P.Protocol.GossipSub.Types
+  ( GossipSubParams
+  , GossipSubRouter (..)
+  , PeerProtocol (..)
+  , RPC
+  , Topic
+  , maxRPCSize
+  )
+import Network.LibP2P.Switch.ConnPool (lookupConn)
+import Network.LibP2P.Switch.Switch (removeStreamHandler, setStreamHandler)
+import Network.LibP2P.Switch.Types
+  ( Connection (..)
+  , MuxerSession (..)
+  , Switch (..)
+  )
+import Prelude hiding (join)
+
+-- | GossipSub protocol ID.
+gossipSubProtocolId :: ProtocolId
+gossipSubProtocolId = "/meshsub/1.1.0"
+
+-- | A GossipSub node: Router + Switch integration.
+data GossipSubNode = GossipSubNode
+  { gsnRouter    :: !GossipSubRouter
+  , gsnSwitch    :: !Switch
+  , gsnHeartbeat :: !(TVar (Maybe (Async ())))
+  , gsnStreams   :: !(TVar (Map.Map PeerId StreamIO))  -- ^ Cached outbound streams per peer
+  }
+
+-- | Create a new GossipSub node with a Router wired to the Switch.
+--
+-- The Router's gsSendRPC callback opens/reuses outbound streams to peers
+-- via the Switch's connection pool.
+newGossipSubNode :: Switch -> GossipSubParams -> IO GossipSubNode
+newGossipSubNode sw params = do
+  streamsVar <- newTVarIO Map.empty
+  hbVar <- newTVarIO Nothing
+  -- Create router with real sendRPC that uses the Switch
+  let localPid = swLocalPeerId sw
+  router <- newRouter params localPid (sendRPCviaSwitch sw streamsVar) getCurrentTime
+  pure GossipSubNode
+    { gsnRouter    = router
+    , gsnSwitch    = sw
+    , gsnHeartbeat = hbVar
+    , gsnStreams   = streamsVar
+    }
+
+-- | Send an RPC to a peer via cached or newly opened stream.
+sendRPCviaSwitch :: Switch -> TVar (Map.Map PeerId StreamIO) -> PeerId -> RPC -> IO ()
+sendRPCviaSwitch sw streamsVar pid rpc = do
+  -- Try to use cached stream
+  mCached <- atomically $ Map.lookup pid <$> readTVar streamsVar
+  case mCached of
+    Just stream -> do
+      -- Try sending on cached stream; reopen on failure
+      sendResult <- trySend stream rpc
+      case sendResult of
+        Right () -> pure ()
+        Left _ -> do
+          atomically $ modifyTVar' streamsVar (Map.delete pid)
+          openAndSend sw streamsVar pid rpc
+    Nothing -> openAndSend sw streamsVar pid rpc
+
+-- | Open a new outbound stream to a peer and send an RPC.
+openAndSend :: Switch -> TVar (Map.Map PeerId StreamIO) -> PeerId -> RPC -> IO ()
+openAndSend sw streamsVar pid rpc = do
+  mStream <- openStreamToPeer sw pid
+  case mStream of
+    Nothing -> pure ()  -- No connection to peer; fire-and-forget
+    Just stream -> do
+      atomically $ modifyTVar' streamsVar (Map.insert pid stream)
+      _ <- trySend stream rpc
+      pure ()
+
+-- | Open a new mux stream to a peer and negotiate GossipSub protocol.
+openStreamToPeer :: Switch -> PeerId -> IO (Maybe StreamIO)
+openStreamToPeer sw pid = do
+  mConn <- atomically $ lookupConn (swConnPool sw) pid
+  case mConn of
+    Nothing -> pure Nothing
+    Just conn -> do
+      result <- (Right <$> openAndNegotiate conn) `catch`
+                  (\(_ :: SomeException) -> pure (Left ()))
+      case result of
+        Left () -> pure Nothing
+        Right mStream -> pure mStream
+
+-- | Open a mux stream and negotiate /meshsub/1.1.0.
+openAndNegotiate :: Connection -> IO (Maybe StreamIO)
+openAndNegotiate conn = do
+  stream <- muxOpenStream (connSession conn)
+  negResult <- negotiateInitiator stream [gossipSubProtocolId]
+  case negResult of
+    Accepted _ -> pure (Just stream)
+    NoProtocol -> pure Nothing
+
+-- | Try to send an RPC on a stream, catching exceptions.
+trySend :: StreamIO -> RPC -> IO (Either () ())
+trySend stream rpc =
+  (writeRPCMessage stream rpc >> pure (Right ()))
+    `catch` (\(_ :: SomeException) -> pure (Left ()))
+
+-- | Handle an inbound GossipSub stream.
+--
+-- Reads framed RPCs in a loop and dispatches each to the Router's handleRPC.
+-- On error or EOF, cleans up the peer's cached stream and removes the peer.
+handleGossipSubStream :: GossipSubNode -> StreamIO -> PeerId -> IO ()
+handleGossipSubStream node stream pid = do
+  -- Register peer with router
+  now <- getCurrentTime
+  addPeer (gsnRouter node) pid GossipSubPeer False now
+  -- Read loop
+  readLoop
+  -- Cleanup on disconnect
+  removePeer (gsnRouter node) pid
+  atomically $ modifyTVar' (gsnStreams node) (Map.delete pid)
+  where
+    readLoop = do
+      result <- readRPCMessage stream maxRPCSize
+      case result of
+        Left _ -> pure ()  -- Error/EOF: stop loop
+        Right rpc -> do
+          handleRPC (gsnRouter node) pid rpc
+          readLoop
+
+-- | Start the GossipSub node: register stream handler and start heartbeat.
+startGossipSub :: GossipSubNode -> IO ()
+startGossipSub node = do
+  -- Register inbound stream handler on Switch
+  setStreamHandler (gsnSwitch node) gossipSubProtocolId
+    (handleGossipSubStream node)
+  -- Start heartbeat background thread
+  hbAsync <- runHeartbeat (gsnRouter node)
+  atomically $ writeTVar (gsnHeartbeat node) (Just hbAsync)
+
+-- | Stop the GossipSub node: cancel heartbeat and unregister handler.
+stopGossipSub :: GossipSubNode -> IO ()
+stopGossipSub node = do
+  -- Cancel heartbeat
+  mHb <- atomically $ do
+    hb <- readTVar (gsnHeartbeat node)
+    writeTVar (gsnHeartbeat node) Nothing
+    pure hb
+  case mHb of
+    Just hbAsync -> cancel hbAsync `catch` (\(_ :: SomeException) -> pure ())
+    Nothing -> pure ()
+  -- Unregister stream handler
+  removeStreamHandler (gsnSwitch node) gossipSubProtocolId
+
+-- | Subscribe to a topic.
+gossipJoin :: GossipSubNode -> Topic -> IO ()
+gossipJoin node topic = join (gsnRouter node) topic
+
+-- | Unsubscribe from a topic.
+gossipLeave :: GossipSubNode -> Topic -> IO ()
+gossipLeave node topic = leave (gsnRouter node) topic
+
+-- | Publish a message to a topic (signed with the Switch's identity key).
+gossipPublish :: GossipSubNode -> Topic -> ByteString -> IO ()
+gossipPublish node topic payload =
+  publish (gsnRouter node) topic payload (Just (swIdentityKey (gsnSwitch node)))

--- a/test/Test/Network/LibP2P/Protocol/GossipSub/HandlerSpec.hs
+++ b/test/Test/Network/LibP2P/Protocol/GossipSub/HandlerSpec.hs
@@ -1,0 +1,323 @@
+-- | Tests for GossipSub Switch Handler (Phase 10b).
+--
+-- Tests the Handler module that bridges Router ↔ Switch for persistent
+-- bidirectional RPC streams.
+module Test.Network.LibP2P.Protocol.GossipSub.HandlerSpec (spec) where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (async)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent.STM
+  ( atomically
+  , newTVarIO
+  , readTVar
+  , writeTVar
+  )
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Network.LibP2P.Crypto.Ed25519 (generateKeyPair)
+import Network.LibP2P.Crypto.Key (KeyPair, publicKey)
+import Network.LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import Network.LibP2P.MultistreamSelect.Negotiation
+  ( NegotiationResult (..)
+  , StreamIO (..)
+  , mkMemoryStreamPair
+  , negotiateResponder
+  )
+import Network.LibP2P.Protocol.GossipSub.Handler
+  ( GossipSubNode (..)
+  , gossipJoin
+  , gossipLeave
+  , gossipPublish
+  , gossipSubProtocolId
+  , handleGossipSubStream
+  , newGossipSubNode
+  , startGossipSub
+  , stopGossipSub
+  )
+import Network.LibP2P.Protocol.GossipSub.Message
+  ( readRPCMessage
+  , writeRPCMessage
+  )
+import Network.LibP2P.Protocol.GossipSub.Router (addPeer)
+import Network.LibP2P.Protocol.GossipSub.Types
+  ( GossipSubParams (..)
+  , GossipSubRouter (..)
+  , PeerProtocol (..)
+  , PubSubMessage (..)
+  , RPC (..)
+  , SubOpts (..)
+  , Topic
+  , defaultGossipSubParams
+  , maxRPCSize
+  )
+import Network.LibP2P.Switch.Switch (lookupStreamHandler, newSwitch, setStreamHandler)
+import Network.LibP2P.Switch.Types (Switch (..))
+import System.Timeout (timeout)
+import Test.Hspec
+import Data.Time.Clock (getCurrentTime)
+
+-- | Generate a test identity (PeerId, KeyPair).
+mkTestIdentity :: IO (PeerId, KeyPair)
+mkTestIdentity = do
+  Right kp <- generateKeyPair
+  let pid = fromPublicKey (publicKey kp)
+  pure (pid, kp)
+
+-- | Create a test Switch (no transport needed for handler unit tests).
+mkTestSwitch :: IO (Switch, PeerId)
+mkTestSwitch = do
+  (pid, kp) <- mkTestIdentity
+  sw <- newSwitch pid kp
+  pure (sw, pid)
+
+-- | Simple params with short heartbeat (1s) for testing.
+testParams :: GossipSubParams
+testParams = defaultGossipSubParams
+  { paramHeartbeatInterval = 10.0  -- Long interval so heartbeat doesn't interfere
+  }
+
+-- | Empty RPC for testing.
+emptyRPC :: RPC
+emptyRPC = RPC
+  { rpcSubscriptions = []
+  , rpcPublish       = []
+  , rpcControl       = Nothing
+  }
+
+-- | Create an RPC with a subscription announcement.
+subscribeRPC :: Topic -> RPC
+subscribeRPC topic = emptyRPC
+  { rpcSubscriptions = [SubOpts True topic]
+  }
+
+-- | Create an RPC with an unsubscription announcement.
+unsubscribeRPC :: Topic -> RPC
+unsubscribeRPC topic = emptyRPC
+  { rpcSubscriptions = [SubOpts False topic]
+  }
+
+spec :: Spec
+spec = do
+  describe "newGossipSubNode" $ do
+    it "creates node with empty state" $ do
+      (sw, _pid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      streams <- atomically $ readTVar (gsnStreams node)
+      Map.null streams `shouldBe` True
+      hb <- atomically $ readTVar (gsnHeartbeat node)
+      case hb of
+        Nothing -> pure ()
+        Just _  -> expectationFailure "heartbeat should not be running"
+
+  describe "handleGossipSubStream" $ do
+    it "processes subscription RPCs via memory streams" $ do
+      (sw, _localPid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      (remotePid, _kp) <- mkTestIdentity
+      -- Create memory stream pair: remote side writes, handler reads
+      (remoteStream, handlerStream) <- mkMemoryStreamPair
+      -- Spawn handler in background (blocks on read loop)
+      _ <- async $ handleGossipSubStream node handlerStream remotePid
+      -- Send a subscription RPC from remote
+      writeRPCMessage remoteStream (subscribeRPC "test-topic")
+      -- Give handler time to process
+      threadDelay 200000
+      -- Verify peer is registered in router
+      peers <- atomically $ readTVar (gsPeers (gsnRouter node))
+      Map.member remotePid peers `shouldBe` True
+
+    it "processes publish RPCs and delivers to onMessage callback" $ do
+      (sw, _localPid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      (remotePid, _kp) <- mkTestIdentity
+      -- Set up message callback
+      msgMVar <- newEmptyMVar
+      atomically $ writeTVar (gsOnMessage (gsnRouter node))
+        (\topic msg -> putMVar msgMVar (topic, msgData msg))
+      -- Subscribe the router to the topic so it accepts messages
+      gossipJoin node "pub-topic"
+      -- Register remote peer and subscribe them
+      now <- getCurrentTime
+      addPeer (gsnRouter node) remotePid GossipSubPeer False now
+      (remoteStream, handlerStream) <- mkMemoryStreamPair
+      -- Spawn handler
+      _ <- async $ handleGossipSubStream node handlerStream remotePid
+      -- Send a publish RPC
+      let msg = PubSubMessage
+            { msgFrom      = Just (BS.pack [1,2,3])
+            , msgData      = "hello gossipsub"
+            , msgSeqNo     = Just (BS.pack [0,0,0,0,0,0,0,1])
+            , msgTopic     = "pub-topic"
+            , msgSignature = Nothing
+            , msgKey       = Nothing
+            }
+      writeRPCMessage remoteStream (emptyRPC { rpcPublish = [msg] })
+      -- Wait for callback
+      result <- timeout 2000000 $ takeMVar msgMVar
+      case result of
+        Nothing -> expectationFailure "onMessage callback not invoked"
+        Just (topic, dat) -> do
+          topic `shouldBe` "pub-topic"
+          dat `shouldBe` "hello gossipsub"
+
+  describe "sendRPC" $ do
+    it "opens outbound stream and writes framed RPC" $ do
+      (sw, _localPid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      (remotePid, _kp) <- mkTestIdentity
+      -- Simulate: manually set up a mock connection in the pool
+      -- For unit testing sendRPC, we inject a stream directly
+      (nodeStream, remoteReadStream) <- mkMemoryStreamPair
+      atomically $ do
+        streams <- readTVar (gsnStreams node)
+        writeTVar (gsnStreams node) (Map.insert remotePid nodeStream streams)
+      -- Send RPC via the cached stream
+      let rpc = subscribeRPC "outbound-topic"
+      gsSendRPC (gsnRouter node) remotePid rpc
+      -- Read from the other side
+      result <- timeout 2000000 $ readRPCMessage remoteReadStream maxRPCSize
+      case result of
+        Nothing -> expectationFailure "timeout reading RPC"
+        Just (Left err) -> expectationFailure $ "decode error: " ++ err
+        Just (Right received) -> do
+          rpcSubscriptions received `shouldBe` [SubOpts True "outbound-topic"]
+
+    it "reuses cached stream on second call" $ do
+      (sw, _localPid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      (remotePid, _kp) <- mkTestIdentity
+      -- Pre-cache a stream
+      (nodeStream, remoteReadStream) <- mkMemoryStreamPair
+      atomically $ do
+        streams <- readTVar (gsnStreams node)
+        writeTVar (gsnStreams node) (Map.insert remotePid nodeStream streams)
+      -- Send two RPCs
+      gsSendRPC (gsnRouter node) remotePid (subscribeRPC "topic1")
+      gsSendRPC (gsnRouter node) remotePid (subscribeRPC "topic2")
+      -- Read both from remote side
+      r1 <- timeout 2000000 $ readRPCMessage remoteReadStream maxRPCSize
+      r2 <- timeout 2000000 $ readRPCMessage remoteReadStream maxRPCSize
+      case (r1, r2) of
+        (Just (Right rpc1), Just (Right rpc2)) -> do
+          rpcSubscriptions rpc1 `shouldBe` [SubOpts True "topic1"]
+          rpcSubscriptions rpc2 `shouldBe` [SubOpts True "topic2"]
+        _ -> expectationFailure "failed to read both RPCs"
+
+  describe "startGossipSub" $ do
+    it "registers handler and starts heartbeat" $ do
+      (sw, _pid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      -- Before start: no handler, no heartbeat
+      handlerBefore <- lookupStreamHandler sw gossipSubProtocolId
+      case handlerBefore of
+        Nothing -> pure ()
+        Just _  -> expectationFailure "handler should not be registered before start"
+      hbBefore <- atomically $ readTVar (gsnHeartbeat node)
+      case hbBefore of
+        Nothing -> pure ()
+        Just _  -> expectationFailure "heartbeat should not be running before start"
+      -- Start
+      startGossipSub node
+      -- After start: handler registered, heartbeat running
+      handlerAfter <- lookupStreamHandler sw gossipSubProtocolId
+      case handlerAfter of
+        Nothing -> expectationFailure "handler should be registered"
+        Just _  -> pure ()
+      hbAfter <- atomically $ readTVar (gsnHeartbeat node)
+      case hbAfter of
+        Nothing -> expectationFailure "heartbeat should be running"
+        Just _  -> pure ()
+      -- Cleanup
+      stopGossipSub node
+
+  describe "stopGossipSub" $ do
+    it "cancels heartbeat and unregisters handler" $ do
+      (sw, _pid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      startGossipSub node
+      -- Verify running state
+      hbRunning <- atomically $ readTVar (gsnHeartbeat node)
+      case hbRunning of
+        Nothing -> expectationFailure "heartbeat should be running after start"
+        Just _  -> pure ()
+      -- Stop
+      stopGossipSub node
+      -- Verify stopped state
+      handlerAfter <- lookupStreamHandler sw gossipSubProtocolId
+      case handlerAfter of
+        Nothing -> pure ()
+        Just _  -> expectationFailure "handler should be unregistered after stop"
+      hbAfter <- atomically $ readTVar (gsnHeartbeat node)
+      case hbAfter of
+        Nothing -> pure ()
+        Just _  -> expectationFailure "heartbeat should not be running after stop"
+
+  describe "Two-node exchange" $ do
+    it "two nodes exchange subscription announcements via memory streams" $ do
+      -- Node A
+      (swA, pidA) <- mkTestSwitch
+      nodeA <- newGossipSubNode swA testParams
+      -- Node B
+      (swB, pidB) <- mkTestSwitch
+      nodeB <- newGossipSubNode swB testParams
+      -- Create paired streams (A→B and B→A)
+      (streamAtoB, streamBfromA) <- mkMemoryStreamPair
+      (streamBtoA, streamAfromB) <- mkMemoryStreamPair
+      -- Spawn stream handlers
+      _ <- async $ handleGossipSubStream nodeB streamBfromA pidA
+      _ <- async $ handleGossipSubStream nodeA streamAfromB pidB
+      -- Inject cached outbound streams for sendRPC
+      atomically $ do
+        writeTVar (gsnStreams nodeA) (Map.singleton pidB streamAtoB)
+        writeTVar (gsnStreams nodeB) (Map.singleton pidA streamBtoA)
+      -- Node A subscribes to topic, which sends subscription RPCs
+      gossipJoin nodeA "shared-topic"
+      -- Give time for RPCs to propagate
+      threadDelay 500000
+      -- Node B should see A's subscription
+      peersB <- atomically $ readTVar (gsPeers (gsnRouter nodeB))
+      case Map.lookup pidA peersB of
+        Nothing -> expectationFailure "nodeB should know about nodeA"
+        Just _  -> pure ()  -- Peer registered by handleGossipSubStream
+
+    it "publish on one node delivers message to the other" $ do
+      -- Node A (publisher)
+      (swA, pidA) <- mkTestSwitch
+      nodeA <- newGossipSubNode swA testParams
+      -- Node B (subscriber)
+      (swB, pidB) <- mkTestSwitch
+      nodeB <- newGossipSubNode swB testParams
+      -- Set up message callback on Node B
+      msgMVar <- newEmptyMVar
+      atomically $ writeTVar (gsOnMessage (gsnRouter nodeB))
+        (\topic msg -> putMVar msgMVar (topic, msgData msg))
+      -- Create paired streams
+      (streamAtoB, streamBfromA) <- mkMemoryStreamPair
+      (streamBtoA, streamAfromB) <- mkMemoryStreamPair
+      -- Spawn stream handlers (registers peers in each router)
+      _ <- async $ handleGossipSubStream nodeB streamBfromA pidA
+      _ <- async $ handleGossipSubStream nodeA streamAfromB pidB
+      -- Inject cached outbound streams
+      atomically $ do
+        writeTVar (gsnStreams nodeA) (Map.singleton pidB streamAtoB)
+        writeTVar (gsnStreams nodeB) (Map.singleton pidA streamBtoA)
+      -- Let handlers register peers
+      threadDelay 200000
+      -- Both subscribe to the topic (this notifies known peers)
+      gossipJoin nodeA "pubtest"
+      gossipJoin nodeB "pubtest"
+      threadDelay 500000  -- Let subscription RPCs propagate
+      -- Verify: nodeA's router should know B subscribes to "pubtest"
+      -- (because B's join sent subscription RPC to A via stream)
+      -- Now publish from A. With floodPublish=True, publish sends to
+      -- ALL peers subscribed to the topic. B should receive it.
+      gossipPublish nodeA "pubtest" "hello from A"
+      -- Wait for B to receive via handleRPC -> onMessage callback
+      result <- timeout 3000000 $ takeMVar msgMVar
+      case result of
+        Nothing -> expectationFailure "nodeB did not receive message"
+        Just (topic, dat) -> do
+          topic `shouldBe` "pubtest"
+          dat `shouldBe` "hello from A"


### PR DESCRIPTION
## Summary
- Creates `GossipSub.Handler` module bridging GossipSub Router with the Switch
- `GossipSubNode` manages persistent bidirectional RPC streams (cached outbound streams per peer)
- `sendRPCviaSwitch` with lazy stream cache + reopen-on-failure pattern
- `handleGossipSubStream` read loop for inbound streams
- `startGossipSub`/`stopGossipSub` lifecycle management
- `gossipJoin`/`gossipLeave`/`gossipPublish` convenience API
- 9 new tests (538 total)

Replaces closed PR #91 (base branch was deleted during merge chain).

Closes #87

## Test plan
- [x] `cabal build` compiles without errors
- [x] `cabal test` passes all 538 tests
- [x] Handler unit tests in HandlerSpec.hs

🤖 Generated with [Claude Code](https://claude.com/claude-code)