### PR TITLE
fix(relay): encode Reservation.expire as absolute Unix timestamp

### DIFF
--- a/src/LibP2P/NAT/Relay.hs
+++ b/src/LibP2P/NAT/Relay.hs
@@ -32,6 +32,7 @@ import Control.Concurrent.Async (race)
 import Control.Concurrent.STM
 import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
 import qualified Data.Map.Strict as Map
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Word (Word32, Word64)
 import LibP2P.NAT.Relay.Message
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
@@ -60,7 +61,7 @@ defaultRelayConfig = RelayConfig
 -- | An active reservation for a peer.
 data ActiveReservation = ActiveReservation
   { arPeerId     :: !PeerId
-  , arExpiration :: !Word64   -- ^ Unix timestamp
+  , arExpiration :: !Word64   -- ^ Absolute expiration time (UTC Unix time, seconds)
   } deriving (Show, Eq)
 
 -- | Mutable relay server state.
@@ -85,8 +86,10 @@ handleReserve state stream peerId = do
   if Map.size reservations >= limit
     then sendHopStatus stream ResourceLimitExceeded
     else do
-      -- Create reservation
-      let expiration = rcReservationDuration (rsConfig state)
+      -- Create reservation. Per circuit-v2 spec, Reservation.expire is an
+      -- absolute UTC Unix time in seconds, not a duration.
+      now <- getPOSIXTime
+      let expiration = floor now + rcReservationDuration (rsConfig state)
           reservation = ActiveReservation
             { arPeerId = peerId
             , arExpiration = expiration

--- a/test/LibP2P/NAT/Relay/ClientSpec.hs
+++ b/test/LibP2P/NAT/Relay/ClientSpec.hs
@@ -5,7 +5,8 @@ import Test.Hspec
 import qualified Data.ByteString as BS
 import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM (newTQueueIO, atomically, writeTQueue, readTQueue, TQueue)
-import Data.Word (Word8)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Word (Word8, Word64)
 import LibP2P.NAT.Relay.Message
 import LibP2P.NAT.Relay.Client
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
@@ -64,6 +65,34 @@ spec = do
             case hopReservation resp of
               Just rsv -> rsvExpire rsv `shouldBe` Just 1700000000
               Nothing -> expectationFailure "Expected reservation"
+          Left err -> expectationFailure $ "makeReservation failed: " ++ err
+
+    it "should interpret received expire as an absolute Unix timestamp" $ do
+      (clientStream, serverStream) <- mkStreamPair
+      now <- getPOSIXTime
+      -- Relay sends an absolute expiration one hour from now, per spec.
+      let absoluteExpire = floor now + 3600 :: Word64
+          serverAction = do
+            _ <- readHopMessage serverStream maxRelayMessageSize
+            writeHopMessage serverStream HopMessage
+              { hopType = Just HopStatus
+              , hopPeer = Nothing
+              , hopReservation = Just Reservation
+                  { rsvExpire = Just absoluteExpire
+                  , rsvAddrs = []
+                  , rsvVoucher = Nothing
+                  }
+              , hopLimit = Nothing
+              , hopStatus = Just RelayOK
+              }
+      withAsync serverAction $ \_ -> do
+        result <- makeReservation clientStream
+        case result of
+          Right resp -> case hopReservation resp >>= rsvExpire of
+            -- The client must not rebase or offset the value: it is
+            -- already a UTC Unix time in seconds.
+            Just expire -> expire `shouldBe` absoluteExpire
+            Nothing -> expectationFailure "Expected reservation with expire"
           Left err -> expectationFailure $ "makeReservation failed: " ++ err
 
     it "returns error when relay refuses reservation" $ do

--- a/test/LibP2P/NAT/Relay/RelaySpec.hs
+++ b/test/LibP2P/NAT/Relay/RelaySpec.hs
@@ -6,7 +6,9 @@ import qualified Data.ByteString as BS
 import Control.Concurrent.Async (withAsync, race)
 import Control.Concurrent.STM
 import Control.Concurrent (threadDelay)
-import Data.Word (Word8)
+import qualified Data.Map.Strict as Map
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Word (Word8, Word64)
 import Data.IORef (newIORef, readIORef, modifyIORef')
 import LibP2P.NAT.Relay.Message
 import LibP2P.NAT.Relay
@@ -62,6 +64,38 @@ spec = do
             Just rsv -> rsvExpire rsv `shouldSatisfy` (/= Nothing)
             Nothing -> expectationFailure "Expected reservation in response"
         Left err -> expectationFailure $ "Read failed: " ++ err
+
+    it "should encode expire as an absolute Unix timestamp when reservation is accepted" $ do
+      relayState <- newRelayState defaultRelayConfig
+      (clientStream, serverStream) <- mkStreamPair
+      writeHopMessage clientStream HopMessage
+        { hopType = Just HopReserve
+        , hopPeer = Nothing
+        , hopReservation = Nothing
+        , hopLimit = Nothing
+        , hopStatus = Nothing
+        }
+      now <- getPOSIXTime
+      handleReserve relayState serverStream testPeerId
+      result <- readHopMessage clientStream maxRelayMessageSize
+      let nowSecs = floor now :: Word64
+          duration = rcReservationDuration defaultRelayConfig
+      case result of
+        Right resp -> case hopReservation resp >>= rsvExpire of
+          Just expire -> do
+            -- Spec (circuit-v2.md): expire is a UTC Unix time in seconds,
+            -- not a duration. It must lie in [now, now + duration + slack].
+            expire `shouldSatisfy` (>= nowSecs)
+            expire `shouldSatisfy` (<= nowSecs + duration + 5)
+          Nothing -> expectationFailure "Expected reservation with expire in response"
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      -- Internal state must carry the same absolute expiration
+      reservations <- readTVarIO (rsReservations relayState)
+      case Map.lookup testPeerId reservations of
+        Just ar -> do
+          arExpiration ar `shouldSatisfy` (>= nowSecs)
+          arExpiration ar `shouldSatisfy` (<= nowSecs + duration + 5)
+        Nothing -> expectationFailure "Expected stored reservation for peer"
 
     it "rejects reservation when max reservations exceeded" $ do
       let config = defaultRelayConfig { rcMaxReservations = 0 }


### PR DESCRIPTION
## Root cause

`handleReserve` copied `rcReservationDuration` (a duration, default `3600`) straight into `Reservation.expire` and `arExpiration`. The circuit-v2 spec (`relay/circuit-v2.md`) defines `expire` as a UTC Unix time in seconds (`optional uint64 expire = 1; // Unix expiration time (UTC)`), so we advertised an expiry of 1970-01-01T01:00:00Z and compliant go/rust clients dropped the reservation immediately.

## Fix

- `handleReserve` now computes `floor now + rcReservationDuration` via `getPOSIXTime` and uses that absolute time both on the wire (`rsvExpire`) and in the stored `arExpiration`.
- New test (TDD, failed before the fix): the encoded `expire` must lie in `[now, now + duration + slack]`, and the stored `ActiveReservation` must carry the same absolute time.
- New client test pinning that a received `expire` is treated as an absolute timestamp and passed through unchanged.

All 619 tests pass with GHC 9.10.1.

Closes #149