### PR TITLE
feat: ECDSA (P-256) key support for peer identity

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -40,6 +40,7 @@ library
     Network.LibP2P.Crypto.Ed25519
     Network.LibP2P.Crypto.RSA
     Network.LibP2P.Crypto.Secp256k1
+    Network.LibP2P.Crypto.ECDSA
     Network.LibP2P.Crypto.Protobuf
     Network.LibP2P.Crypto.PeerId
     Network.LibP2P.MultistreamSelect.Wire
@@ -133,6 +134,7 @@ test-suite libp2p-hs-test
     Test.Network.LibP2P.Crypto.PeerIdSpec
     Test.Network.LibP2P.Crypto.RSASpec
     Test.Network.LibP2P.Crypto.Secp256k1Spec
+    Test.Network.LibP2P.Crypto.ECDSASpec
     Test.Network.LibP2P.MultistreamSelect.NegotiationSpec
     Test.Network.LibP2P.Mux.Yamux.FrameSpec
     Test.Network.LibP2P.Mux.Yamux.StreamSpec

--- a/src/Network/LibP2P/Crypto/ECDSA.hs
+++ b/src/Network/LibP2P/Crypto/ECDSA.hs
@@ -1,0 +1,109 @@
+-- | ECDSA (NIST P-256) key operations for libp2p peer identity, using crypton.
+--
+-- Wire formats follow the libp2p peer-ids spec (matching go-libp2p):
+-- - Public key: DER-encoded SubjectPublicKeyInfo (PKIX), uncompressed point.
+-- - Private key: 32-byte big-endian scalar.
+-- - Signatures: ECDSA over SHA-256, DER-encoded (SEQUENCE { r, s }).
+--
+-- Operates on raw 'ByteString' so this module has no dependency on
+-- "Network.LibP2P.Crypto.Key".
+module Network.LibP2P.Crypto.ECDSA
+  ( generate
+  , signIO
+  , verify
+  ) where
+
+import Crypto.Hash.Algorithms (SHA256 (..))
+import Crypto.Number.Serialize (i2ospOf_, os2ip)
+import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
+import Crypto.PubKey.ECC.Generate (generateQ)
+import Crypto.PubKey.ECC.Types
+  ( Curve
+  , CurveCommon (ecc_n)
+  , CurveName (SEC_p256r1)
+  , Point (..)
+  , common_curve
+  , getCurveByName
+  )
+import Crypto.Random (getRandomBytes)
+import Data.ASN1.BinaryEncoding (DER (..))
+import Data.ASN1.Encoding (decodeASN1', encodeASN1')
+import Data.ASN1.Types (ASN1 (..), ASN1ConstructionType (..), fromASN1, toASN1)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.X509 (PubKey (PubKeyEC), PubKeyEC (PubKeyEC_Named), SerializedPoint (..))
+import Data.X509.EC (unserializePoint)
+
+-- | The NIST P-256 curve (a.k.a. prime256v1 / secp256r1).
+curve :: Curve
+curve = getCurveByName SEC_p256r1
+
+-- | Curve order (n).
+curveOrder :: Integer
+curveOrder = ecc_n (common_curve curve)
+
+-- | Generate a new P-256 key pair, returning (public SPKI DER, 32-byte private).
+generate :: IO (ByteString, ByteString)
+generate = do
+  d <- randomScalar
+  let q = generateQ curve d
+  pure (encodePublicKey q, i2ospOf_ 32 d)
+
+-- | Draw a private scalar in [1, n-1] via rejection sampling.
+randomScalar :: IO Integer
+randomScalar = do
+  bytes <- getRandomBytes 32 :: IO ByteString
+  let d = os2ip bytes
+  if d >= 1 && d < curveOrder then pure d else randomScalar
+
+-- | Sign a message with a 32-byte private scalar (ECDSA/SHA-256, DER output).
+-- Runs in IO because ECDSA signing requires a random nonce.
+signIO :: ByteString -> ByteString -> IO (Either String ByteString)
+signIO privRaw msg
+  | BS.length privRaw /= 32 = pure (Left "ECDSA.signIO: private key must be 32 bytes")
+  | otherwise = do
+      let priv = ECDSA.PrivateKey curve (os2ip privRaw)
+      sig <- ECDSA.sign priv SHA256 msg
+      pure (Right (encodeSignature sig))
+
+-- | Verify a DER signature against an SPKI-DER public key (ECDSA/SHA-256).
+verify :: ByteString -> ByteString -> ByteString -> Bool
+verify pubDer msg sigDer =
+  case (decodePublicKey pubDer, decodeSignature sigDer) of
+    (Right pt, Right sig) -> ECDSA.verify SHA256 (ECDSA.PublicKey curve pt) sig msg
+    _ -> False
+
+-- | Encode a curve point as DER SubjectPublicKeyInfo (uncompressed point).
+encodePublicKey :: Point -> ByteString
+encodePublicKey PointO = BS.empty
+encodePublicKey (Point x y) =
+  let uncompressed = BS.cons 0x04 (i2ospOf_ 32 x <> i2ospOf_ 32 y)
+      pub = PubKeyEC (PubKeyEC_Named SEC_p256r1 (SerializedPoint uncompressed))
+   in encodeASN1' DER (toASN1 pub [])
+
+-- | Decode a DER SubjectPublicKeyInfo into a curve point.
+decodePublicKey :: ByteString -> Either String Point
+decodePublicKey bs =
+  case decodeASN1' DER bs of
+    Left err -> Left $ "ECDSA.decodePublicKey: " <> show err
+    Right asn1 -> case fromASN1 asn1 of
+      Right (PubKeyEC (PubKeyEC_Named name sp), _) ->
+        case unserializePoint (getCurveByName name) sp of
+          Just pt -> Right pt
+          Nothing -> Left "ECDSA.decodePublicKey: invalid EC point"
+      Right _ -> Left "ECDSA.decodePublicKey: not a named EC public key"
+      Left err -> Left $ "ECDSA.decodePublicKey: " <> err
+
+-- | Encode an ECDSA signature as DER SEQUENCE { r, s }.
+encodeSignature :: ECDSA.Signature -> ByteString
+encodeSignature (ECDSA.Signature r s) =
+  encodeASN1' DER [Start Sequence, IntVal r, IntVal s, End Sequence]
+
+-- | Decode a DER SEQUENCE { r, s } into an ECDSA signature.
+decodeSignature :: ByteString -> Either String ECDSA.Signature
+decodeSignature bs =
+  case decodeASN1' DER bs of
+    Left err -> Left $ "ECDSA.decodeSignature: " <> show err
+    Right (Start Sequence : IntVal r : IntVal s : End Sequence : _) ->
+      Right (ECDSA.Signature r s)
+    Right _ -> Left "ECDSA.decodeSignature: unexpected ASN.1 structure"

--- a/src/Network/LibP2P/Crypto/Key.hs
+++ b/src/Network/LibP2P/Crypto/Key.hs
@@ -9,12 +9,14 @@ module Network.LibP2P.Crypto.Key
   , verify
   , generateRSAKeyPair
   , generateSecp256k1KeyPair
+  , generateECDSAKeyPair
   ) where
 
 import qualified Crypto.Error as CE
 import qualified Crypto.PubKey.Ed25519 as Ed
 import Data.ByteArray (convert)
 import Data.ByteString (ByteString)
+import qualified Network.LibP2P.Crypto.ECDSA as ECDSA
 import qualified Network.LibP2P.Crypto.RSA as RSA
 import qualified Network.LibP2P.Crypto.Secp256k1 as Secp256k1
 
@@ -23,6 +25,7 @@ data KeyType
   = Ed25519
   | RSA
   | Secp256k1
+  | ECDSA
   deriving (Show, Eq, Ord)
 
 -- | A public key with its type.
@@ -65,6 +68,8 @@ sign (PrivateKey Ed25519 skRaw) msg =
 sign (PrivateKey RSA skRaw) msg = RSA.sign skRaw msg
 sign (PrivateKey Secp256k1 _) _ =
   Left "sign: secp256k1 signing runs in IO (Network.LibP2P.Crypto.Secp256k1.signIO)"
+sign (PrivateKey ECDSA _) _ =
+  Left "sign: ECDSA signing runs in IO (Network.LibP2P.Crypto.ECDSA.signIO)"
 
 -- | Verify a signature against a public key and message.
 -- Supports every libp2p key type so remote peers of any type can be authenticated.
@@ -75,6 +80,7 @@ verify (PublicKey Ed25519 pkRaw) msg sigRaw =
     _ -> False
 verify (PublicKey RSA pkRaw) msg sigRaw = RSA.verify pkRaw msg sigRaw
 verify (PublicKey Secp256k1 pkRaw) msg sigRaw = Secp256k1.verify pkRaw msg sigRaw
+verify (PublicKey ECDSA pkRaw) msg sigRaw = ECDSA.verify pkRaw msg sigRaw
 
 -- | Generate a new RSA key pair (2048-bit) with libp2p wire-format key bytes.
 generateRSAKeyPair :: IO KeyPair
@@ -87,3 +93,9 @@ generateSecp256k1KeyPair :: IO KeyPair
 generateSecp256k1KeyPair = do
   (pub, priv) <- Secp256k1.generate
   pure $ KeyPair (PublicKey Secp256k1 pub) (PrivateKey Secp256k1 priv)
+
+-- | Generate a new ECDSA (P-256) key pair with libp2p wire-format key bytes.
+generateECDSAKeyPair :: IO KeyPair
+generateECDSAKeyPair = do
+  (pub, priv) <- ECDSA.generate
+  pure $ KeyPair (PublicKey ECDSA pub) (PrivateKey ECDSA priv)

--- a/src/Network/LibP2P/Crypto/Protobuf.hs
+++ b/src/Network/LibP2P/Crypto/Protobuf.hs
@@ -17,17 +17,18 @@ import Network.LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 import Network.LibP2P.Crypto.Key (KeyType (..), PublicKey (..))
 
 -- | Protobuf KeyType enum values (per libp2p peer-ids spec: RSA=0, Ed25519=1,
--- Secp256k1=2, ECDSA=3). ECDSA is not yet supported and decodes to a typed error.
+-- Secp256k1=2, ECDSA=3).
 keyTypeToProto :: KeyType -> Word64
 keyTypeToProto RSA = 0
 keyTypeToProto Ed25519 = 1
 keyTypeToProto Secp256k1 = 2
+keyTypeToProto ECDSA = 3
 
 keyTypeFromProto :: Word64 -> Either String KeyType
 keyTypeFromProto 0 = Right RSA
 keyTypeFromProto 1 = Right Ed25519
 keyTypeFromProto 2 = Right Secp256k1
-keyTypeFromProto 3 = Left "unsupported KeyType: ECDSA (3)"
+keyTypeFromProto 3 = Right ECDSA
 keyTypeFromProto n = Left $ "unknown KeyType: " <> show n
 
 -- | Deterministic protobuf encoding of a PublicKey message.

--- a/test/Test/Network/LibP2P/Crypto/ECDSASpec.hs
+++ b/test/Test/Network/LibP2P/Crypto/ECDSASpec.hs
@@ -1,0 +1,40 @@
+module Test.Network.LibP2P.Crypto.ECDSASpec (spec) where
+
+import qualified Data.ByteString as BS
+import qualified Network.LibP2P.Crypto.ECDSA as ECDSA
+import Network.LibP2P.Crypto.Key
+import Network.LibP2P.Crypto.PeerId
+import Network.LibP2P.Crypto.Protobuf
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "ECDSA (P-256) peer identity" $ do
+    it "generates a key pair of the ECDSA key type" $ do
+      kp <- generateECDSAKeyPair
+      pkType (publicKey kp) `shouldBe` ECDSA
+      (BS.length (pkBytes (publicKey kp)) > 0) `shouldBe` True
+
+    it "round-trips the public key through protobuf" $ do
+      kp <- generateECDSAKeyPair
+      let pub = publicKey kp
+      case decodePublicKey (encodePublicKey pub) of
+        Left err -> expectationFailure err
+        Right pub' -> do
+          pkType pub' `shouldBe` ECDSA
+          pkBytes pub' `shouldBe` pkBytes pub
+
+    it "round-trips the PeerId through base58" $ do
+      kp <- generateECDSAKeyPair
+      let pid = fromPublicKey (publicKey kp)
+      fromBase58 (toBase58 pid) `shouldBe` Right pid
+
+    it "signs and verifies a message" $ do
+      kp <- generateECDSAKeyPair
+      let msg = "libp2p ecdsa identity"
+      signed <- ECDSA.signIO (skBytes (kpPrivate kp)) msg
+      case signed of
+        Left err -> expectationFailure err
+        Right sig -> do
+          verify (kpPublic kp) msg sig `shouldBe` True
+          verify (kpPublic kp) "tampered" sig `shouldBe` False

--- a/test/Test/Network/LibP2P/Crypto/RSASpec.hs
+++ b/test/Test/Network/LibP2P/Crypto/RSASpec.hs
@@ -40,13 +40,6 @@ spec = do
           verify (kpPublic kp) "tampered" sig `shouldBe` False
 
   describe "protobuf key-type decoding" $ do
-    it "fails gracefully on the unsupported ECDSA key type" $ do
-      -- Field 1 (Type) = 3 (ECDSA), Field 2 (Data) = empty.
-      let bs = BS.pack [0x08, 0x03, 0x12, 0x00]
-      case decodePublicKey bs of
-        Left err -> null err `shouldBe` False
-        Right _ -> expectationFailure "expected decode to fail for ECDSA"
-
     it "fails gracefully on an unknown key type" $ do
       let bs = BS.pack [0x08, 0x63, 0x12, 0x00]
       case decodePublicKey bs of


### PR DESCRIPTION
Follow-up to #137 (RSA/secp256k1). Completes the libp2p key-type set by adding ECDSA over NIST P-256, addressing the "and ECDSA if in scope" note on #7.

## Changes
- `KeyType` gains `ECDSA` (proto `3`); `Protobuf` now decodes it (previously a typed error).
- **`Crypto.ECDSA`** (new): DER SubjectPublicKeyInfo public keys (uncompressed point) via `crypton-x509`, 32-byte scalar private keys, ECDSA/SHA-256 with DER signatures over P-256 — matching go-libp2p's wire format.
- `Key.verify` dispatches to ECDSA; signing (randomised nonce) lives in `ECDSA.signIO`. Local identities remain Ed25519.

## Design note
Public keys use SPKI DER (uncompressed point) as go-libp2p does, distinct from secp256k1's 33-byte compressed encoding. Uses `crypton` generic ECC + `crypton-x509`, consistent with the RSA/secp256k1 path — no extra dependencies.

## Tests
- ECDSA keypair generation, protobuf public-key round-trip, PeerId base58 round-trip, sign/verify.

Full suite: **597 examples, 0 failures**.