### PR TITLE
Add Haddock API documentation with GitHub Pages deployment

### DIFF
--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -1,0 +1,56 @@
+name: Haddock
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  haddock:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.10.1'
+          cabal-version: '3.12'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-haddock-${{ hashFiles('libp2p-hs.cabal', 'cabal.project') }}
+          restore-keys: ${{ runner.os }}-haddock-
+
+      - name: Build dependencies
+        run: cabal update && cabal build --only-dependencies
+
+      - name: Generate Haddock
+        run: cabal haddock --haddock-hyperlink-source --haddock-quickjump --haddock-html-location='https://hackage.haskell.org/package/$pkg-$version/docs'
+
+      - name: Prepare docs directory
+        run: |
+          HADDOCK_DIR=$(find dist-newstyle -path '*/doc/html/libp2p-hs' -type d | head -1)
+          cp -r "$HADDOCK_DIR" docs-out
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-out
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ cabal test --test-option="--match=Integration"
 
 ## Documentation
 
+**[API Reference](https://adust09.github.io/libp2p-hs/)** — Generated Haddock documentation.
+
 The `docs/` directory contains a 12-chapter implementation-level textbook
 covering wire formats, protobuf definitions, handshake sequences, and
 byte-level structures for every component.


### PR DESCRIPTION
## Summary

- Add `.github/workflows/haddock.yml` — generates Haddock docs on push to `main` and deploys to GitHub Pages
- Add API Reference link to `README.md` pointing to `https://adust09.github.io/libp2p-hs/`

## Details

The workflow:
1. Builds with GHC 9.10.1 (matching CI)
2. Generates Haddock with `--haddock-hyperlink-source` (source links), `--haddock-quickjump` (search), and `--haddock-html-location` (Hackage cross-references)
3. Deploys via `actions/deploy-pages@v4` (no `gh-pages` branch needed)

## Post-merge setup

After merging, enable GitHub Pages in **Settings → Pages → Source → GitHub Actions**.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)