### PR TITLE
ci: add cross-implementation transport-interop job

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,0 +1,54 @@
+name: Interop
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  transport-interop:
+    name: transport-interop (hs <-> go, tcp+noise+yamux)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Pinned go-libp2p release; docker-compose.cross.yml builds its PingDockerfile.
+      - name: Clone go-libp2p (pinned)
+        run: git clone --depth 1 --branch v0.48.0 https://github.com/libp2p/go-libp2p.git go-libp2p
+
+      # Build the libp2p-hs interop image once, with a GHA-backed Docker layer
+      # cache. The Dockerfile builds dependencies in a separate layer, so this
+      # is fast unless libp2p-hs.cabal changes. Both compose hs services consume
+      # this image via `image: libp2p-hs-interop:latest`.
+      - name: Build libp2p-hs interop image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: libp2p-hs-interop:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Direction 1 — go listener, hs dialer
+        run: >
+          docker compose -f docker-compose.cross.yml up
+          --exit-code-from hs-dialer
+          redis go-listener hs-dialer
+
+      - name: Reset between directions
+        run: docker compose -f docker-compose.cross.yml down
+
+      - name: Direction 2 — hs listener, go dialer
+        run: >
+          docker compose -f docker-compose.cross.yml up
+          --exit-code-from go-dialer
+          redis hs-listener go-dialer
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.cross.yml down -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,29 @@ FROM haskell:9.10-slim-bookworm AS builder
 
 WORKDIR /app
 
-# Copy all source files needed for building
+# Copy only the package description first, so the dependency-build layer below
+# is cached and reused as long as libp2p-hs.cabal / cabal.project are unchanged.
 COPY libp2p-hs.cabal cabal.project ./
-COPY src/ src/
-COPY interop/ interop/
 
-# Fix ppad-sha256 ARM SHA2 intrinsic compilation on Docker (GCC 12)
-# Only apply ARM-specific flags on aarch64; skip on x86_64
+# Fix ppad-sha256 ARM SHA2 intrinsic compilation on Docker (GCC 12).
+# Only apply ARM-specific flags on aarch64; skip on x86_64.
+# Must run before any build so the override is in effect.
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
       echo 'package ppad-sha256' >> cabal.project && \
       echo '  ghc-options: -optc-march=armv8-a+crypto' >> cabal.project; \
     fi
 
-# Build the interop executable
-RUN cabal update && cabal build libp2p-interop \
+# Pre-build the library's dependencies. This is the expensive layer (crypton,
+# cacophony, tls, lens, ...) and is cached unless the cabal file changes, so
+# source-only edits skip it. We target the library (not the executable) because
+# the executable depends on the local libp2p-hs library, which cannot be built
+# before its source is copied below.
+RUN cabal update && cabal build --only-dependencies lib:libp2p-hs
+
+# Copy sources and build the project itself.
+COPY src/ src/
+COPY interop/ interop/
+RUN cabal build libp2p-interop \
     && cp "$(cabal list-bin libp2p-interop)" /app/libp2p-interop \
     && strip /app/libp2p-interop
 

--- a/docker-compose.cross.yml
+++ b/docker-compose.cross.yml
@@ -1,18 +1,28 @@
 # Cross-implementation interop test: libp2p-hs <-> go-libp2p.
 #
 # Prerequisites:
-#   git clone https://github.com/libp2p/go-libp2p.git go-libp2p
+#   git clone --depth 1 --branch v0.48.0 https://github.com/libp2p/go-libp2p.git go-libp2p
 #
 # Test 1: go-libp2p listener, libp2p-hs dialer
-#   docker compose -f docker-compose.cross.yml up --build go-listener hs-dialer redis --abort-on-container-exit
+#   docker compose -f docker-compose.cross.yml up --build --exit-code-from hs-dialer redis go-listener hs-dialer
 #
 # Test 2: libp2p-hs listener, go-libp2p dialer
-#   docker compose -f docker-compose.cross.yml up --build hs-listener go-dialer redis --abort-on-container-exit
+#   docker compose -f docker-compose.cross.yml up --build --exit-code-from go-dialer redis hs-listener go-dialer
+#
+# --exit-code-from <dialer> makes `up` return the dialer's exit code (0 on success),
+# so failures are not masked when another container exits 0 first.
 services:
   redis:
     image: redis:7-alpine
+    # Disable persistence so a stale listenerAddr never survives across runs.
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
     ports:
       - "6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
 
   # --- Test 1: go listener, hs dialer ---
   go-listener:
@@ -20,7 +30,8 @@ services:
       context: ./go-libp2p
       dockerfile: test-plans/PingDockerfile
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     environment:
       transport: tcp
       security: noise
@@ -31,9 +42,12 @@ services:
 
   hs-dialer:
     build: .
+    image: libp2p-hs-interop:latest
     depends_on:
-      - redis
-      - go-listener
+      redis:
+        condition: service_healthy
+      go-listener:
+        condition: service_started
     environment:
       transport: tcp
       security: noise
@@ -45,8 +59,10 @@ services:
   # --- Test 2: hs listener, go dialer ---
   hs-listener:
     build: .
+    image: libp2p-hs-interop:latest
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     environment:
       transport: tcp
       security: noise
@@ -60,8 +76,10 @@ services:
       context: ./go-libp2p
       dockerfile: test-plans/PingDockerfile
     depends_on:
-      - redis
-      - hs-listener
+      redis:
+        condition: service_healthy
+      hs-listener:
+        condition: service_started
     environment:
       transport: tcp
       security: noise


### PR DESCRIPTION
## Summary

Adds a CI job that runs the libp2p-hs ↔ go-libp2p transport-interop **ping** test (TCP+Noise+Yamux) on every PR and push, so cross-implementation interop is continuously proven.

- **`.github/workflows/interop.yml`** — builds the interop image once with a **GHA-backed Docker layer cache** (`docker/build-push-action` `cache-from/to type=gha`), clones go-libp2p at the pinned **v0.48.0**, then runs both directions via `docker compose ... --exit-code-from <dialer>` so a dialer failure can't be masked by another container exiting 0 first.
- **`Dockerfile`** — splits dependency compilation into its own layer (`cabal build --only-dependencies lib:libp2p-hs`) so the expensive GHC build (crypton, cacophony, tls, lens, …) is cached unless `libp2p-hs.cabal` changes. The library component is targeted because the executable depends on the local library, which can't be built before its source is copied.
- **`docker-compose.cross.yml`** — Redis gets a `healthcheck` and the daemons depend on `condition: service_healthy`, fixing the race where the daemon's single `checkedConnect` could hit Redis before it was ready; Redis persistence is disabled so a stale `listenerAddr` never survives a run; both hs services reference the prebuilt `image: libp2p-hs-interop:latest`.

## Why

Closes #125. After #124 proved the interop works locally, this keeps it green automatically — the CI run is the evidence the website-matrix PR and upstream submission rely on.

## Test plan (run locally before pushing)

Both directions green with the full updated stack (prebuilt cached image + redis healthcheck + `--exit-code-from`):

| Direction | Dialer output | Dialer exit |
|-----------|---------------|-------------|
| go listener → **hs dialer** | `{"handshakePlusOneRTTMillis":139.908078,"pingRTTMilllis":46.839554}` | **0** |
| **hs listener** → go dialer | `{"handshakePlusOneRTTMillis":185.952,"pingRTTMilllis":43.551}` | **0** |

- [x] Restructured Dockerfile builds from scratch (`docker build` exit 0, image 161 MB)
- [x] `docker compose config` validates
- [x] Direction 1 (go listener / hs dialer) — exit 0
- [x] Direction 2 (hs listener / go dialer) — exit 0
- [x] Interop workflow YAML parses

## Follow-up

- #126 — submit `haskell-v0.1` to upstream `libp2p/test-plans`