### PR TITLE
feat: RSA/secp256k1 key support for peer identity (Phase 1e)

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -38,6 +38,8 @@ library
     Network.LibP2P.Multiaddr.Codec
     Network.LibP2P.Crypto.Key
     Network.LibP2P.Crypto.Ed25519
+    Network.LibP2P.Crypto.RSA
+    Network.LibP2P.Crypto.Secp256k1
     Network.LibP2P.Crypto.Protobuf
     Network.LibP2P.Crypto.PeerId
     Network.LibP2P.MultistreamSelect.Wire
@@ -89,6 +91,9 @@ library
     text        >= 1.2  && < 2.2,
     cacophony   >= 0.11 && < 0.12,
     crypton     >= 1.0   && < 1.1,
+    crypton-x509 >= 1.7  && < 1.9,
+    crypton-asn1-types >= 0.4 && < 0.5,
+    crypton-asn1-encoding >= 0.9 && < 0.11,
     memory      >= 0.18  && < 0.19,
     ppad-base58 >= 0.2  && < 0.3,
     iproute     >= 1.7  && < 1.8,
@@ -126,6 +131,8 @@ test-suite libp2p-hs-test
     Test.Network.LibP2P.Core.MultihashSpec
     Test.Network.LibP2P.Multiaddr.MultiaddrSpec
     Test.Network.LibP2P.Crypto.PeerIdSpec
+    Test.Network.LibP2P.Crypto.RSASpec
+    Test.Network.LibP2P.Crypto.Secp256k1Spec
     Test.Network.LibP2P.MultistreamSelect.NegotiationSpec
     Test.Network.LibP2P.Mux.Yamux.FrameSpec
     Test.Network.LibP2P.Mux.Yamux.StreamSpec

--- a/src/Network/LibP2P/Crypto/Key.hs
+++ b/src/Network/LibP2P/Crypto/Key.hs
@@ -7,16 +7,22 @@ module Network.LibP2P.Crypto.Key
   , publicKey
   , sign
   , verify
+  , generateRSAKeyPair
+  , generateSecp256k1KeyPair
   ) where
 
 import qualified Crypto.Error as CE
 import qualified Crypto.PubKey.Ed25519 as Ed
 import Data.ByteArray (convert)
 import Data.ByteString (ByteString)
+import qualified Network.LibP2P.Crypto.RSA as RSA
+import qualified Network.LibP2P.Crypto.Secp256k1 as Secp256k1
 
 -- | Supported key types per the libp2p spec.
 data KeyType
   = Ed25519
+  | RSA
+  | Secp256k1
   deriving (Show, Eq, Ord)
 
 -- | A public key with its type.
@@ -43,7 +49,11 @@ publicKey :: KeyPair -> PublicKey
 publicKey = kpPublic
 
 -- | Sign a message with a private key.
--- Returns Left on invalid key bytes.
+--
+-- Ed25519 and RSA signing are deterministic and therefore pure. secp256k1 (ECDSA)
+-- requires a random nonce, so its signing lives in IO
+-- ('Network.LibP2P.Crypto.Secp256k1.signIO'); local peer identities in this
+-- implementation are Ed25519. Returns Left on invalid key bytes.
 sign :: PrivateKey -> ByteString -> Either String ByteString
 sign (PrivateKey Ed25519 skRaw) msg =
   case CE.eitherCryptoError (Ed.secretKey skRaw) of
@@ -52,10 +62,28 @@ sign (PrivateKey Ed25519 skRaw) msg =
       let pk = Ed.toPublic sk
           sig = Ed.sign sk pk msg
        in Right (convert sig)
+sign (PrivateKey RSA skRaw) msg = RSA.sign skRaw msg
+sign (PrivateKey Secp256k1 _) _ =
+  Left "sign: secp256k1 signing runs in IO (Network.LibP2P.Crypto.Secp256k1.signIO)"
 
 -- | Verify a signature against a public key and message.
+-- Supports every libp2p key type so remote peers of any type can be authenticated.
 verify :: PublicKey -> ByteString -> ByteString -> Bool
 verify (PublicKey Ed25519 pkRaw) msg sigRaw =
   case (CE.eitherCryptoError (Ed.publicKey pkRaw), CE.eitherCryptoError (Ed.signature sigRaw)) of
     (Right pk, Right sig) -> Ed.verify pk msg sig
     _ -> False
+verify (PublicKey RSA pkRaw) msg sigRaw = RSA.verify pkRaw msg sigRaw
+verify (PublicKey Secp256k1 pkRaw) msg sigRaw = Secp256k1.verify pkRaw msg sigRaw
+
+-- | Generate a new RSA key pair (2048-bit) with libp2p wire-format key bytes.
+generateRSAKeyPair :: IO KeyPair
+generateRSAKeyPair = do
+  (pub, priv) <- RSA.generate
+  pure $ KeyPair (PublicKey RSA pub) (PrivateKey RSA priv)
+
+-- | Generate a new secp256k1 key pair with libp2p wire-format key bytes.
+generateSecp256k1KeyPair :: IO KeyPair
+generateSecp256k1KeyPair = do
+  (pub, priv) <- Secp256k1.generate
+  pure $ KeyPair (PublicKey Secp256k1 pub) (PrivateKey Secp256k1 priv)

--- a/src/Network/LibP2P/Crypto/Protobuf.hs
+++ b/src/Network/LibP2P/Crypto/Protobuf.hs
@@ -16,12 +16,18 @@ import Numeric (showHex)
 import Network.LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 import Network.LibP2P.Crypto.Key (KeyType (..), PublicKey (..))
 
--- | Protobuf KeyType enum values.
+-- | Protobuf KeyType enum values (per libp2p peer-ids spec: RSA=0, Ed25519=1,
+-- Secp256k1=2, ECDSA=3). ECDSA is not yet supported and decodes to a typed error.
 keyTypeToProto :: KeyType -> Word64
+keyTypeToProto RSA = 0
 keyTypeToProto Ed25519 = 1
+keyTypeToProto Secp256k1 = 2
 
 keyTypeFromProto :: Word64 -> Either String KeyType
+keyTypeFromProto 0 = Right RSA
 keyTypeFromProto 1 = Right Ed25519
+keyTypeFromProto 2 = Right Secp256k1
+keyTypeFromProto 3 = Left "unsupported KeyType: ECDSA (3)"
 keyTypeFromProto n = Left $ "unknown KeyType: " <> show n
 
 -- | Deterministic protobuf encoding of a PublicKey message.

--- a/src/Network/LibP2P/Crypto/RSA.hs
+++ b/src/Network/LibP2P/Crypto/RSA.hs
@@ -1,0 +1,116 @@
+-- | RSA key operations for libp2p peer identity, using crypton.
+--
+-- Wire formats follow the libp2p peer-ids spec:
+-- - Public key: DER-encoded SubjectPublicKeyInfo (PKIX).
+-- - Private key: DER-encoded PKCS#1 RSAPrivateKey.
+-- - Signatures: RSASSA-PKCS1-v1_5 over SHA-256.
+--
+-- All functions operate on raw 'ByteString' so this module does not depend on
+-- "Network.LibP2P.Crypto.Key" (avoids an import cycle with the dispatcher).
+module Network.LibP2P.Crypto.RSA
+  ( generate
+  , sign
+  , verify
+  ) where
+
+import Crypto.Hash.Algorithms (SHA256 (..))
+import qualified Crypto.PubKey.RSA as RSA
+import qualified Crypto.PubKey.RSA.PKCS15 as PKCS15
+import Data.ASN1.BinaryEncoding (DER (..))
+import Data.ASN1.Encoding (decodeASN1', encodeASN1')
+import Data.ASN1.Types (ASN1 (..), ASN1ConstructionType (..), fromASN1, toASN1)
+import Data.ByteString (ByteString)
+import Data.X509 (PubKey (PubKeyRSA))
+
+-- | Public exponent used for generated keys (65537).
+publicExponent :: Integer
+publicExponent = 0x10001
+
+-- | Default modulus size in bytes (2048-bit).
+keySizeBytes :: Int
+keySizeBytes = 256
+
+-- | Generate a new RSA key pair, returning (public SPKI DER, private PKCS#1 DER).
+generate :: IO (ByteString, ByteString)
+generate = do
+  (pub, priv) <- RSA.generate keySizeBytes publicExponent
+  pure (encodePublicKey pub, encodePrivateKey priv)
+
+-- | Sign a message with a PKCS#1-DER private key (RSASSA-PKCS1-v1_5, SHA-256).
+-- Deterministic (no blinder), so it is pure.
+sign :: ByteString -> ByteString -> Either String ByteString
+sign privDer msg = do
+  priv <- decodePrivateKey privDer
+  case PKCS15.sign Nothing (Just SHA256) priv msg of
+    Left err -> Left $ "RSA.sign: " <> show err
+    Right sig -> Right sig
+
+-- | Verify a signature against an SPKI-DER public key (RSASSA-PKCS1-v1_5, SHA-256).
+verify :: ByteString -> ByteString -> ByteString -> Bool
+verify pubDer msg sig =
+  case decodePublicKey pubDer of
+    Left _ -> False
+    Right pub -> PKCS15.verify (Just SHA256) pub msg sig
+
+-- | Encode an RSA public key as DER SubjectPublicKeyInfo.
+encodePublicKey :: RSA.PublicKey -> ByteString
+encodePublicKey pub = encodeASN1' DER (toASN1 (PubKeyRSA pub) [])
+
+-- | Decode a DER SubjectPublicKeyInfo into an RSA public key.
+decodePublicKey :: ByteString -> Either String RSA.PublicKey
+decodePublicKey bs =
+  case decodeASN1' DER bs of
+    Left err -> Left $ "RSA.decodePublicKey: " <> show err
+    Right asn1 -> case fromASN1 asn1 of
+      Right (PubKeyRSA pub, _) -> Right pub
+      Right _ -> Left "RSA.decodePublicKey: not an RSA public key"
+      Left err -> Left $ "RSA.decodePublicKey: " <> err
+
+-- | Encode an RSA private key as DER PKCS#1 RSAPrivateKey.
+encodePrivateKey :: RSA.PrivateKey -> ByteString
+encodePrivateKey priv =
+  encodeASN1' DER $
+    [ Start Sequence
+    , IntVal 0 -- version (two-prime)
+    , IntVal (RSA.public_n (RSA.private_pub priv))
+    , IntVal (RSA.public_e (RSA.private_pub priv))
+    , IntVal (RSA.private_d priv)
+    , IntVal (RSA.private_p priv)
+    , IntVal (RSA.private_q priv)
+    , IntVal (RSA.private_dP priv)
+    , IntVal (RSA.private_dQ priv)
+    , IntVal (RSA.private_qinv priv)
+    , End Sequence
+    ]
+
+-- | Decode a DER PKCS#1 RSAPrivateKey into an RSA private key.
+decodePrivateKey :: ByteString -> Either String RSA.PrivateKey
+decodePrivateKey bs =
+  case decodeASN1' DER bs of
+    Left err -> Left $ "RSA.decodePrivateKey: " <> show err
+    Right
+      ( Start Sequence
+          : IntVal _ver
+          : IntVal n
+          : IntVal e
+          : IntVal d
+          : IntVal p
+          : IntVal q
+          : IntVal dP
+          : IntVal dQ
+          : IntVal qinv
+          : End Sequence
+          : _
+        ) ->
+        Right
+          RSA.PrivateKey
+            { RSA.private_pub =
+                RSA.PublicKey {RSA.public_size = keySizeBytes, RSA.public_n = n, RSA.public_e = e}
+            , RSA.private_d = d
+            , RSA.private_p = p
+            , RSA.private_q = q
+            , RSA.private_dP = dP
+            , RSA.private_dQ = dQ
+            , RSA.private_qinv = qinv
+            }
+    Right _ -> Left "RSA.decodePrivateKey: unexpected ASN.1 structure"

--- a/src/Network/LibP2P/Crypto/Secp256k1.hs
+++ b/src/Network/LibP2P/Crypto/Secp256k1.hs
@@ -1,0 +1,118 @@
+-- | Secp256k1 key operations for libp2p peer identity, using crypton.
+--
+-- Wire formats follow the libp2p peer-ids spec:
+-- - Public key: 33-byte SEC1 compressed point (0x02/0x03 prefix + 32-byte X).
+-- - Private key: 32-byte big-endian scalar.
+-- - Signatures: ECDSA over SHA-256, DER-encoded (SEQUENCE { r, s }).
+--
+-- Operates on raw 'ByteString' so this module has no dependency on
+-- "Network.LibP2P.Crypto.Key".
+module Network.LibP2P.Crypto.Secp256k1
+  ( generate
+  , signIO
+  , verify
+  ) where
+
+import Crypto.Hash.Algorithms (SHA256 (..))
+import Crypto.Number.ModArithmetic (expFast)
+import Crypto.Number.Serialize (i2ospOf_, os2ip)
+import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
+import Crypto.PubKey.ECC.Generate (generateQ)
+import Crypto.PubKey.ECC.Types
+  ( Curve (..)
+  , CurveCommon (..)
+  , CurveName (SEC_p256k1)
+  , CurvePrime (..)
+  , Point (..)
+  , getCurveByName
+  )
+import Crypto.Random (getRandomBytes)
+import Data.ASN1.BinaryEncoding (DER (..))
+import Data.ASN1.Encoding (decodeASN1', encodeASN1')
+import Data.ASN1.Types (ASN1 (..), ASN1ConstructionType (..))
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+
+-- | The secp256k1 curve.
+curve :: Curve
+curve = getCurveByName SEC_p256k1
+
+-- | Field prime and curve coefficients (a, b) for secp256k1.
+curveParams :: (Integer, Integer, Integer)
+curveParams = case curve of
+  CurveFP (CurvePrime p cc) -> (p, ecc_a cc, ecc_b cc)
+  _ -> error "Secp256k1: expected a prime-field curve"
+
+-- | Curve order (n).
+curveOrder :: Integer
+curveOrder = case curve of
+  CurveFP (CurvePrime _ cc) -> ecc_n cc
+  _ -> error "Secp256k1: expected a prime-field curve"
+
+-- | Generate a new secp256k1 key pair, returning (compressed public, 32-byte private).
+generate :: IO (ByteString, ByteString)
+generate = do
+  d <- randomScalar
+  let q = generateQ curve d
+  pure (encodePoint q, i2ospOf_ 32 d)
+
+-- | Draw a private scalar in [1, n-1] via rejection sampling.
+randomScalar :: IO Integer
+randomScalar = do
+  bytes <- getRandomBytes 32 :: IO ByteString
+  let d = os2ip bytes
+  if d >= 1 && d < curveOrder then pure d else randomScalar
+
+-- | Sign a message with a 32-byte private scalar (ECDSA/SHA-256, DER output).
+-- Runs in IO because ECDSA signing requires a random nonce.
+signIO :: ByteString -> ByteString -> IO (Either String ByteString)
+signIO privRaw msg
+  | BS.length privRaw /= 32 = pure (Left "Secp256k1.signIO: private key must be 32 bytes")
+  | otherwise = do
+      let priv = ECDSA.PrivateKey curve (os2ip privRaw)
+      sig <- ECDSA.sign priv SHA256 msg
+      pure (Right (encodeSignature sig))
+
+-- | Verify a DER signature against a 33-byte compressed public key (ECDSA/SHA-256).
+verify :: ByteString -> ByteString -> ByteString -> Bool
+verify pubRaw msg sigDer =
+  case (decodePoint pubRaw, decodeSignature sigDer) of
+    (Right pt, Right sig) -> ECDSA.verify SHA256 (ECDSA.PublicKey curve pt) sig msg
+    _ -> False
+
+-- | Encode a curve point as a 33-byte SEC1 compressed public key.
+encodePoint :: Point -> ByteString
+encodePoint PointO = BS.replicate 33 0
+encodePoint (Point x y) =
+  let prefix = if even y then 0x02 else 0x03
+   in BS.cons prefix (i2ospOf_ 32 x)
+
+-- | Decode a 33-byte SEC1 compressed public key into a curve point.
+decodePoint :: ByteString -> Either String Point
+decodePoint bs
+  | BS.length bs /= 33 = Left "Secp256k1.decodePoint: expected 33 bytes"
+  | prefix /= 0x02 && prefix /= 0x03 = Left "Secp256k1.decodePoint: bad prefix"
+  | otherwise =
+      let (p, a, b) = curveParams
+          x = os2ip (BS.drop 1 bs)
+          rhs = (x * x * x + a * x + b) `mod` p
+          y0 = expFast rhs ((p + 1) `div` 4) p
+          wantOdd = prefix == 0x03
+          y = if (odd y0) == wantOdd then y0 else p - y0
+       in Right (Point x y)
+  where
+    prefix = BS.head bs
+
+-- | Encode an ECDSA signature as DER SEQUENCE { r, s }.
+encodeSignature :: ECDSA.Signature -> ByteString
+encodeSignature (ECDSA.Signature r s) =
+  encodeASN1' DER [Start Sequence, IntVal r, IntVal s, End Sequence]
+
+-- | Decode a DER SEQUENCE { r, s } into an ECDSA signature.
+decodeSignature :: ByteString -> Either String ECDSA.Signature
+decodeSignature bs =
+  case decodeASN1' DER bs of
+    Left err -> Left $ "Secp256k1.decodeSignature: " <> show err
+    Right (Start Sequence : IntVal r : IntVal s : End Sequence : _) ->
+      Right (ECDSA.Signature r s)
+    Right _ -> Left "Secp256k1.decodeSignature: unexpected ASN.1 structure"

--- a/test/Test/Network/LibP2P/Crypto/RSASpec.hs
+++ b/test/Test/Network/LibP2P/Crypto/RSASpec.hs
@@ -1,0 +1,54 @@
+module Test.Network.LibP2P.Crypto.RSASpec (spec) where
+
+import qualified Data.ByteString as BS
+import Network.LibP2P.Crypto.Key
+import Network.LibP2P.Crypto.PeerId
+import Network.LibP2P.Crypto.Protobuf
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "RSA peer identity" $ do
+    it "derives a SHA-256 multihash PeerId for keys larger than 42 bytes" $ do
+      kp <- generateRSAKeyPair
+      let pub = publicKey kp
+      -- The serialized SPKI DER of a 2048-bit RSA key is far larger than 42 bytes.
+      (BS.length (encodePublicKey pub) > 42) `shouldBe` True
+      let PeerId mh = fromPublicKey pub
+      -- SHA-256 multihash: 0x12 (code) 0x20 (length=32) + 32 bytes.
+      BS.head mh `shouldBe` 0x12
+      BS.index mh 1 `shouldBe` 0x20
+      BS.length mh `shouldBe` 34
+
+    it "round-trips the public key through protobuf" $ do
+      kp <- generateRSAKeyPair
+      let pub = publicKey kp
+      case decodePublicKey (encodePublicKey pub) of
+        Left err -> expectationFailure err
+        Right pub' -> do
+          pkType pub' `shouldBe` RSA
+          pkType pub' `shouldBe` pkType pub
+          pkBytes pub' `shouldBe` pkBytes pub
+
+    it "signs and verifies a message" $ do
+      kp <- generateRSAKeyPair
+      let msg = "libp2p rsa identity"
+      case sign (kpPrivate kp) msg of
+        Left err -> expectationFailure err
+        Right sig -> do
+          verify (kpPublic kp) msg sig `shouldBe` True
+          verify (kpPublic kp) "tampered" sig `shouldBe` False
+
+  describe "protobuf key-type decoding" $ do
+    it "fails gracefully on the unsupported ECDSA key type" $ do
+      -- Field 1 (Type) = 3 (ECDSA), Field 2 (Data) = empty.
+      let bs = BS.pack [0x08, 0x03, 0x12, 0x00]
+      case decodePublicKey bs of
+        Left err -> null err `shouldBe` False
+        Right _ -> expectationFailure "expected decode to fail for ECDSA"
+
+    it "fails gracefully on an unknown key type" $ do
+      let bs = BS.pack [0x08, 0x63, 0x12, 0x00]
+      case decodePublicKey bs of
+        Left _ -> pure ()
+        Right _ -> expectationFailure "expected decode to fail for unknown type"

--- a/test/Test/Network/LibP2P/Crypto/Secp256k1Spec.hs
+++ b/test/Test/Network/LibP2P/Crypto/Secp256k1Spec.hs
@@ -1,0 +1,43 @@
+module Test.Network.LibP2P.Crypto.Secp256k1Spec (spec) where
+
+import qualified Data.ByteString as BS
+import Network.LibP2P.Crypto.Key
+import Network.LibP2P.Crypto.PeerId
+import Network.LibP2P.Crypto.Protobuf
+import qualified Network.LibP2P.Crypto.Secp256k1 as Secp256k1
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "secp256k1 peer identity" $ do
+    it "produces a 33-byte compressed public key" $ do
+      kp <- generateSecp256k1KeyPair
+      let pub = publicKey kp
+      pkType pub `shouldBe` Secp256k1
+      BS.length (pkBytes pub) `shouldBe` 33
+      -- Compressed SEC1 prefix is 0x02 or 0x03.
+      (BS.head (pkBytes pub) `elem` [0x02, 0x03]) `shouldBe` True
+
+    it "round-trips the public key through protobuf" $ do
+      kp <- generateSecp256k1KeyPair
+      let pub = publicKey kp
+      case decodePublicKey (encodePublicKey pub) of
+        Left err -> expectationFailure err
+        Right pub' -> do
+          pkType pub' `shouldBe` Secp256k1
+          pkBytes pub' `shouldBe` pkBytes pub
+
+    it "round-trips the PeerId through base58" $ do
+      kp <- generateSecp256k1KeyPair
+      let pid = fromPublicKey (publicKey kp)
+      fromBase58 (toBase58 pid) `shouldBe` Right pid
+
+    it "signs and verifies a message" $ do
+      kp <- generateSecp256k1KeyPair
+      let msg = "libp2p secp256k1 identity"
+      signed <- Secp256k1.signIO (skBytes (kpPrivate kp)) msg
+      case signed of
+        Left err -> expectationFailure err
+        Right sig -> do
+          verify (kpPublic kp) msg sig `shouldBe` True
+          verify (kpPublic kp) "tampered" sig `shouldBe` False


### PR DESCRIPTION
Closes #7.

## Summary
Adds RSA and secp256k1 key-type support to peer identity, closing the key-type compatibility gap found during spec-conformance review. Previously only Ed25519 was supported, so non-Ed25519 remote peers could not be authenticated.

## Changes
- `KeyType` gains `RSA` (proto `0`) and `Secp256k1` (proto `2`) per the libp2p `peer-ids` spec. ECDSA (proto `3`) decodes to a typed error (not yet supported).
- **`Crypto.RSA`** (new): DER SubjectPublicKeyInfo / PKCS#1 (de)serialization, RSASSA-PKCS1-v1_5 SHA-256 sign/verify via `crypton` + `crypton-x509`.
- **`Crypto.Secp256k1`** (new): 33-byte SEC1 compressed public keys, ECDSA/SHA-256 with DER signatures, point compression/decompression over `crypton` generic ECC (`SEC_p256k1`).
- `Key.verify` dispatches across **all** key types so remote peers of any type can be authenticated (e.g. during the Noise handshake). Signing is pure for Ed25519/RSA (deterministic); secp256k1 signing is randomised and lives in `Secp256k1.signIO`. Local identities remain Ed25519.
- Protobuf key decoding fails gracefully with typed errors for unsupported/unknown key types.

## Design note
`crypton` is used for all key types (no `libsecp256k1` binding) to keep dependencies minimal, consistent with the existing Ed25519 path. The generic ECC path is sufficient for interop; it can be swapped for `secp256k1-haskell` later if hardening is needed.

## Tests
- RSA public key (>42 bytes serialized) derives a **SHA-256 multihash** PeerId.
- secp256k1 public-key encode/decode and PeerId base58 round-trips.
- sign/verify round-trips for RSA and secp256k1.
- Graceful protobuf decode failure for ECDSA and unknown key types.

Full suite: **594 examples, 0 failures**.