### PR TITLE
fix: chunk noise frames larger than 65535 bytes instead of truncating length prefix

### DIFF
--- a/src/LibP2P/Noise/Framing.hs
+++ b/src/LibP2P/Noise/Framing.hs
@@ -2,10 +2,18 @@
 --
 -- All Noise messages (handshake and transport) are framed as:
 -- [2 bytes BE length][noise_message]
+--
+-- Per the libp2p Noise spec, a Noise message has a maximum length of
+-- 65535 bytes. Plaintext larger than one message allows must be split
+-- across multiple Noise transport messages before encryption (see
+-- 'chunkPlaintext'); 'encodeFrame' rejects oversized messages instead
+-- of silently truncating the length prefix.
 module LibP2P.Noise.Framing
   ( encodeFrame
   , decodeFrame
+  , chunkPlaintext
   , maxNoiseMessageSize
+  , maxNoisePlaintextSize
   ) where
 
 import Data.ByteString (ByteString)
@@ -16,11 +24,35 @@ import LibP2P.Core.Binary (readWord16BE, word16BE)
 maxNoiseMessageSize :: Int
 maxNoiseMessageSize = 65535
 
+-- | Maximum plaintext per Noise transport message: the 65535-byte Noise
+-- message cap minus the 16-byte ChaChaPoly1305 authentication tag.
+-- Matches the chunking threshold used by go-libp2p.
+maxNoisePlaintextSize :: Int
+maxNoisePlaintextSize = maxNoiseMessageSize - 16
+
+-- | Split plaintext into chunks of at most 'maxNoisePlaintextSize' bytes,
+-- so each chunk plus its AEAD tag fits in a single Noise message.
+-- Empty input yields a single empty chunk so callers still emit one frame.
+chunkPlaintext :: ByteString -> [ByteString]
+chunkPlaintext bs
+  | BS.length bs <= maxNoisePlaintextSize = [bs]
+  | otherwise =
+      let (chunk, rest) = BS.splitAt maxNoisePlaintextSize bs
+       in chunk : chunkPlaintext rest
+
 -- | Encode a Noise message with a 2-byte big-endian length prefix.
-encodeFrame :: ByteString -> ByteString
-encodeFrame msg =
-  let len = BS.length msg
-   in word16BE (fromIntegral len) <> msg
+-- Rejects messages larger than 'maxNoiseMessageSize' — the 2-byte prefix
+-- cannot represent them, and truncating the length would corrupt every
+-- subsequent frame boundary on the connection.
+encodeFrame :: ByteString -> Either String ByteString
+encodeFrame msg
+  | len > maxNoiseMessageSize =
+      Left $
+        "encodeFrame: message length " <> show len
+          <> " exceeds maximum Noise message size " <> show maxNoiseMessageSize
+  | otherwise = Right $ word16BE (fromIntegral len) <> msg
+  where
+    len = BS.length msg
 
 -- | Decode a framed Noise message. Returns the message and remaining bytes.
 decodeFrame :: ByteString -> Either String (ByteString, ByteString)

--- a/src/LibP2P/Switch/Upgrade.hs
+++ b/src/LibP2P/Switch/Upgrade.hs
@@ -44,7 +44,7 @@ import LibP2P.MultistreamSelect.Negotiation
   , negotiateInitiator
   , negotiateResponder
   )
-import LibP2P.Noise.Framing (encodeFrame)
+import LibP2P.Noise.Framing (chunkPlaintext, encodeFrame)
 import LibP2P.Noise.Handshake
   ( HandshakeResult (..)
   , buildHandshakePayload
@@ -87,8 +87,11 @@ readFramedMessage stream = do
     else readExact stream len
 
 -- | Write a 2-byte-BE-length-prefixed Noise frame to a StreamIO.
+-- Fails (instead of truncating the length prefix) if the message exceeds
+-- the 65535-byte Noise message cap.
 writeFramedMessage :: StreamIO -> ByteString -> IO ()
-writeFramedMessage stream msg = streamWrite stream (encodeFrame msg)
+writeFramedMessage stream msg =
+  either fail (streamWrite stream) (encodeFrame msg)
 
 -- | Perform a Noise XX handshake over a StreamIO using framed messages.
 -- Returns (NoiseSession, HandshakeResult) with the remote PeerId.
@@ -198,15 +201,21 @@ noiseSessionToStreamIO sendRef recvRef bufRef rawIO = StreamIO
   , streamClose = pure ()  -- Encryption layer does not own the connection
   }
 
--- | Encrypt plaintext and write as a framed Noise message.
+-- | Encrypt plaintext and write as framed Noise messages.
+-- A Noise message is capped at 65535 bytes, so plaintext is split into
+-- chunks of at most 65519 bytes (65535 minus the 16-byte AEAD tag) and
+-- each chunk is encrypted and framed as its own Noise transport message.
 encryptAndWrite :: IORef NoiseSession -> StreamIO -> ByteString -> IO ()
-encryptAndWrite sendRef rawIO plaintext = do
-  sess <- readIORef sendRef
-  case encryptMessage sess plaintext of
-    Left err -> fail $ "encryptAndWrite: " <> err
-    Right (ct, sess') -> do
-      writeIORef sendRef sess'
-      writeFramedMessage rawIO ct
+encryptAndWrite sendRef rawIO plaintext =
+  mapM_ encryptChunk (chunkPlaintext plaintext)
+  where
+    encryptChunk chunk = do
+      sess <- readIORef sendRef
+      case encryptMessage sess chunk of
+        Left err -> fail $ "encryptAndWrite: " <> err
+        Right (ct, sess') -> do
+          writeIORef sendRef sess'
+          writeFramedMessage rawIO ct
 
 -- | Read and decrypt a byte from the Noise channel.
 -- If the buffer has bytes, return the first. Otherwise, read a full Noise

--- a/test/LibP2P/Noise/HandshakeSpec.hs
+++ b/test/LibP2P/Noise/HandshakeSpec.hs
@@ -15,7 +15,19 @@ spec = do
   describe "Framing" $ do
     it "encodes with 2-byte BE length prefix" $ do
       let msg = BS.pack [0x01, 0x02, 0x03]
-      encodeFrame msg `shouldBe` BS.pack [0x00, 0x03, 0x01, 0x02, 0x03]
+      encodeFrame msg `shouldBe` Right (BS.pack [0x00, 0x03, 0x01, 0x02, 0x03])
+
+    it "accepts a message of exactly maxNoiseMessageSize bytes" $ do
+      let msg = BS.replicate maxNoiseMessageSize 0x42
+      case encodeFrame msg of
+        Right framed -> do
+          BS.length framed `shouldBe` maxNoiseMessageSize + 2
+          BS.take 2 framed `shouldBe` BS.pack [0xFF, 0xFF]
+        Left err -> expectationFailure err
+
+    it "rejects a message larger than maxNoiseMessageSize bytes" $ do
+      let msg = BS.replicate (maxNoiseMessageSize + 1) 0x42
+      encodeFrame msg `shouldSatisfy` isLeft
 
     it "decodes framed message" $ do
       let framed = BS.pack [0x00, 0x03, 0x01, 0x02, 0x03]
@@ -34,11 +46,36 @@ spec = do
 
     it "round-trip" $ do
       let msg = BS.replicate 100 0x42
-      case decodeFrame (encodeFrame msg) of
+      case encodeFrame msg >>= decodeFrame of
         Right (decoded, remaining) -> do
           decoded `shouldBe` msg
           remaining `shouldBe` BS.empty
         Left err -> expectationFailure err
+
+  describe "chunkPlaintext" $ do
+    it "keeps a small plaintext as a single chunk" $
+      chunkPlaintext (BS.replicate 100 0x01) `shouldBe` [BS.replicate 100 0x01]
+
+    it "keeps a plaintext of exactly maxNoisePlaintextSize as a single chunk" $ do
+      let msg = BS.replicate maxNoisePlaintextSize 0x01
+      chunkPlaintext msg `shouldBe` [msg]
+
+    it "splits a plaintext one byte over the limit into two chunks" $ do
+      let msg = BS.replicate (maxNoisePlaintextSize + 1) 0x01
+      map BS.length (chunkPlaintext msg) `shouldBe` [maxNoisePlaintextSize, 1]
+
+    it "splits a 70000-byte plaintext into spec-sized chunks that reassemble" $ do
+      let msg = BS.pack (take 70000 (cycle [0 .. 255]))
+          chunks = chunkPlaintext msg
+      map BS.length chunks `shouldBe` [maxNoisePlaintextSize, 70000 - maxNoisePlaintextSize]
+      BS.concat chunks `shouldBe` msg
+
+    it "yields a single empty chunk for empty input" $
+      chunkPlaintext BS.empty `shouldBe` [BS.empty]
+
+    it "every chunk plus the 16-byte AEAD tag fits in a Noise message" $ do
+      let msg = BS.replicate 200000 0x01
+      chunkPlaintext msg `shouldSatisfy` all (\c -> BS.length c + 16 <= maxNoiseMessageSize)
 
   describe "Static key signing" $ do
     it "signStaticKey produces verifiable signature" $ do

--- a/test/LibP2P/Switch/UpgradeSpec.hs
+++ b/test/LibP2P/Switch/UpgradeSpec.hs
@@ -52,6 +52,10 @@ spec = do
       received <- readFramedMessage streamB
       received `shouldBe` BS.empty
 
+    it "writeFramedMessage rejects a message larger than 65535 bytes" $ do
+      (streamA, _streamB) <- mkMemoryStreamPair
+      writeFramedMessage streamA (BS.replicate 65536 0x42) `shouldThrow` anyIOException
+
   describe "performStreamHandshake" $ do
     it "initiator and responder complete handshake and return correct PeerIds" $ do
       (pidA, kpA) <- mkTestIdentity
@@ -92,6 +96,37 @@ spec = do
       streamWrite encB "world"
       received2 <- readExact encA 5
       received2 `shouldBe` "world"
+
+    it "round-trips a payload larger than 65535 bytes without corruption" $ do
+      (_pidA, kpA) <- mkTestIdentity
+      (_pidB, kpB) <- mkTestIdentity
+      (rawA, rawB) <- mkMemoryStreamPair
+      ((sessA, _), (sessB, _)) <-
+        concurrently
+          (performStreamHandshake kpA Outbound rawA)
+          (performStreamHandshake kpB Inbound rawB)
+      sendRefA <- newIORef sessA
+      recvRefA <- newIORef sessA
+      bufRefA  <- newIORef BS.empty
+      sendRefB <- newIORef sessB
+      recvRefB <- newIORef sessB
+      bufRefB  <- newIORef BS.empty
+      let encA = noiseSessionToStreamIO sendRefA recvRefA bufRefA rawA
+          encB = noiseSessionToStreamIO sendRefB recvRefB bufRefB rawB
+          -- Larger than the 65535-byte Noise message cap: must be chunked
+          -- into multiple frames, never truncated.
+          bigPayload = BS.pack (take 70000 (cycle [0 .. 255]))
+      streamWrite encA bigPayload
+      received <- readExact encB 70000
+      received `shouldBe` bigPayload
+      -- The connection must remain usable after the large write
+      streamWrite encA "still alive"
+      received2 <- readExact encB 11
+      received2 `shouldBe` "still alive"
+      -- And the reverse direction too
+      streamWrite encB bigPayload
+      received3 <- readExact encA 70000
+      received3 `shouldBe` bigPayload
 
   describe "Full upgrade pipeline" $ do
     it "upgradeOutbound + upgradeInbound exchange data on muxed stream" $ do


### PR DESCRIPTION
## Root cause

`encodeFrame` encoded the frame length with `fromIntegral :: Int -> Word16`, which wraps modulo 65536 for any Noise message over 65535 bytes. The frame was written with a wrong declared length, the receiver read the wrong number of bytes, and every subsequent frame boundary on the connection was misaligned — silent, unrecoverable corruption. `encryptAndWrite` passed the whole plaintext to `encryptMessage` in one call, so any single stream write over 64 KiB (large GossipSub message, DHT record response) hit this path.

## Fix

Per the libp2p Noise spec (`noise/README.md`, Wire Format), a Noise message has a maximum length of 65535 bytes, so larger plaintext must be split across multiple transport messages:

- `encryptAndWrite` now splits plaintext via new `chunkPlaintext` into chunks of at most **65519** bytes (65535 minus the 16-byte ChaChaPoly1305 tag — the same threshold go-libp2p uses), encrypting and framing each chunk as its own Noise transport message. The receive side (`decryptAndReadByte`) already reassembles across frames via its read buffer.
- `encodeFrame` now returns `Either String ByteString` and **rejects** messages over 65535 bytes, so a future caller cannot reintroduce the silent truncation. `writeFramedMessage` propagates the rejection as an error.
- `maxNoisePlaintextSize` and `chunkPlaintext` are exported from `LibP2P.Noise.Framing`.

## Tests

- Unit: `encodeFrame` accepts exactly 65535 bytes / rejects 65536; `chunkPlaintext` boundary cases (empty, exact limit, limit+1, 70000 bytes, reassembly, tag headroom).
- Integration: encrypted `StreamIO` round-trips a 70000-byte payload in both directions with no corruption, and the connection stays usable afterwards.
- Full suite: 627 examples, 0 failures.

Closes #141