### PR TITLE
Add public API facade and README (Phase 10d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,121 @@
 # libp2p-hs
+
+A Haskell implementation of the [libp2p](https://libp2p.io/) modular peer-to-peer networking stack.
+
+## Quickstart
+
+```haskell
+import Network.LibP2P
+import Network.LibP2P.Crypto.Key (publicKey)
+
+main :: IO ()
+main = do
+  -- Generate identity
+  Right kp <- generateKeyPair
+  let pid = fromPublicKey (publicKey kp)
+
+  -- Create and configure switch
+  sw <- newSwitch pid kp
+  tcp <- newTCPTransport
+  addTransport sw tcp
+  registerIdentifyHandlers sw
+  registerPingHandler sw
+
+  -- Start listening
+  addrs <- switchListen sw defaultConnectionGater
+    [Multiaddr [IP4 0x7f000001, TCP 0]]
+  putStrLn $ "Listening on: " ++ show addrs
+
+  -- Dial a remote peer
+  -- result <- dial sw remotePeerId [remoteAddr]
+
+  -- Clean shutdown
+  switchClose sw
+```
+
+## Architecture
+
+```
+Application (GossipSub, DHT, Identify, Ping)
+         |
+   multistream-select (protocol negotiation)
+         |
+   Yamux (stream multiplexing)
+         |
+   multistream-select (muxer negotiation)
+         |
+   Noise XX (encryption + authentication)
+         |
+   multistream-select (security negotiation)
+         |
+   TCP (transport)
+```
+
+The **Switch** is the central coordinator managing the full upgrade pipeline,
+connection pool, protocol handler dispatch, and resource limits.
+
+## Component Status
+
+| Component | Module | Status |
+|-----------|--------|--------|
+| Varint / Multihash | `Core.Varint`, `Core.Multihash` | Complete |
+| Multiaddr | `Multiaddr.*` | Complete |
+| Peer Identity (Ed25519) | `Crypto.*` | Complete |
+| multistream-select | `MultistreamSelect.*` | Complete |
+| Noise XX handshake | `Security.Noise.*` | Complete |
+| Yamux multiplexer | `Mux.Yamux.*` | Complete |
+| TCP transport | `Transport.TCP` | Complete |
+| Switch (core + dial + listen) | `Switch.*` | Complete |
+| Resource manager | `Switch.ResourceManager` | Complete |
+| Identify protocol | `Protocol.Identify.*` | Complete |
+| Ping protocol | `Protocol.Ping.*` | Complete |
+| Kademlia DHT | `DHT.*` | Complete |
+| AutoNAT | `NAT.AutoNAT.*` | Complete |
+| Circuit Relay v2 | `NAT.Relay.*` | Complete |
+| DCUtR | `NAT.DCUtR.*` | Complete |
+| GossipSub | `Protocol.GossipSub.*` | Complete |
+| Public API | `Network.LibP2P` | Complete |
+
+## Building
+
+Requires **GHC 9.10.x** (the `cacophony` dependency requires `base < 4.22`).
+
+```bash
+# Build
+cabal build
+
+# Run tests
+cabal test
+
+# Build documentation
+cabal haddock
+```
+
+## Tests
+
+547 tests covering all components: unit tests, property tests, and end-to-end
+integration tests over real TCP connections.
+
+```bash
+# Run all tests
+cabal test --test-show-details=streaming
+
+# Run specific test module
+cabal test --test-option="--match=Integration"
+```
+
+## Documentation
+
+The `docs/` directory contains a 12-chapter implementation-level textbook
+covering wire formats, protobuf definitions, handshake sequences, and
+byte-level structures for every component.
+
+## Specification
+
+Based on the [libp2p specification](https://github.com/libp2p/specs).
+Reference implementations: [go-libp2p](https://github.com/libp2p/go-libp2p),
+[rust-libp2p](https://github.com/libp2p/rust-libp2p).
+
+## License
+
+MIT

--- a/src/Network/LibP2P.hs
+++ b/src/Network/LibP2P.hs
@@ -1,7 +1,102 @@
 -- | libp2p-hs: Haskell implementation of the libp2p networking stack.
 --
--- This is the public API facade. As components are implemented,
--- they will be re-exported from here.
+-- This is the public API facade for the library. Import this module
+-- for the common types and functions needed to build a libp2p node:
+--
+-- @
+-- import Network.LibP2P
+--
+-- main :: IO ()
+-- main = do
+--   (pid, kp) <- generateAndPeerId
+--   sw <- newSwitch pid kp
+--   tcp <- newTCPTransport
+--   addTransport sw tcp
+--   registerIdentifyHandlers sw
+--   registerPingHandler sw
+--   addrs <- switchListen sw defaultConnectionGater [fromText "/ip4/127.0.0.1/tcp/0"]
+--   print addrs
+--   -- ... dial other peers, etc.
+--   switchClose sw
+-- @
 module Network.LibP2P
-  (
+  ( -- * Identity
+    PeerId
+  , KeyPair
+  , generateKeyPair
+  , fromPublicKey
+
+    -- * Addressing
+  , Multiaddr (..)
+  , Protocol (..)
+
+    -- * Switch (central coordinator)
+  , Switch
+  , newSwitch
+  , addTransport
+  , switchListen
+  , switchListenAddrs
+  , switchClose
+  , dial
+  , DialError (..)
+  , setStreamHandler
+  , removeStreamHandler
+  , StreamIO (..)
+  , StreamHandler
+  , ProtocolId
+  , Connection (..)
+
+    -- * Transport
+  , Transport (..)
+  , newTCPTransport
+
+    -- * Connection gating
+  , ConnectionGater (..)
+  , defaultConnectionGater
+
+    -- * Identify protocol
+  , registerIdentifyHandlers
+  , requestIdentify
+
+    -- * Ping protocol
+  , registerPingHandler
+  , sendPing
+  , PingResult (..)
+  , PingError (..)
+
+    -- * GossipSub
+  , GossipSubNode (..)
+  , GossipSubParams (..)
+  , defaultGossipSubParams
+  , newGossipSubNode
+  , startGossipSub
+  , stopGossipSub
+  , gossipJoin
+  , gossipLeave
+  , gossipPublish
   ) where
+
+import Network.LibP2P.Crypto.Ed25519 (generateKeyPair)
+import Network.LibP2P.Crypto.Key (KeyPair)
+import Network.LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import Network.LibP2P.Multiaddr.Multiaddr (Multiaddr (..))
+import Network.LibP2P.Multiaddr.Protocol (Protocol (..))
+import Network.LibP2P.MultistreamSelect.Negotiation (ProtocolId, StreamIO (..))
+import Network.LibP2P.Protocol.GossipSub.Handler
+  ( GossipSubNode (..)
+  , gossipJoin
+  , gossipLeave
+  , gossipPublish
+  , newGossipSubNode
+  , startGossipSub
+  , stopGossipSub
+  )
+import Network.LibP2P.Protocol.GossipSub.Types (GossipSubParams (..), defaultGossipSubParams)
+import Network.LibP2P.Protocol.Identify.Identify (registerIdentifyHandlers, requestIdentify)
+import Network.LibP2P.Protocol.Ping.Ping (PingError (..), PingResult (..), registerPingHandler, sendPing)
+import Network.LibP2P.Switch.Dial (dial)
+import Network.LibP2P.Switch.Listen (ConnectionGater (..), defaultConnectionGater, switchListen, switchListenAddrs)
+import Network.LibP2P.Switch.Switch (addTransport, newSwitch, removeStreamHandler, setStreamHandler, switchClose)
+import Network.LibP2P.Switch.Types (Connection (..), DialError (..), StreamHandler, Switch)
+import Network.LibP2P.Transport.TCP (newTCPTransport)
+import Network.LibP2P.Transport.Transport (Transport (..))


### PR DESCRIPTION
## Summary
- `Network.LibP2P` public API facade with curated re-exports (Identity, Addressing, Switch, Transport, Protocols)
- Comprehensive README.md with quickstart example, architecture diagram, component status table, build instructions
- No new tests (purely re-exports + documentation)

Replaces closed PR #93 (base branch was deleted during merge chain).

Closes #89

## Test plan
- [x] `cabal build` compiles without errors
- [x] `cabal test` passes all 547 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)