### PR TITLE
Remove unused imports and variables from Haddock warnings

### DIFF
--- a/src/Network/LibP2P/DHT/DHT.hs
+++ b/src/Network/LibP2P/DHT/DHT.hs
@@ -29,13 +29,12 @@ module Network.LibP2P.DHT.DHT
 
 import Control.Concurrent.STM
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Data.Time (UTCTime)
 import Network.LibP2P.Crypto.PeerId (PeerId, peerIdBytes)
-import Network.LibP2P.DHT.Distance (peerIdToKey, sortByDistance)
+import Network.LibP2P.DHT.Distance (peerIdToKey)
 import Network.LibP2P.DHT.Message
 import Network.LibP2P.DHT.RoutingTable (RoutingTable, closestPeers, newRoutingTable)
 import Network.LibP2P.DHT.Types
@@ -164,7 +163,7 @@ handlePutValue node msg = do
 
 -- | ADD_PROVIDER: verify sender and store provider record.
 handleAddProvider :: DHTNode -> DHTMessage -> PeerId -> IO DHTMessage
-handleAddProvider node msg remotePeerId = do
+handleAddProvider _node msg remotePeerId = do
   -- Verify that provider peers match sender's Peer ID
   let validProviders = filter (\p -> dhtPeerId p == peerIdBytes remotePeerId) (msgProviderPeers msg)
   if null validProviders

--- a/src/Network/LibP2P/DHT/Lookup.hs
+++ b/src/Network/LibP2P/DHT/Lookup.hs
@@ -20,14 +20,13 @@ import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.STM
 import Control.Exception (SomeException, catch)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Time (UTCTime, getCurrentTime)
-import Network.LibP2P.Crypto.PeerId (PeerId (..), peerIdBytes)
-import Network.LibP2P.DHT.DHT (DHTNode (..), ProviderEntry (..), Validator (..), storeRecord)
+import Network.LibP2P.Crypto.PeerId (PeerId (..))
+import Network.LibP2P.DHT.DHT (DHTNode (..), ProviderEntry (..), Validator (..))
 import Network.LibP2P.DHT.Distance (peerIdToKey, xorDistance, sortByDistance)
 import Network.LibP2P.DHT.Message
 import Network.LibP2P.DHT.RoutingTable (RoutingTable, closestPeers, insertPeer, allPeers)

--- a/src/Network/LibP2P/Protocol/GossipSub/Handler.hs
+++ b/src/Network/LibP2P/Protocol/GossipSub/Handler.hs
@@ -72,7 +72,6 @@ import Network.LibP2P.Switch.Types
   , MuxerSession (..)
   , Switch (..)
   )
-import Prelude hiding (join)
 
 -- | GossipSub protocol ID.
 gossipSubProtocolId :: ProtocolId

--- a/src/Network/LibP2P/Protocol/Identify/Identify.hs
+++ b/src/Network/LibP2P/Protocol/Identify/Identify.hs
@@ -29,7 +29,6 @@ import Control.Concurrent.STM (atomically, readTVar, writeTVar)
 import Control.Exception (SomeException, catch)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
-import Data.Text (Text)
 import Network.LibP2P.Crypto.PeerId (PeerId)
 import Network.LibP2P.Crypto.Protobuf (encodePublicKey)
 import Network.LibP2P.Crypto.Key (kpPublic)
@@ -52,7 +51,6 @@ import Network.LibP2P.Switch.Types
   , Connection (..)
   , MuxerSession (..)
   , Switch (..)
-  , StreamHandler
   )
 
 -- | Identify protocol ID.

--- a/src/Network/LibP2P/Security/Noise/Session.hs
+++ b/src/Network/LibP2P/Security/Noise/Session.hs
@@ -27,7 +27,7 @@ import Data.ByteString (ByteString)
 type CacophonyState = NoiseState ChaChaPoly1305 Curve25519 SHA256
 
 -- | A post-handshake transport session for encrypted communication.
-newtype NoiseSession = NoiseSession { nsState :: CacophonyState }
+newtype NoiseSession = NoiseSession CacophonyState
 
 -- | Create a NoiseSession from a completed handshake state.
 mkNoiseSession :: CacophonyState -> NoiseSession


### PR DESCRIPTION
## Summary

- Remove 10 unused import/variable warnings detected by the Haddock CI workflow

## Changes

| File | Fix |
|------|-----|
| `DHT/Lookup.hs` | Remove unused `peerIdBytes`, `storeRecord`, `qualified BS` |
| `DHT/DHT.hs` | Remove unused `sortByDistance`, `qualified BS`; prefix unused `node` with `_` |
| `GossipSub/Handler.hs` | Remove unnecessary `Prelude hiding (join)` (Prelude doesn't export `join` in base-4.20) |
| `Identify/Identify.hs` | Remove unused `Data.Text` and `StreamHandler` imports |
| `Noise/Session.hs` | Remove unused `nsState` record accessor (use plain newtype) |

## Test plan

- [x] `cabal build` succeeds with no new warnings
- [x] `cabal test` — 551 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)