### PR TITLE
Harden protocol parsing and upgrade path against malformed input

### DIFF
--- a/src/Network/LibP2P/MultistreamSelect/Wire.hs
+++ b/src/Network/LibP2P/MultistreamSelect/Wire.hs
@@ -44,7 +44,8 @@ decodeMessage bs = do
        in if BS.null payload || BS.last payload /= 0x0a
             then Left "decodeMessage: message does not end with newline"
             else
-              let text = TE.decodeUtf8 (BS.init payload)
-               in Right (text, rest2)
+              case TE.decodeUtf8' (BS.init payload) of
+                Left err -> Left $ "decodeMessage: invalid UTF-8: " <> show err
+                Right text -> Right (text, rest2)
   where
     -- BS.init is safe here because we checked non-null above


### PR DESCRIPTION
## Summary
- **Wire.hs**: Replace `TE.decodeUtf8` with `TE.decodeUtf8'` for safe UTF-8 handling on network input
- **Upgrade.hs**: Replace all 21 partial pattern matches with explicit case/either handling:
  - `let Right ... = expr` → `case expr of { Right r -> ...; Left err -> fail msg }`
  - `Accepted _ <- negotiate...` → `case result of { Accepted _ -> ...; NoProtocol -> fail msg }`
  - `Right stream <- Yamux.openStream` → explicit case match
  - `BS.head chunk` with empty guard
- Error strategy: `fail` in IO, callers handle via exception catching (Dial: `waitAnyCatch`, Listen: async handler cleanup)

Fixes #118

## Test plan
- [x] 2 new tests: `decodeMessage` returns `Left` on invalid UTF-8 (was `UnicodeException` crash)
- [x] Grep verification: 0 `let Right` patterns, 0 `Accepted _ <-` patterns remain in Upgrade.hs
- [x] Full test suite: 585 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)