### PR TITLE
fix(gossipsub): verify inbound message signatures before propagation

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -82,6 +82,7 @@ library
     LibP2P.Protocol.GossipSub.Message
     LibP2P.Protocol.GossipSub.Router
     LibP2P.Protocol.GossipSub.Score
+    LibP2P.Protocol.GossipSub.Validation
     LibP2P.Protocol.GossipSub.MessageCache
     LibP2P.Protocol.GossipSub.Heartbeat
     LibP2P.Protocol.GossipSub.Handler
@@ -168,6 +169,7 @@ test-suite libp2p-hs-test
     LibP2P.Protocol.GossipSub.MessageSpec
     LibP2P.Protocol.GossipSub.RouterSpec
     LibP2P.Protocol.GossipSub.ScoreSpec
+    LibP2P.Protocol.GossipSub.ValidationSpec
     LibP2P.Protocol.GossipSub.MessageCacheSpec
     LibP2P.Protocol.GossipSub.HeartbeatSpec
     LibP2P.Protocol.GossipSub.HandlerSpec

--- a/src/LibP2P/Protocol/GossipSub/Router.hs
+++ b/src/LibP2P/Protocol/GossipSub/Router.hs
@@ -14,6 +14,9 @@ module LibP2P.Protocol.GossipSub.Router
   , leave
     -- * Publishing
   , publish
+    -- * Topic validation
+  , registerValidator
+  , unregisterValidator
     -- * Inbound RPC handling
   , handleRPC
     -- * Control message handlers
@@ -29,6 +32,7 @@ module LibP2P.Protocol.GossipSub.Router
   ) where
 
 import Prelude
+import Control.Exception (throwIO)
 import Control.Monad (unless)
 import Control.Concurrent.STM
 import Data.ByteString (ByteString)
@@ -42,9 +46,9 @@ import LibP2P.Crypto.PeerId (PeerId, peerIdBytes)
 import LibP2P.Crypto.Key (KeyPair (..), sign)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Protocol.GossipSub.Types
-import LibP2P.Protocol.GossipSub.Message (encodePubSubMessageBS)
 import LibP2P.Protocol.GossipSub.MessageCache (newMessageCache, cachePut, cacheGet)
-import LibP2P.Protocol.GossipSub.Score (computeScore, addP7Penalty, recordMeshFailure)
+import LibP2P.Protocol.GossipSub.Score (computeScore, addP7Penalty, recordMeshFailure, recordInvalidMessage)
+import LibP2P.Protocol.GossipSub.Validation (validateMessage, signingBytes)
 
 -- | Create a new GossipSub router with empty state.
 newRouter :: GossipSubParams
@@ -63,6 +67,7 @@ newRouter params localPid sendRPC getTime = do
   mcache   <- newTVarIO (newMessageCache (paramMcacheLen params) (paramMcacheGossip params))
   hbCount  <- newTVarIO 0
   onMsg    <- newTVarIO (\_ _ -> pure ())
+  validators <- newTVarIO Map.empty
   pure GossipSubRouter
     { gsParams         = params
     , gsLocalPeerId    = localPid
@@ -80,7 +85,21 @@ newRouter params localPid sendRPC getTime = do
     , gsSendRPC        = sendRPC
     , gsGetTime        = getTime
     , gsOnMessage      = onMsg
+    , gsValidators     = validators
     }
+
+-- Topic validation
+
+-- | Attach an application validator to a topic. Messages the validator rejects
+-- are dropped without propagation and count against the sender's P4 score.
+registerValidator :: GossipSubRouter -> Topic -> TopicValidator -> IO ()
+registerValidator router topic v = atomically $
+  modifyTVar' (gsValidators router) (Map.insert topic v)
+
+-- | Remove a topic's validator.
+unregisterValidator :: GossipSubRouter -> Topic -> IO ()
+unregisterValidator router topic = atomically $
+  modifyTVar' (gsValidators router) (Map.delete topic)
 
 -- Peer management
 
@@ -190,7 +209,7 @@ publish router topic payload mKeyPair = do
   -- Build message (with signing if StrictSign)
   msg <- case paramSignaturePolicy (gsParams router) of
     StrictSign -> case mKeyPair of
-      Nothing -> pure $ mkUnsignedMessage topic payload
+      Nothing -> throwIO (SigningFailed "StrictSign publish requires a key pair")
       Just kp -> mkSignedMessage router topic payload kp
     StrictNoSign -> pure $ mkUnsignedMessage topic payload
 
@@ -265,34 +284,61 @@ handleRPC router sender rpc = do
       handleGraft router sender (ctrlGraft ctrl)
       handlePrune router sender (ctrlPrune ctrl)
 
--- | Process a published message: deduplicate, validate, forward, deliver.
+-- | Process a published message: verify, deduplicate, validate, forward, deliver.
+--
+-- Signature verification runs before deduplication so that an invalid message
+-- is never cached, forwarded or delivered, and never poisons the seen cache for
+-- the genuine message with the same ID.
 handlePublishedMessage :: GossipSubRouter -> PeerId -> PubSubMessage -> IO ()
-handlePublishedMessage router sender msg = do
-  let msgId = paramMessageIdFn (gsParams router) msg
-  now <- gsGetTime router
+handlePublishedMessage router sender msg =
+  case validateMessage (paramSignaturePolicy (gsParams router)) msg of
+    Left _err -> rejectMessage router sender msg
+    Right ()  -> do
+      let msgId = paramMessageIdFn (gsParams router) msg
+      now <- gsGetTime router
 
-  -- Deduplicate
-  alreadySeen <- atomically $ do
-    s <- readTVar (gsSeen router)
-    if Map.member msgId s
-      then pure True
-      else do
-        writeTVar (gsSeen router) (Map.insert msgId now s)
-        pure False
+      -- Deduplicate
+      alreadySeen <- atomically $ do
+        s <- readTVar (gsSeen router)
+        if Map.member msgId s
+          then pure True
+          else do
+            writeTVar (gsSeen router) (Map.insert msgId now s)
+            pure False
 
-  if alreadySeen
-    then pure ()
-    else do
-      -- Cache the message for IWANT responses
-      atomically $ modifyTVar' (gsMessageCache router) $
-        cachePut msgId msg
+      unless alreadySeen $ do
+        accepted <- runTopicValidator router sender msg
+        if not accepted
+          then rejectMessage router sender msg
+          else do
+            -- Cache the message for IWANT responses
+            atomically $ modifyTVar' (gsMessageCache router) $
+              cachePut msgId msg
 
-      -- Forward to mesh peers (excluding sender)
-      forwardMessage router sender msg
+            -- Forward to mesh peers (excluding sender)
+            forwardMessage router sender msg
 
-      -- Deliver to application
-      onMsg <- readTVarIO (gsOnMessage router)
-      onMsg (msgTopic msg) msg
+            -- Deliver to application
+            onMsg <- readTVarIO (gsOnMessage router)
+            onMsg (msgTopic msg) msg
+
+-- | Run the topic validator, if one is registered. No validator means accept.
+runTopicValidator :: GossipSubRouter -> PeerId -> PubSubMessage -> IO Bool
+runTopicValidator router sender msg = do
+  validators <- readTVarIO (gsValidators router)
+  case Map.lookup (msgTopic msg) validators of
+    Nothing -> pure True
+    Just v  -> v sender msg
+
+-- | Drop a message and charge the propagation source a P4 invalid delivery.
+rejectMessage :: GossipSubRouter -> PeerId -> PubSubMessage -> IO ()
+rejectMessage router sender msg = atomically $
+  modifyTVar' (gsPeers router) $ Map.adjust bumpInvalid sender
+  where
+    topic = msgTopic msg
+    bumpInvalid ps =
+      let tps = Map.findWithDefault defaultTopicPeerState topic (psTopicState ps)
+      in ps { psTopicState = Map.insert topic (recordInvalidMessage tps) (psTopicState ps) }
 
 -- Control message handlers
 
@@ -466,14 +512,8 @@ mkSignedMessage router topic payload kp = do
         , msgSignature = Nothing
         , msgKey       = Just pubKeyBytes
         }
-      -- Sign: prefix "libp2p-pubsub:" + marshalled message
-      signData = "libp2p-pubsub:" <> marshalForSigning unsigned
-  case sign (kpPrivate kp) signData of
-    Left _err -> pure unsigned  -- Signing failed, send unsigned
+  case sign (kpPrivate kp) (signingBytes unsigned) of
+    -- Publishing unsigned under StrictSign would emit a message every
+    -- compliant receiver must drop, so fail loudly instead.
+    Left err  -> throwIO (SigningFailed err)
     Right sig -> pure unsigned { msgSignature = Just sig }
-
--- | Marshal a message for signature computation.
--- Per the libp2p spec, the signed data excludes both signature and key fields.
-marshalForSigning :: PubSubMessage -> ByteString
-marshalForSigning msg = encodePubSubMessageBS
-  (msg { msgSignature = Nothing, msgKey = Nothing })

--- a/src/LibP2P/Protocol/GossipSub/Types.hs
+++ b/src/LibP2P/Protocol/GossipSub/Types.hs
@@ -26,6 +26,10 @@ module LibP2P.Protocol.GossipSub.Types
   , RPC (..)
     -- * Signature policy
   , SignaturePolicy (..)
+    -- * Errors
+  , GossipSubError (..)
+    -- * Topic validation
+  , TopicValidator
     -- * Configuration
   , GossipSubParams (..)
   , defaultGossipSubParams
@@ -53,6 +57,7 @@ module LibP2P.Protocol.GossipSub.Types
   ) where
 
 import Control.Concurrent.STM (TVar)
+import Control.Exception (Exception)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Map.Strict (Map)
@@ -147,6 +152,25 @@ data SignaturePolicy
   = StrictSign       -- ^ All messages must be signed
   | StrictNoSign     -- ^ No signatures allowed
   deriving (Show, Eq)
+
+-- Errors
+
+-- | Fatal GossipSub errors surfaced to the caller.
+data GossipSubError
+  = SigningFailed String
+    -- ^ StrictSign publish could not sign the message. Emitting it unsigned
+    -- would produce a message every compliant receiver must reject, so the
+    -- publish fails instead.
+  deriving (Show, Eq)
+
+instance Exception GossipSubError
+
+-- Topic validation
+
+-- | Application validator for a topic. Receives the propagation source and the
+-- message; returning False drops the message without propagation
+-- (specs/pubsub/README.md, "Topic validation").
+type TopicValidator = PeerId -> PubSubMessage -> IO Bool
 
 -- Configuration
 
@@ -389,6 +413,8 @@ data GossipSubRouter = GossipSubRouter
     -- ^ Time source (injectable for deterministic tests)
   , gsOnMessage   :: !(TVar (Topic -> PubSubMessage -> IO ()))
     -- ^ Application message callback
+  , gsValidators  :: !(TVar (Map Topic TopicValidator))
+    -- ^ Per-topic application validators, applied before propagation
   }
 
 -- Defaults

--- a/src/LibP2P/Protocol/GossipSub/Validation.hs
+++ b/src/LibP2P/Protocol/GossipSub/Validation.hs
@@ -1,0 +1,87 @@
+-- | Inbound pubsub message validation (specs/pubsub/README.md).
+--
+-- Under @StrictSign@ the consuming side must enforce that @from@, @seqno@ and
+-- @signature@ are present, that the signature verifies against the author's
+-- public key, and that the key matches the @from@ peer ID. Messages that fail
+-- are dropped without propagation. Under @StrictNoSign@ the signing fields must
+-- be absent.
+--
+-- The signed bytes are @"libp2p-pubsub:" <> protobuf(msg without signature and
+-- key)@, symmetric with the signing path in "LibP2P.Protocol.GossipSub.Router".
+module LibP2P.Protocol.GossipSub.Validation
+  ( ValidationError (..)
+  , validateMessage
+  , signaturePrefix
+  , marshalForSigning
+  , signingBytes
+  ) where
+
+import Prelude
+import Control.Monad (unless, when)
+import Data.ByteString (ByteString)
+import LibP2P.Core.Multihash (HashFunction (..), validateMultihash)
+import LibP2P.Crypto.Key (PublicKey, verify)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
+import LibP2P.Crypto.Protobuf (decodePublicKey)
+import LibP2P.Protocol.GossipSub.Message (encodePubSubMessageBS)
+import LibP2P.Protocol.GossipSub.Types
+
+-- | Why an inbound message was rejected.
+data ValidationError
+  = MissingField String       -- ^ A field required by StrictSign is absent
+  | UnexpectedField String    -- ^ A signing field is present under StrictNoSign
+  | MalformedKey String       -- ^ The key field (or inlined key) failed to decode
+  | KeyPeerIdMismatch         -- ^ The public key does not derive the @from@ peer ID
+  | BadSignature              -- ^ Signature verification failed
+  deriving (Show, Eq)
+
+-- | Domain separation prefix for pubsub message signatures.
+signaturePrefix :: ByteString
+signaturePrefix = "libp2p-pubsub:"
+
+-- | Marshal a message for signature computation.
+-- Per the libp2p spec, the signed data excludes both signature and key fields.
+marshalForSigning :: PubSubMessage -> ByteString
+marshalForSigning msg = encodePubSubMessageBS
+  (msg { msgSignature = Nothing, msgKey = Nothing })
+
+-- | The exact bytes covered by a message signature.
+signingBytes :: PubSubMessage -> ByteString
+signingBytes msg = signaturePrefix <> marshalForSigning msg
+
+-- | Validate an inbound message against the configured signature policy.
+validateMessage :: SignaturePolicy -> PubSubMessage -> Either ValidationError ()
+validateMessage StrictSign msg = do
+  from <- required "from" (msgFrom msg)
+  _    <- required "seqno" (msgSeqNo msg)
+  sig  <- required "signature" (msgSignature msg)
+  pk   <- authorKey from (msgKey msg)
+  let PeerId derived = fromPublicKey pk
+  unless (derived == from) (Left KeyPeerIdMismatch)
+  unless (verify pk (signingBytes msg) sig) (Left BadSignature)
+validateMessage StrictNoSign msg = do
+  forbid "signature" (msgSignature msg)
+  forbid "key" (msgKey msg)
+  forbid "from" (msgFrom msg)
+  forbid "seqno" (msgSeqNo msg)
+
+-- | Resolve the author's public key: from the explicit key field when present,
+-- otherwise from the identity multihash inlined in the @from@ peer ID.
+-- Implementations omit the key field whenever the peer ID inlines it (small
+-- keys such as Ed25519), so both forms must be accepted.
+authorKey :: ByteString -> Maybe ByteString -> Either ValidationError PublicKey
+authorKey from Nothing =
+  case validateMultihash from of
+    Left err -> Left (MalformedKey ("from is not a valid multihash: " <> err))
+    Right (SHA256, _) -> Left (MissingField "key")
+    Right (Identity, inlined) -> decodeKey inlined
+authorKey _ (Just keyBytes) = decodeKey keyBytes
+
+decodeKey :: ByteString -> Either ValidationError PublicKey
+decodeKey bs = either (Left . MalformedKey) Right (decodePublicKey bs)
+
+required :: String -> Maybe a -> Either ValidationError a
+required name = maybe (Left (MissingField name)) Right
+
+forbid :: String -> Maybe a -> Either ValidationError ()
+forbid name v = when (maybe False (const True) v) (Left (UnexpectedField name))

--- a/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
@@ -17,8 +17,9 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
-import LibP2P.Crypto.Key (KeyPair, publicKey)
-import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.Crypto.Key (KeyPair (..), publicKey, sign)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
+import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.MultistreamSelect.Negotiation
   ( NegotiationResult (..)
   , StreamIO (..)
@@ -41,6 +42,7 @@ import LibP2P.Protocol.GossipSub.Message
   , writeRPCMessage
   )
 import LibP2P.Protocol.GossipSub.Router (addPeer)
+import LibP2P.Protocol.GossipSub.Validation (signingBytes)
 import LibP2P.Protocol.GossipSub.Types
   ( GossipSubParams (..)
   , GossipSubRouter (..)
@@ -64,6 +66,22 @@ mkTestIdentity = do
   Right kp <- generateKeyPair
   let pid = fromPublicKey (publicKey kp)
   pure (pid, kp)
+
+-- | Build a correctly signed message, as a remote peer would publish it.
+signedMessage :: KeyPair -> Topic -> BS.ByteString -> PubSubMessage
+signedMessage kp topic payload =
+  let PeerId from = fromPublicKey (publicKey kp)
+      unsigned = PubSubMessage
+        { msgFrom      = Just from
+        , msgData      = payload
+        , msgSeqNo     = Just (BS.pack [0, 0, 0, 0, 0, 0, 0, 1])
+        , msgTopic     = topic
+        , msgSignature = Nothing
+        , msgKey       = Just (encodePublicKey (publicKey kp))
+        }
+  in case sign (kpPrivate kp) (signingBytes unsigned) of
+       Left err  -> error ("test fixture signing failed: " <> err)
+       Right sig -> unsigned { msgSignature = Just sig }
 
 -- | Create a test Switch (no transport needed for handler unit tests).
 mkTestSwitch :: IO (Switch, PeerId)
@@ -131,7 +149,7 @@ spec = do
     it "processes publish RPCs and delivers to onMessage callback" $ do
       (sw, _localPid) <- mkTestSwitch
       node <- newGossipSubNode sw testParams
-      (remotePid, _kp) <- mkTestIdentity
+      (remotePid, remoteKp) <- mkTestIdentity
       -- Set up message callback
       msgMVar <- newEmptyMVar
       atomically $ writeTVar (gsOnMessage (gsnRouter node))
@@ -145,14 +163,7 @@ spec = do
       -- Spawn handler
       _ <- async $ handleGossipSubStream node handlerStream remotePid
       -- Send a publish RPC
-      let msg = PubSubMessage
-            { msgFrom      = Just (BS.pack [1,2,3])
-            , msgData      = "hello gossipsub"
-            , msgSeqNo     = Just (BS.pack [0,0,0,0,0,0,0,1])
-            , msgTopic     = "pub-topic"
-            , msgSignature = Nothing
-            , msgKey       = Nothing
-            }
+      let msg = signedMessage remoteKp "pub-topic" "hello gossipsub"
       writeRPCMessage remoteStream (emptyRPC { rpcPublish = [msg] })
       -- Wait for callback
       result <- timeout 2000000 $ takeMVar msgMVar

--- a/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
@@ -10,9 +10,14 @@ import qualified Data.Set as Set
 import Data.IORef
 import Data.Time (UTCTime, addUTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import LibP2P.Crypto.PeerId (PeerId (..))
+import Control.Exception (try)
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair (..), sign)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
+import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Protocol.GossipSub.Types
 import LibP2P.Protocol.GossipSub.Router
+import LibP2P.Protocol.GossipSub.Validation (signingBytes, validateMessage)
 
 -- Test helpers
 
@@ -58,6 +63,35 @@ mkTestRouterWithTime localPid t = do
 
 localPid :: PeerId
 localPid = mkPeerId 0
+
+-- | A fresh Ed25519 identity for signing test messages.
+newKeyPair :: IO KeyPair
+newKeyPair = either (error . ("keygen failed: " <>)) id <$> generateKeyPair
+
+-- | Build a correctly signed message, mirroring the publish path.
+signedMessage :: KeyPair -> Topic -> ByteString -> PubSubMessage
+signedMessage kp topic payload =
+  let PeerId from = fromPublicKey (kpPublic kp)
+      unsigned = PubSubMessage
+        { msgFrom      = Just from
+        , msgData      = payload
+        , msgSeqNo     = Just (BS.pack [0, 0, 0, 0, 0, 0, 0, 1])
+        , msgTopic     = topic
+        , msgSignature = Nothing
+        , msgKey       = Just (encodePublicKey (kpPublic kp))
+        }
+  in case sign (kpPrivate kp) (signingBytes unsigned) of
+       Left err  -> error ("test fixture signing failed: " <> err)
+       Right sig -> unsigned { msgSignature = Just sig }
+
+-- | P4 invalid-message counter recorded for a peer on a topic.
+invalidCount :: GossipSubRouter -> PeerId -> Topic -> IO Double
+invalidCount router pid topic = do
+  peers <- readTVarIO (gsPeers router)
+  pure $ case Map.lookup pid peers of
+    Nothing -> 0
+    Just ps -> tpsInvalidMessages
+      (Map.findWithDefault defaultTopicPeerState topic (psTopicState ps))
 
 -- | Add a peer that is subscribed to a topic.
 addSubscribedPeer :: GossipSubRouter -> PeerId -> Topic -> IO ()
@@ -385,7 +419,8 @@ spec = do
         addSubscribedPeer router peerA "blocks"
         addSubscribedPeer router peerB "blocks"
         addPeer router peerC GossipSubPeer False fixedTime
-        publish router "blocks" (BS.pack [1, 2, 3]) Nothing
+        kp <- newKeyPair
+        publish router "blocks" (BS.pack [1, 2, 3]) (Just kp)
         sent <- readIORef logRef
         -- peerA and peerB should receive, but not peerC
         let publishedTo = map fst $ filter (\(_, rpc) -> not (null (rpcPublish rpc))) sent
@@ -395,9 +430,33 @@ spec = do
         (router, _) <- mkTestRouter localPid
         let peerA = mkPeerId 1
         addSubscribedPeer router peerA "blocks"
-        publish router "blocks" (BS.pack [1, 2, 3]) Nothing
+        kp <- newKeyPair
+        publish router "blocks" (BS.pack [1, 2, 3]) (Just kp)
         seen <- readTVarIO (gsSeen router)
         Map.size seen `shouldBe` 1
+
+      it "signs the message and the result verifies under StrictSign" $ do
+        kp <- newKeyPair
+        (router, logRef) <- mkTestRouter (fromPublicKey (kpPublic kp))
+        let peerA = mkPeerId 1
+        addSubscribedPeer router peerA "blocks"
+        publish router "blocks" (BS.pack [1, 2, 3]) (Just kp)
+        sent <- readIORef logRef
+        case concatMap (rpcPublish . snd) sent of
+          [msg] -> do
+            msgSignature msg `shouldSatisfy` (/= Nothing)
+            validateMessage StrictSign msg `shouldBe` Right ()
+          other -> expectationFailure ("expected one published message, got " <> show (length other))
+
+      it "fails loudly instead of publishing unsigned under StrictSign" $ do
+        (router, logRef) <- mkTestRouter localPid
+        addSubscribedPeer router (mkPeerId 1) "blocks"
+        result <- try (publish router "blocks" (BS.pack [1]) Nothing)
+        case result of
+          Left (SigningFailed _) -> pure ()
+          Right ()               -> expectationFailure "expected SigningFailed"
+        sent <- readIORef logRef
+        sent `shouldBe` []
 
       it "delivers message to local application callback" $ do
         (router, _) <- mkTestRouter localPid
@@ -406,7 +465,8 @@ spec = do
           modifyIORef' deliveredRef (++ [(topic, msgData msg)])
         let peerA = mkPeerId 1
         addSubscribedPeer router peerA "blocks"
-        publish router "blocks" (BS.pack [42]) Nothing
+        kp <- newKeyPair
+        publish router "blocks" (BS.pack [42]) (Just kp)
         delivered <- readIORef deliveredRef
         length delivered `shouldBe` 1
         snd (head delivered) `shouldBe` BS.pack [42]
@@ -469,14 +529,118 @@ spec = do
         deliveredRef <- newIORef (0 :: Int)
         atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
           modifyIORef' deliveredRef (+ 1)
-        let msg = PubSubMessage (Just (BS.pack [1])) (BS.pack [1]) (Just (BS.pack [0,0,0,0,0,0,0,1])) "t" Nothing Nothing
-            rpc = emptyRPC { rpcPublish = [msg] }
+        kp <- newKeyPair
+        let rpc = emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
         -- Send same message twice
         handleRPC router sender rpc
         handleRPC router sender rpc
         delivered <- readIORef deliveredRef
         -- Should only be delivered once
         delivered `shouldBe` 1
+
+    describe "inbound message validation" $ do
+      it "delivers and forwards a correctly signed message" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            meshPeer = mkPeerId 2
+        addPeer router sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.fromList [sender, meshPeer])
+        deliveredRef <- newIORef (0 :: Int)
+        atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
+          modifyIORef' deliveredRef (+ 1)
+        kp <- newKeyPair
+        handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
+        readIORef deliveredRef `shouldReturn` 1
+        sent <- readIORef logRef
+        map fst sent `shouldBe` [meshPeer]
+
+      it "drops a message with a forged signature without forwarding or delivering" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            meshPeer = mkPeerId 2
+        addPeer router sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.fromList [sender, meshPeer])
+        deliveredRef <- newIORef (0 :: Int)
+        atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
+          modifyIORef' deliveredRef (+ 1)
+        kp <- newKeyPair
+        let forged = (signedMessage kp "t" (BS.pack [1])) { msgData = BS.pack [99] }
+        handleRPC router sender emptyRPC { rpcPublish = [forged] }
+        readIORef deliveredRef `shouldReturn` 0
+        readIORef logRef `shouldReturn` []
+        -- Not cached for IWANT, and not marked seen
+        cache <- readTVarIO (gsMessageCache router)
+        Map.size (mcIndex cache) `shouldBe` 0
+        seen <- readTVarIO (gsSeen router)
+        Map.size seen `shouldBe` 0
+
+      it "drops a message whose from does not match its key" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        deliveredRef <- newIORef (0 :: Int)
+        atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
+          modifyIORef' deliveredRef (+ 1)
+        kp <- newKeyPair
+        impostor <- newKeyPair
+        let PeerId spoofed = fromPublicKey (kpPublic impostor)
+            msg = (signedMessage kp "t" (BS.pack [1])) { msgFrom = Just spoofed }
+        handleRPC router sender emptyRPC { rpcPublish = [msg] }
+        readIORef deliveredRef `shouldReturn` 0
+
+      it "charges the sender a P4 invalid delivery for a rejected message" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        kp <- newKeyPair
+        let forged = (signedMessage kp "t" (BS.pack [1])) { msgData = BS.pack [99] }
+        handleRPC router sender emptyRPC { rpcPublish = [forged] }
+        invalidCount router sender "t" `shouldReturn` 1
+
+    describe "topic validators" $ do
+      it "drops a message the topic validator rejects" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            meshPeer = mkPeerId 2
+        addPeer router sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.fromList [sender, meshPeer])
+        deliveredRef <- newIORef (0 :: Int)
+        atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
+          modifyIORef' deliveredRef (+ 1)
+        registerValidator router "t" (\_ _ -> pure False)
+        kp <- newKeyPair
+        handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
+        readIORef deliveredRef `shouldReturn` 0
+        readIORef logRef `shouldReturn` []
+        invalidCount router sender "t" `shouldReturn` 1
+
+      it "propagates a message the topic validator accepts" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        deliveredRef <- newIORef (0 :: Int)
+        atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
+          modifyIORef' deliveredRef (+ 1)
+        registerValidator router "t" (\_ _ -> pure True)
+        kp <- newKeyPair
+        handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
+        readIORef deliveredRef `shouldReturn` 1
+
+      it "unregisterValidator restores unvalidated propagation" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        deliveredRef <- newIORef (0 :: Int)
+        atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
+          modifyIORef' deliveredRef (+ 1)
+        registerValidator router "t" (\_ _ -> pure False)
+        unregisterValidator router "t"
+        kp <- newKeyPair
+        handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
+        readIORef deliveredRef `shouldReturn` 1
 
     describe "peerScore" $ do
       it "returns 0 for unknown peer" $ do

--- a/test/LibP2P/Protocol/GossipSub/ValidationSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/ValidationSpec.hs
@@ -1,0 +1,109 @@
+module LibP2P.Protocol.GossipSub.ValidationSpec (spec) where
+
+import Test.Hspec
+
+import qualified Data.ByteString as BS
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair (..), sign)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
+import LibP2P.Crypto.Protobuf (encodePublicKey)
+import LibP2P.Protocol.GossipSub.Types
+import LibP2P.Protocol.GossipSub.Validation
+
+-- | Build a correctly signed message from a key pair, mirroring the publish path.
+signedMessage :: KeyPair -> Topic -> BS.ByteString -> PubSubMessage
+signedMessage kp topic payload =
+  let PeerId from = fromPublicKey (kpPublic kp)
+      unsigned = PubSubMessage
+        { msgFrom      = Just from
+        , msgData      = payload
+        , msgSeqNo     = Just (BS.pack [0, 0, 0, 0, 0, 0, 0, 1])
+        , msgTopic     = topic
+        , msgSignature = Nothing
+        , msgKey       = Just (encodePublicKey (kpPublic kp))
+        }
+  in case sign (kpPrivate kp) (signingBytes unsigned) of
+       Left err  -> error ("test fixture signing failed: " <> err)
+       Right sig -> unsigned { msgSignature = Just sig }
+
+newKeyPair :: IO KeyPair
+newKeyPair = either (error . ("keygen failed: " <>)) id <$> generateKeyPair
+
+spec :: Spec
+spec = do
+  describe "validateMessage (StrictSign)" $ do
+    it "accepts a correctly signed message" $ do
+      kp <- newKeyPair
+      validateMessage StrictSign (signedMessage kp "blocks" "payload")
+        `shouldBe` Right ()
+
+    it "accepts a signed message with the key field omitted (inlined in from)" $ do
+      kp <- newKeyPair
+      let msg = signedMessage kp "blocks" "payload"
+      validateMessage StrictSign (msg { msgKey = Nothing }) `shouldBe` Right ()
+
+    it "rejects a message whose payload was tampered with" $ do
+      kp <- newKeyPair
+      let msg = signedMessage kp "blocks" "payload"
+      validateMessage StrictSign (msg { msgData = "tampered" })
+        `shouldBe` Left BadSignature
+
+    it "rejects a message whose topic was tampered with" $ do
+      kp <- newKeyPair
+      let msg = signedMessage kp "blocks" "payload"
+      validateMessage StrictSign (msg { msgTopic = "other" })
+        `shouldBe` Left BadSignature
+
+    it "rejects a garbage signature" $ do
+      kp <- newKeyPair
+      let msg = signedMessage kp "blocks" "payload"
+      validateMessage StrictSign (msg { msgSignature = Just (BS.replicate 64 0) })
+        `shouldBe` Left BadSignature
+
+    it "rejects a spoofed from that does not match the key" $ do
+      kp <- newKeyPair
+      other <- newKeyPair
+      let msg = signedMessage kp "blocks" "payload"
+          PeerId otherFrom = fromPublicKey (kpPublic other)
+      validateMessage StrictSign (msg { msgFrom = Just otherFrom })
+        `shouldBe` Left KeyPeerIdMismatch
+
+    it "rejects a key that does not derive the from peer ID" $ do
+      kp <- newKeyPair
+      other <- newKeyPair
+      let msg = signedMessage kp "blocks" "payload"
+      validateMessage StrictSign (msg { msgKey = Just (encodePublicKey (kpPublic other)) })
+        `shouldBe` Left KeyPeerIdMismatch
+
+    it "rejects a malformed key" $ do
+      kp <- newKeyPair
+      let msg = signedMessage kp "blocks" "payload"
+      case validateMessage StrictSign (msg { msgKey = Just "not-a-protobuf" }) of
+        Left (MalformedKey _) -> pure ()
+        other -> expectationFailure ("expected MalformedKey, got " <> show other)
+
+    it "rejects missing signature, from and seqno" $ do
+      kp <- newKeyPair
+      let msg = signedMessage kp "blocks" "payload"
+      validateMessage StrictSign (msg { msgSignature = Nothing })
+        `shouldBe` Left (MissingField "signature")
+      validateMessage StrictSign (msg { msgFrom = Nothing })
+        `shouldBe` Left (MissingField "from")
+      validateMessage StrictSign (msg { msgSeqNo = Nothing })
+        `shouldBe` Left (MissingField "seqno")
+
+  describe "validateMessage (StrictNoSign)" $ do
+    it "accepts a message with no signing fields" $ do
+      let msg = PubSubMessage Nothing "payload" Nothing "blocks" Nothing Nothing
+      validateMessage StrictNoSign msg `shouldBe` Right ()
+
+    it "rejects any present signing field" $ do
+      let msg = PubSubMessage Nothing "payload" Nothing "blocks" Nothing Nothing
+      validateMessage StrictNoSign (msg { msgSignature = Just "sig" })
+        `shouldBe` Left (UnexpectedField "signature")
+      validateMessage StrictNoSign (msg { msgKey = Just "key" })
+        `shouldBe` Left (UnexpectedField "key")
+      validateMessage StrictNoSign (msg { msgFrom = Just "from" })
+        `shouldBe` Left (UnexpectedField "from")
+      validateMessage StrictNoSign (msg { msgSeqNo = Just "seqno" })
+        `shouldBe` Left (UnexpectedField "seqno")


### PR DESCRIPTION
Closes #154.

## Problem

`handlePublishedMessage` deduped, cached, forwarded and delivered every inbound message with no verification. Any peer could inject a message with an arbitrary `from` and a garbage signature, and we amplified it across our mesh. `paramSignaturePolicy` was only read on the publishing path.

## Fix

New `LibP2P.Protocol.GossipSub.Validation`, applied at the top of `handlePublishedMessage` (before dedup, so an invalid message never poisons the seen cache for the genuine one):

- **StrictSign** — requires `from`, `seqno`, `signature`; resolves the author key from the `key` field or, when absent, from the identity multihash inlined in `from` (go-libp2p omits `key` whenever the peer ID inlines it, so both forms must be accepted for interop); checks the key derives `from`; verifies the signature over `"libp2p-pubsub:" || protobuf(msg without signature and key)`, symmetric with our signing path.
- **StrictNoSign** — rejects any present signing field.
- Rejected messages are dropped without propagation and charge the propagation source a **P4 invalid delivery** — that score component previously had no possible write path.

Publish side: under StrictSign, a signing failure (or a missing key pair) now throws `SigningFailed` instead of quietly emitting an unsigned message that every compliant receiver must reject.

Also adds **topic validators** (`registerValidator` / `unregisterValidator`), required by `specs/pubsub/README.md`. A rejecting validator drops the message before propagation and records a P4 invalid delivery.

## Tests

617 examples, 0 failures (was 547).

New `ValidationSpec` covers accept, key-omitted, tampered payload/topic, garbage signature, spoofed `from`, mismatched key, malformed key, missing fields, and all StrictNoSign rejections. New `RouterSpec` cases cover forward+deliver on a valid message, full drop (no delivery, no forward, not cached, not marked seen) on a forgery, the P4 charge, and validator accept/reject/unregister. Three existing tests that asserted unsigned messages propagate were rewritten to use signed fixtures.

## Out of scope

`seqno` remains random rather than a monotonic counter (issue #154 notes rust-libp2p does the same); PRUNE peer exchange and the remaining scoring counters stay with #156/#157.