### PR TITLE
fix(interop): conform to transport-interop ping contract and verify go-libp2p interop

### DIFF
--- a/docs/interop-results.md
+++ b/docs/interop-results.md
@@ -1,0 +1,115 @@
+---
+title: Transport-Interop Results
+last_updated: 2026-05-27
+tags:
+  - interop
+  - transport
+  - testing
+  - go-libp2p
+---
+
+# Transport-Interop Results
+
+This document records reproducible evidence that the `libp2p-interop` binary
+(`interop/Main.hs`) passes the upstream
+[libp2p/test-plans](https://github.com/libp2p/test-plans/tree/master/transport-interop)
+**ping** contract against go-libp2p, in both dialer and listener roles, over
+**TCP + Noise + Yamux**.
+
+## Environment
+
+| Item | Value |
+|------|-------|
+| libp2p-hs commit | `d0b74b7` (plus the conformance fixes in this PR) |
+| go-libp2p | `v0.48.0` (`062200be7aa1d18a0f54eefb17b0dbe2e96f0a79`) |
+| Transport / Security / Muxer | `tcp` / `noise` / `yamux` |
+| GHC (in Docker) | 9.10 (`haskell:9.10-slim-bookworm`) |
+| Docker | 29.3.0, Compose v5.1.0 |
+| Date | 2026-05-27 |
+
+## Conformance fixes applied (verified against the upstream README)
+
+- **Listener timeout exit code.** Per the README ("Listener", step 5), a listener that
+  reaches `test_timeout_seconds` must exit with a non-zero code. `runListener` previously
+  slept, closed the switch, and fell through to exit 0; it now logs and calls `exitFailure`.
+- **Dialer metric semantics.** Per the README ("Dialer", steps 4–9) the dialer records
+  `handshakeStartInstant`, connects, performs **one** ping (its round trip is `pingRTT`),
+  and reports the total elapsed since the start as `handshakePlusOneRTT`. `runDialer`
+  previously sent a *second* ping to measure `pingRTT`; it now uses the single ping for
+  both metrics. The upstream-mandated key spelling `pingRTTMilllis` (triple L) is preserved.
+
+## Results
+
+Both directions exit 0 on the process whose exit code the framework keys on (the dialer),
+asserted explicitly via `docker compose up --exit-code-from <dialer-service>`.
+
+### Direction 1 — go-libp2p listener, libp2p-hs dialer
+
+Command:
+
+```bash
+docker compose -f docker-compose.cross.yml up --build \
+  --exit-code-from hs-dialer redis go-listener hs-dialer
+```
+
+- go-listener bound `/ip4/172.19.0.3/tcp/40097`.
+- hs-dialer dialed and printed to stdout:
+
+  ```json
+  {"handshakePlusOneRTTMillis":183.559457,"pingRTTMilllis":43.797114}
+  ```
+
+- **hs-dialer exited 0.** (go-listener exited 2 because `--exit-code-from` aborts the
+  remaining services once the dialer finishes — expected, not a failure.)
+
+### Direction 2 — libp2p-hs listener, go-libp2p dialer
+
+Command:
+
+```bash
+docker compose -f docker-compose.cross.yml up --build \
+  --exit-code-from go-dialer redis hs-listener go-dialer
+```
+
+- hs-listener bound `/ip4/172.19.0.3/tcp/43701` and published it to Redis.
+- go-dialer dialed and printed to stdout:
+
+  ```json
+  {"handshakePlusOneRTTMillis":179.622,"pingRTTMilllis":43.953}
+  ```
+
+- **go-dialer exited 0.** (hs-listener exited 137 = SIGKILL by the runner after the dialer
+  finished — the normal flow described by the README.)
+
+### Listener timeout behavior
+
+Running the listener with a short timeout and no dialer confirms the conformance fix:
+
+```bash
+docker compose -f docker-compose.cross.yml run --rm \
+  -e test_timeout_seconds=5 hs-listener
+# -> logs "Listener timed out waiting to be dialed", exit code 1
+```
+
+## Reproducing
+
+1. Clone go-libp2p at the pinned commit into `./go-libp2p`:
+
+   ```bash
+   git clone --depth 1 --branch v0.48.0 https://github.com/libp2p/go-libp2p.git go-libp2p
+   ```
+
+2. Run the two cross-test directions with the commands above, or via the Makefile targets
+   `make -C interop cross-test-go-listener` and `make -C interop cross-test-hs-listener`
+   (note: the Makefile uses `--abort-on-container-exit`; prefer `--exit-code-from` to
+   assert the dialer's exit code explicitly, as shown above).
+
+## Scope notes
+
+- This validates the upstream transport-interop **ping** contract against go-libp2p.
+  Continuous proof in CI and upstream registration in `libp2p/test-plans` are tracked
+  separately.
+- A GossipSub cross-test against the bundled `interop/rust-peer/`
+  (`make -C interop cross-gossipsub`) exists but validates GossipSub messaging, not the
+  transport-interop ping spec; a true rust transport-interop ping check uses the official
+  rust container and is deferred to the upstream-submission work.

--- a/interop/Main.hs
+++ b/interop/Main.hs
@@ -168,9 +168,13 @@ runListener sw pid ip redisConn timeoutS = do
           exitFailure
         Right _ -> do
           logInfo "Address published to Redis, waiting..."
-          -- Block until timeout (framework kills container)
+          -- The test runner kills this process once the dialer finishes.
+          -- Reaching the timeout means we were never successfully dialed,
+          -- which is a test failure (transport-interop README, Listener step 5).
           threadDelay (timeoutS * 1000000)
+          hPutStrLn stderr "Listener timed out waiting to be dialed"
           switchClose sw
+          exitFailure
 
 -- | Dialer mode: get address from Redis, dial, ping, output JSON.
 runDialer :: Switch -> PeerId -> Redis.Connection -> Int -> IO ()
@@ -207,7 +211,8 @@ runDialer sw _pid redisConn timeoutS = do
           Just (transportAddr, remotePeerId) -> do
             logInfo $ "Dialing peer: " ++ T.unpack (toBase58 remotePeerId)
 
-            -- Measure handshake + first ping
+            -- handshakeStartInstant, recorded before connecting
+            -- (transport-interop README, Dialer step 4).
             t0 <- getCurrentTime
 
             dialResult <- dial sw remotePeerId [transportAddr]
@@ -217,38 +222,30 @@ runDialer sw _pid redisConn timeoutS = do
                 switchClose sw
                 exitFailure
               Right conn -> do
-                -- First ping (included in handshake timing)
-                pingResult1 <- sendPing conn
+                -- A single ping (README steps 5-6): its round-trip time is
+                -- pingRTT, and the total elapsed since t0 is handshakePlusOneRTT.
+                pingResult <- sendPing conn
                 t1 <- getCurrentTime
 
-                case pingResult1 of
+                case pingResult of
                   Left err -> do
-                    hPutStrLn stderr $ "First ping failed: " ++ show err
+                    hPutStrLn stderr $ "Ping failed: " ++ show err
                     switchClose sw
                     exitFailure
-                  Right _ -> do
+                  Right pr -> do
                     let handshakePlusOneRTT = realToFrac (diffUTCTime t1 t0) * 1000 :: Double
+                        pingRTTMs = realToFrac (pingRTT pr) * 1000 :: Double
 
-                    -- Second ping (standalone RTT measurement)
-                    pingResult2 <- sendPing conn
-                    case pingResult2 of
-                      Left err -> do
-                        hPutStrLn stderr $ "Second ping failed: " ++ show err
-                        switchClose sw
-                        exitFailure
-                      Right pr -> do
-                        let pingRTTMs = realToFrac (pingRTT pr) * 1000 :: Double
+                    -- Output JSON (pingRTTMilllis triple-L is the upstream spelling)
+                    let jsonOutput = object
+                          [ "handshakePlusOneRTTMillis" .= handshakePlusOneRTT
+                          , "pingRTTMilllis" .= pingRTTMs
+                          ]
+                    LBS8.putStrLn (Aeson.encode jsonOutput)
+                    hFlush stdout
 
-                        -- Output JSON (note: pingRTTMilllis has 3 L's - intentional)
-                        let jsonOutput = object
-                              [ "handshakePlusOneRTTMillis" .= handshakePlusOneRTT
-                              , "pingRTTMilllis" .= pingRTTMs
-                              ]
-                        LBS8.putStrLn (Aeson.encode jsonOutput)
-                        hFlush stdout
-
-                        switchClose sw
-                        exitSuccess
+                    switchClose sw
+                    exitSuccess
 
 -- | GossipSub listener: join topic, wait for message, reply, report to Redis.
 runGossipSubListener :: Switch -> PeerId -> String -> Redis.Connection -> Int -> IO ()


### PR DESCRIPTION
## Summary

- Fix two transport-interop conformance bugs in the `libp2p-interop` daemon (`interop/Main.hs`), verified against the upstream [libp2p/test-plans transport-interop README](https://github.com/libp2p/test-plans/tree/master/transport-interop):
  - **Listener timeout** now exits **non-zero** when `test_timeout_seconds` is reached without being dialed (README "Listener" step 5). Previously it closed the switch and fell through to exit 0.
  - **Dialer metrics** now derive both `handshakePlusOneRTTMillis` and `pingRTTMilllis` from a **single** ping (README "Dialer" steps 4–9). Previously a second ping was sent solely for the RTT measurement. The mandated triple-L key spelling is preserved.
- Add `docs/interop-results.md` recording reproducible hs ↔ go-libp2p interop evidence.

## Why

Closes #124. Step 2 of the libp2p-official-recognition roadmap needs demonstrated cross-implementation interop. The local interop harness already existed, but had not been run against another implementation, and two behaviors diverged from the upstream contract.

## Verification — go-libp2p v0.48.0 (`062200be…`), TCP+Noise+Yamux

Asserted with `docker compose up --exit-code-from <dialer>` (explicit exit-code check, not `--abort-on-container-exit` alone).

| Direction | Dialer output | Dialer exit |
|-----------|---------------|-------------|
| go listener → **hs dialer** | `{"handshakePlusOneRTTMillis":183.559457,"pingRTTMilllis":43.797114}` | **0** |
| **hs listener** → go dialer | `{"handshakePlusOneRTTMillis":179.622,"pingRTTMilllis":43.953}` | **0** |

Listener-timeout fix: `docker compose run --rm -e test_timeout_seconds=5 hs-listener` (no dialer) logs `Listener timed out waiting to be dialed` and exits **1**.

Full commands and output are in `docs/interop-results.md`.

## Test plan

- [x] Direction 1 (go listener / hs dialer) — hs-dialer exit 0, valid JSON
- [x] Direction 2 (hs listener / go dialer) — go-dialer exit 0, valid JSON
- [x] Listener timeout path exits non-zero
- [x] Interop binary compiles under GHC 9.10 (built inside `haskell:9.10-slim-bookworm` during the cross-test)

## Follow-ups (separate issues)

- #125 — add the cross-impl interop job to CI (continuous proof)
- #126 — submit `haskell-v0.1` to upstream `libp2p/test-plans`