### PR TITLE
Add Noise identity_sig verification against remote static key

### DIFF
--- a/src/Network/LibP2P/Security/Noise/Handshake.hs
+++ b/src/Network/LibP2P/Security/Noise/Handshake.hs
@@ -23,6 +23,8 @@ module Network.LibP2P.Security.Noise.Handshake
   , writeHandshakeMsg
   , readHandshakeMsg
   , sessionComplete
+    -- * Remote static key extraction
+  , getRemoteNoiseStaticKey
     -- * Convenience
   , performFullHandshake
   , performFullHandshakeWithSessions
@@ -39,6 +41,7 @@ import Crypto.Noise
   , handshakeComplete
   , noiseState
   , readMessage
+  , remoteStaticKey
   , setLocalEphemeral
   , setLocalStatic
   , writeMessage
@@ -200,6 +203,13 @@ readHandshakeMsg hs ciphertext =
           Left $ "readHandshakeMsg: " <> show ex
         NoiseResultNeedPSK _ ->
           Left "readHandshakeMsg: unexpected PSK request"
+
+-- | Extract the remote party's Noise static public key from the handshake state.
+-- Returns Just after the remote static key has been transmitted (msg2 for initiator,
+-- msg3 for responder in XX pattern).
+getRemoteNoiseStaticKey :: HandshakeState -> Maybe ByteString
+getRemoteNoiseStaticKey hs =
+  convert . dhPubToBytes <$> remoteStaticKey (hsNoiseState hs)
 
 -- | Check whether the handshake is complete.
 sessionComplete :: HandshakeState -> Bool


### PR DESCRIPTION
## Summary
- Add `getRemoteNoiseStaticKey` helper using cacophony's `remoteStaticKey` API
- Verify `identity_sig` in both `performInitiatorHandshake` (after msg2) and `performResponderHandshake` (after msg3)
- Replaces placeholder forged-sig test with real MitM scenario test (replayed identity payload with wrong Noise key)

## Security impact
Without this fix, authentication was incomplete: an attacker could replay a legitimate identity payload while running their own Noise session, impersonating any peer.

## Test plan
- [x] Replayed identity payload detected by verifyStaticKey (MitM scenario, new test)
- [x] Valid identity signature passes verifyStaticKey (new test)
- [x] Existing handshake + upgrade integration tests still pass
- [x] All 559 tests pass

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)