### PR TITLE
refactor: standardize lazy ByteString alias to BL

### DIFF
--- a/src/Network/LibP2P/Core/Binary.hs
+++ b/src/Network/LibP2P/Core/Binary.hs
@@ -12,21 +12,21 @@ module Network.LibP2P.Core.Binary
 import Data.Binary.Get (getWord16be, getWord32be, runGet)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Builder as Builder
-import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy as BL
 import Data.Word (Word16, Word32)
 
 -- | Encode a Word16 as 2-byte big-endian ByteString.
 word16BE :: Word16 -> ByteString
-word16BE = LBS.toStrict . Builder.toLazyByteString . Builder.word16BE
+word16BE = BL.toStrict . Builder.toLazyByteString . Builder.word16BE
 
 -- | Encode a Word32 as 4-byte big-endian ByteString.
 word32BE :: Word32 -> ByteString
-word32BE = LBS.toStrict . Builder.toLazyByteString . Builder.word32BE
+word32BE = BL.toStrict . Builder.toLazyByteString . Builder.word32BE
 
 -- | Read a big-endian Word16 from a ByteString (must be >= 2 bytes).
 readWord16BE :: ByteString -> Word16
-readWord16BE = runGet getWord16be . LBS.fromStrict
+readWord16BE = runGet getWord16be . BL.fromStrict
 
 -- | Read a big-endian Word32 from a ByteString (must be >= 4 bytes).
 readWord32BE :: ByteString -> Word32
-readWord32BE = runGet getWord32be . LBS.fromStrict
+readWord32BE = runGet getWord32be . BL.fromStrict

--- a/src/Network/LibP2P/Core/Varint.hs
+++ b/src/Network/LibP2P/Core/Varint.hs
@@ -11,7 +11,7 @@ import Data.Bits (Bits (..))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as Builder
-import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy as BL
 import Data.Word (Word64)
 
 -- | Maximum number of bytes for a valid unsigned varint (ceil(64/7) = 10).
@@ -20,7 +20,7 @@ maxVarintBytes = 10
 
 -- | Encode a Word64 as an unsigned LEB128 varint.
 encodeUvarint :: Word64 -> ByteString
-encodeUvarint = LBS.toStrict . Builder.toLazyByteString . go
+encodeUvarint = BL.toStrict . Builder.toLazyByteString . go
   where
     go :: Word64 -> Builder.Builder
     go n


### PR DESCRIPTION
## Summary

Part of the naming-convention refactoring effort. Standardizes the qualified import alias for `Data.ByteString.Lazy`.

The Core modules (`Core.Binary`, `Core.Varint`) aliased it as `LBS`, while the other 7 modules in the codebase use `BL`. This unifies on the majority `BL` convention.

## Changes
- `Core/Binary.hs`: `LBS` → `BL`
- `Core/Varint.hs`: `LBS` → `BL`

## Verification
- `cabal build` passes
- `cabal test`: 585 examples, 0 failures