### PR TITLE
Add streamClose to StreamIO and close stream in handleIdentify

### DIFF
--- a/src/Network/LibP2P/Protocol/Identify/Identify.hs
+++ b/src/Network/LibP2P/Protocol/Identify/Identify.hs
@@ -70,7 +70,7 @@ handleIdentify sw stream _remotePeerId = do
   info <- buildLocalIdentify sw Nothing
   let encoded = encodeIdentify info
   streamWrite stream encoded
-  -- Stream closure (by muxer) signals end of message
+  streamClose stream  -- Signal EOF so the remote side's readUntilEOF terminates
 
 -- | Request Identify from a remote peer (initiator side).
 --

--- a/src/Network/LibP2P/Switch/Upgrade.hs
+++ b/src/Network/LibP2P/Switch/Upgrade.hs
@@ -185,6 +185,7 @@ noiseSessionToStreamIO
 noiseSessionToStreamIO sendRef recvRef bufRef rawIO = StreamIO
   { streamWrite = encryptAndWrite sendRef rawIO
   , streamReadByte = decryptAndReadByte recvRef bufRef rawIO
+  , streamClose = pure ()  -- Encryption layer does not own the connection
   }
 
 -- | Encrypt plaintext and write as a framed Noise message.
@@ -263,6 +264,9 @@ yamuxStreamToStreamIO yamuxStream = do
           else do
             writeIORef readBuf (BS.tail buf)
             pure (BS.head buf)
+    , streamClose = do
+        _ <- YS.streamClose yamuxStream  -- Sends FIN flag
+        pure ()
     }
 
 -- | Upgrade an outbound (dialer) raw connection.

--- a/src/Network/LibP2P/Transport/TCP.hs
+++ b/src/Network/LibP2P/Transport/TCP.hs
@@ -119,6 +119,7 @@ socketToStreamIO sock = StreamIO
       if BS.null bs
         then fail "socketToStreamIO: connection closed"
         else pure (BS.head bs)
+  , streamClose = NS.close sock
   }
 
 -- | Convert a SockAddr to a Multiaddr.

--- a/test/Test/Network/LibP2P/DHT/DHTSpec.hs
+++ b/test/Test/Network/LibP2P/DHT/DHTSpec.hs
@@ -89,10 +89,12 @@ mkStreamPair = do
   let streamA = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q2)
+        , streamClose = pure ()
         }
       streamB = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q1)
+        , streamClose = pure ()
         }
   pure (streamA, streamB)
 

--- a/test/Test/Network/LibP2P/DHT/MessageSpec.hs
+++ b/test/Test/Network/LibP2P/DHT/MessageSpec.hs
@@ -17,10 +17,12 @@ mkStreamPair = do
   let streamA = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q2)
+        , streamClose = pure ()
         }
       streamB = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q1)
+        , streamClose = pure ()
         }
   pure (streamA, streamB)
 

--- a/test/Test/Network/LibP2P/NAT/AutoNAT/AutoNATSpec.hs
+++ b/test/Test/Network/LibP2P/NAT/AutoNAT/AutoNATSpec.hs
@@ -23,10 +23,12 @@ mkStreamPair = do
   let streamA = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q2)
+        , streamClose = pure ()
         }
       streamB = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q1)
+        , streamClose = pure ()
         }
   pure (streamA, streamB)
 

--- a/test/Test/Network/LibP2P/NAT/AutoNAT/MessageSpec.hs
+++ b/test/Test/Network/LibP2P/NAT/AutoNAT/MessageSpec.hs
@@ -16,10 +16,12 @@ mkStreamPair = do
   let streamA = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q2)
+        , streamClose = pure ()
         }
       streamB = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q1)
+        , streamClose = pure ()
         }
   pure (streamA, streamB)
 

--- a/test/Test/Network/LibP2P/NAT/DCUtR/DCUtRSpec.hs
+++ b/test/Test/Network/LibP2P/NAT/DCUtR/DCUtRSpec.hs
@@ -21,10 +21,12 @@ mkStreamPair = do
   let streamA = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q2)
+        , streamClose = pure ()
         }
       streamB = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q1)
+        , streamClose = pure ()
         }
   pure (streamA, streamB)
 

--- a/test/Test/Network/LibP2P/NAT/DCUtR/MessageSpec.hs
+++ b/test/Test/Network/LibP2P/NAT/DCUtR/MessageSpec.hs
@@ -16,10 +16,12 @@ mkStreamPair = do
   let streamA = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q2)
+        , streamClose = pure ()
         }
       streamB = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q1)
+        , streamClose = pure ()
         }
   pure (streamA, streamB)
 

--- a/test/Test/Network/LibP2P/NAT/Relay/ClientSpec.hs
+++ b/test/Test/Network/LibP2P/NAT/Relay/ClientSpec.hs
@@ -19,10 +19,12 @@ mkStreamPair = do
   let streamA = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q2)
+        , streamClose = pure ()
         }
       streamB = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q1)
+        , streamClose = pure ()
         }
   pure (streamA, streamB)
 

--- a/test/Test/Network/LibP2P/NAT/Relay/MessageSpec.hs
+++ b/test/Test/Network/LibP2P/NAT/Relay/MessageSpec.hs
@@ -16,10 +16,12 @@ mkStreamPair = do
   let streamA = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q2)
+        , streamClose = pure ()
         }
       streamB = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q1)
+        , streamClose = pure ()
         }
   pure (streamA, streamB)
 

--- a/test/Test/Network/LibP2P/NAT/Relay/RelaySpec.hs
+++ b/test/Test/Network/LibP2P/NAT/Relay/RelaySpec.hs
@@ -21,10 +21,12 @@ mkStreamPair = do
   let streamA = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q2)
+        , streamClose = pure ()
         }
       streamB = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q1)
+        , streamClose = pure ()
         }
   pure (streamA, streamB)
 

--- a/test/Test/Network/LibP2P/Protocol/GossipSub/MessageSpec.hs
+++ b/test/Test/Network/LibP2P/Protocol/GossipSub/MessageSpec.hs
@@ -18,10 +18,12 @@ mkStreamPair = do
   let streamA = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q2)
+        , streamClose = pure ()
         }
       streamB = StreamIO
         { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
         , streamReadByte = atomically (readTQueue q1)
+        , streamClose = pure ()
         }
   pure (streamA, streamB)
 

--- a/test/Test/Network/LibP2P/Protocol/Identify/IdentifySpec.hs
+++ b/test/Test/Network/LibP2P/Protocol/Identify/IdentifySpec.hs
@@ -15,6 +15,7 @@ import Control.Concurrent.STM
   )
 import Control.Exception (throwIO)
 import qualified Data.ByteString as BS
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
 import Network.LibP2P.Crypto.Ed25519 (generateKeyPair)
 import Network.LibP2P.Crypto.Key (kpPublic)
@@ -39,9 +40,9 @@ mkTestSwitch = do
   setStreamHandler sw "/test/2.0.0" (\_ _ -> pure ())
   pure sw
 
--- | Create a stream pair where the writer can signal EOF.
+-- | Create a stream pair where the writer can signal EOF via streamClose.
 -- After close is called, reads on the other side throw an IOError.
-mkClosableStreamPair :: IO (StreamIO, IO (), StreamIO)
+mkClosableStreamPair :: IO (StreamIO, StreamIO)
 mkClosableStreamPair = do
   qAtoB <- newTQueueIO :: IO (TQueue (Maybe Word8))
   qBtoA <- newTQueueIO :: IO (TQueue (Maybe Word8))
@@ -60,9 +61,17 @@ mkClosableStreamPair = do
       closeWriter q closed = atomically $ do
         putTMVar closed ()
         writeTQueue q Nothing  -- sentinel for EOF
-      streamA = StreamIO (writeQ qAtoB closedA) (readQ qBtoA)
-      streamB = StreamIO (writeQ qBtoA closedB) (readQ qAtoB)
-  pure (streamA, closeWriter qAtoB closedA, streamB)
+      streamA = StreamIO
+        { streamWrite    = writeQ qAtoB closedA
+        , streamReadByte = readQ qBtoA
+        , streamClose    = closeWriter qAtoB closedA
+        }
+      streamB = StreamIO
+        { streamWrite    = writeQ qBtoA closedB
+        , streamReadByte = readQ qAtoB
+        , streamClose    = closeWriter qBtoA closedB
+        }
+  pure (streamA, streamB)
 
 spec :: Spec
 spec = do
@@ -88,11 +97,9 @@ spec = do
 
     it "handleIdentify sends decodable protobuf over stream" $ do
       sw <- mkTestSwitch
-      (streamA, closeA, streamB) <- mkClosableStreamPair
-      -- handleIdentify writes protobuf to streamA, then we close it
-      writer <- async $ do
-        handleIdentify sw streamA (PeerId "remote")
-        closeA
+      (streamA, streamB) <- mkClosableStreamPair
+      -- handleIdentify writes protobuf to streamA and closes it (EOF)
+      writer <- async $ handleIdentify sw streamA (PeerId "remote")
       -- Read all bytes from streamB until EOF
       bytesOrErr <- readUntilEOF streamB 65536
       wait writer
@@ -104,10 +111,52 @@ spec = do
             idProtocolVersion info `shouldBe` Just "ipfs/0.1.0"
             idAgentVersion info `shouldBe` Just "libp2p-hs/0.1.0"
 
+    it "handleIdentify closes stream after writing (signals EOF)" $ do
+      sw <- mkTestSwitch
+      closeCalledRef <- newIORef False
+      qAtoB <- newTQueueIO :: IO (TQueue (Maybe Word8))
+      closedA <- newEmptyTMVarIO :: IO (TMVar ())
+      let writeQ q closed bs = do
+            c <- atomically $ tryReadTMVar closed
+            case c of
+              Just () -> throwIO (mkIOError eofErrorType "stream closed" Nothing Nothing)
+              Nothing -> mapM_ (\b -> atomically $ writeTQueue q (Just b)) (BS.unpack bs)
+          readQ q = do
+            mv <- atomically $ readTQueue q
+            case mv of
+              Just b  -> pure b
+              Nothing -> throwIO (mkIOError eofErrorType "EOF" Nothing Nothing)
+          closeWriter q closed = atomically $ do
+            putTMVar closed ()
+            writeTQueue q Nothing
+          testStream = StreamIO
+            { streamWrite    = writeQ qAtoB closedA
+            , streamReadByte = fail "not used in this test"
+            , streamClose    = do
+                writeIORef closeCalledRef True
+                closeWriter qAtoB closedA
+            }
+          readerStream = StreamIO
+            { streamWrite    = \_ -> fail "not used"
+            , streamReadByte = readQ qAtoB
+            , streamClose    = pure ()
+            }
+      -- handleIdentify should write + close the stream
+      writer <- async $ handleIdentify sw testStream (PeerId "remote")
+      bytesOrErr <- readUntilEOF readerStream 65536
+      wait writer
+      -- Stream close should have been called by handleIdentify
+      closeCalled <- readIORef closeCalledRef
+      closeCalled `shouldBe` True
+      -- And the data should be readable
+      case bytesOrErr of
+        Right _ -> pure ()
+        Left err -> expectationFailure $ "readUntilEOF failed: " ++ err
+
     it "handleIdentifyPush stores info in peer store" $ do
       sw <- mkTestSwitch
       let remotePeerId = PeerId "push-peer"
-      (streamA, closeA, streamB) <- mkClosableStreamPair
+      (streamA, streamB) <- mkClosableStreamPair
       let testInfo = IdentifyInfo
             { idProtocolVersion = Just "test/1.0"
             , idAgentVersion    = Just "test-agent/0.1"
@@ -119,7 +168,7 @@ spec = do
       -- Write encoded message then signal EOF
       let encoded = encodeIdentify testInfo
       streamWrite streamA encoded
-      closeA
+      streamClose streamA
       -- handleIdentifyPush reads from streamB
       handleIdentifyPush sw streamB remotePeerId
       -- Check peer store

--- a/test/Test/Network/LibP2P/Switch/ConnPoolSpec.hs
+++ b/test/Test/Network/LibP2P/Switch/ConnPoolSpec.hs
@@ -22,6 +22,7 @@ mockStreamIO :: StreamIO
 mockStreamIO = StreamIO
   { streamWrite    = \_ -> pure ()
   , streamReadByte = pure 0
+  , streamClose    = pure ()
   }
 
 -- | Create a mock connection with the given PeerId and direction.


### PR DESCRIPTION
## Summary
- Added `streamClose :: IO ()` field to the `StreamIO` record type, enabling protocols to signal EOF/stream-end
- Wired `streamClose` at every constructor site (4 source, 13 test files):
  - **TCP socket**: `NS.close sock`
  - **Yamux stream**: `YS.streamClose` (sends FIN flag)
  - **Noise encrypted**: `pure ()` (encryption layer doesn't own connection)
  - **In-memory test pairs**: `pure ()` or sentinel-based close for EOF tests
- Fixed `handleIdentify` to call `streamClose` after writing the Identify payload, so the remote side's `readUntilEOF` terminates without requiring external close

## Test plan
- [x] New test: "handleIdentify closes stream after writing (signals EOF)" — tracks close call via IORef, verifies both close was called and data was readable
- [x] Existing "handleIdentify sends decodable protobuf over stream" test updated to rely on streamClose instead of external closeA call
- [x] Full test suite: 562 tests pass, 0 failures (no regressions)

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)