### PR TITLE
Add PeerId verification after dial

### DIFF
--- a/src/Network/LibP2P/Switch/Types.hs
+++ b/src/Network/LibP2P/Switch/Types.hs
@@ -81,6 +81,7 @@ data DialError
   | DialUpgradeFailed !String -- ^ Connection upgrade pipeline failed
   | DialSwitchClosed          -- ^ Switch has been shut down
   | DialResourceLimit !ResourceError  -- ^ Resource limit exceeded
+  | DialPeerIdMismatch !PeerId !PeerId  -- ^ Expected vs actual remote PeerId
   deriving (Show, Eq)
 
 -- | Per-peer dial backoff state (docs/08-switch.md §Dial Backoff).


### PR DESCRIPTION
## Summary
- Verify `connPeerId` matches target `remotePeerId` after upgrade, before broadcasting to waiting threads
- Add `DialPeerIdMismatch !PeerId !PeerId` variant to `DialError`
- On mismatch: close mux session, release resources, record backoff

## Test plan
- [x] Dial to wrong peer returns `DialPeerIdMismatch` with expected/actual PeerIds (new test)
- [x] All 558 tests pass (557 existing + 1 new)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)