### PR TITLE
fix(identify): frame messages with varint length prefix

### DIFF
--- a/src/LibP2P/Protocol/Identify.hs
+++ b/src/LibP2P/Protocol/Identify.hs
@@ -4,8 +4,10 @@
 --
 -- After a connection is established, both sides exchange IdentifyInfo
 -- messages to learn about each other's capabilities, listen addresses,
--- and agent version. The message has no length prefix — the boundary
--- is determined by stream closure.
+-- and agent version. Like all libp2p protobuf streams, the message is
+-- varint-length-delimited on the wire: uvarint(len) ++ protobuf. This
+-- matches the delimited reader/writer used by go-libp2p (pbio),
+-- rust-libp2p, and js-libp2p.
 --
 -- Also implements Identify Push (/ipfs/id/push/1.0.0) for proactive
 -- updates when local state changes.
@@ -21,14 +23,16 @@ module LibP2P.Protocol.Identify
   , buildLocalIdentify
     -- * Registration
   , registerIdentifyHandlers
-    -- * Helpers
-  , readUntilEOF
+    -- * Wire framing
+  , encodeFramedIdentify
+  , readFramedIdentify
   ) where
 
 import Control.Concurrent.STM (atomically, readTVar, writeTVar)
 import Control.Exception (SomeException, catch)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
+import LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 import LibP2P.Crypto.PeerId (PeerId)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Crypto.Key (kpPublic)
@@ -63,46 +67,39 @@ identifyPushProtocolId = "/ipfs/id/push/1.0.0"
 
 -- | Handle an inbound Identify request (responder side).
 --
--- Sends our local IdentifyInfo as protobuf to the stream, then closes.
--- The remote side reads until EOF.
+-- Sends our local IdentifyInfo as a varint-length-prefixed protobuf,
+-- then closes the stream (per specs/identify: respond and close).
 handleIdentify :: Switch -> StreamIO -> PeerId -> IO ()
 handleIdentify sw stream _remotePeerId = do
   info <- buildLocalIdentify sw Nothing
-  let encoded = encodeIdentify info
-  streamWrite stream encoded
-  streamClose stream  -- Signal EOF so the remote side's readUntilEOF terminates
+  streamWrite stream (encodeFramedIdentify info)
+  streamClose stream
 
 -- | Request Identify from a remote peer (initiator side).
 --
--- Opens a new stream, negotiates /ipfs/id/1.0.0, reads until EOF,
--- then decodes the protobuf message.
+-- Opens a new stream, negotiates /ipfs/id/1.0.0, then reads one
+-- varint-length-prefixed protobuf message.
 requestIdentify :: Connection -> IO (Either String IdentifyInfo)
 requestIdentify conn = do
   stream <- muxOpenStream (connSession conn)
   result <- negotiateInitiator stream [identifyProtocolId]
   case result of
-    Accepted _ -> do
-      bytesOrErr <- readUntilEOF stream maxIdentifySize
-      case bytesOrErr of
-        Left err -> pure (Left err)
-        Right bs -> case decodeIdentify bs of
-          Left parseErr -> pure (Left (show parseErr))
-          Right info -> pure (Right info)
+    Accepted _ -> readFramedIdentify stream maxIdentifySize
     NoProtocol -> pure (Left "remote does not support identify")
 
 -- | Handle an inbound Identify Push (responder side).
 --
--- Reads the pushed IdentifyInfo from the remote peer.
+-- Reads the pushed varint-length-prefixed IdentifyInfo from the remote
+-- peer. The length prefix is the message boundary — identify push has
+-- no stream-close boundary to fall back on.
 handleIdentifyPush :: Switch -> StreamIO -> PeerId -> IO ()
 handleIdentifyPush sw stream remotePeerId = do
-  bytesOrErr <- readUntilEOF stream maxIdentifySize
-  case bytesOrErr of
+  infoOrErr <- readFramedIdentify stream maxIdentifySize
+  case infoOrErr of
     Left _ -> pure ()
-    Right bs -> case decodeIdentify bs of
-      Left _ -> pure ()
-      Right info -> atomically $ do
-        store <- readTVar (swPeerStore sw)
-        writeTVar (swPeerStore sw) (Map.insert remotePeerId info store)
+    Right info -> atomically $ do
+      store <- readTVar (swPeerStore sw)
+      writeTVar (swPeerStore sw) (Map.insert remotePeerId info store)
 
 -- | Build our local IdentifyInfo from Switch state.
 buildLocalIdentify :: Switch -> Maybe Connection -> IO IdentifyInfo
@@ -133,18 +130,52 @@ registerIdentifyHandlers sw = do
         protos'' = Map.insert identifyPushProtocolId (handleIdentifyPush sw) protos'
     writeTVar (swProtocols sw) protos''
 
--- | Read bytes from a StreamIO until EOF, up to a maximum size.
+-- | Encode an IdentifyInfo with its uvarint length prefix, as written
+-- on the wire: uvarint(len) ++ protobuf.
+encodeFramedIdentify :: IdentifyInfo -> BS.ByteString
+encodeFramedIdentify info =
+  let payload = encodeIdentify info
+  in encodeUvarint (fromIntegral (BS.length payload)) <> payload
+
+-- | Read one varint-length-prefixed Identify message from a stream.
 --
--- Identify uses stream closure as message boundary (no length prefix).
--- Accumulates bytes until streamReadByte throws (EOF/stream closed).
-readUntilEOF :: StreamIO -> Int -> IO (Either String BS.ByteString)
-readUntilEOF stream maxSize = go []  0
+-- Reads the uvarint length prefix, then exactly that many payload
+-- bytes, and decodes the protobuf. Rejects messages larger than
+-- maxSize before reading the payload.
+readFramedIdentify :: StreamIO -> Int -> IO (Either String IdentifyInfo)
+readFramedIdentify stream maxSize = readFramed `catch` onError
   where
-    go acc size
-      | size >= maxSize = pure (Left "message exceeds maximum size")
+    onError :: SomeException -> IO (Either String IdentifyInfo)
+    onError e = pure (Left ("identify stream read failed: " ++ show e))
+
+    readFramed = do
+      varintBytes <- readVarintBytes stream
+      case decodeUvarint varintBytes of
+        Left err -> pure (Left ("identify length prefix decode error: " ++ err))
+        Right (len, _) -> do
+          let msgLen = fromIntegral len :: Int
+          if msgLen > maxSize
+            then pure (Left ("identify message too large: "
+                             ++ show msgLen ++ " > " ++ show maxSize))
+            else do
+              payload <- readExact stream msgLen
+              case decodeIdentify payload of
+                Left parseErr ->
+                  pure (Left ("identify protobuf decode error: " ++ show parseErr))
+                Right info -> pure (Right info)
+
+-- | Read the bytes of one unsigned varint from a stream (up to 10 bytes).
+readVarintBytes :: StreamIO -> IO BS.ByteString
+readVarintBytes stream = go [] (0 :: Int)
+  where
+    go acc n
+      | n >= 10 = pure (BS.pack (reverse acc))  -- max varint length
       | otherwise = do
-          result <- (Right <$> streamReadByte stream) `catch`
-                    (\(_ :: SomeException) -> pure (Left ()))
-          case result of
-            Left () -> pure (Right (BS.pack (reverse acc)))
-            Right b -> go (b : acc) (size + 1)
+          b <- streamReadByte stream
+          if b < 0x80
+            then pure (BS.pack (reverse (b : acc)))
+            else go (b : acc) (n + 1)
+
+-- | Read exactly n bytes from a stream.
+readExact :: StreamIO -> Int -> IO BS.ByteString
+readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]

--- a/src/LibP2P/Protocol/Identify/Message.hs
+++ b/src/LibP2P/Protocol/Identify/Message.hs
@@ -8,8 +8,9 @@
 --   Field 5: protocolVersion (string, optional)
 --   Field 6: agentVersion    (string, optional)
 --
--- Uses proto3-wire for protobuf encoding/decoding. No length prefix;
--- the message boundary is determined by stream closure.
+-- Uses proto3-wire for protobuf encoding/decoding. On the wire the
+-- message is varint-length-delimited; the framing lives in
+-- "LibP2P.Protocol.Identify" (encodeFramedIdentify / readFramedIdentify).
 module LibP2P.Protocol.Identify.Message
   ( IdentifyInfo (..)
   , encodeIdentify

--- a/test/LibP2P/Protocol/Identify/IdentifySpec.hs
+++ b/test/LibP2P/Protocol/Identify/IdentifySpec.hs
@@ -13,7 +13,7 @@ import Control.Concurrent.STM
   , tryReadTMVar
   , writeTQueue
   )
-import Control.Exception (throwIO)
+import Control.Exception (SomeException, catch, throwIO)
 import qualified Data.ByteString as BS
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
@@ -21,9 +21,10 @@ import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (kpPublic)
 import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
+import LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
 import LibP2P.Protocol.Identify
-import LibP2P.Protocol.Identify.Message (IdentifyInfo (..), decodeIdentify, encodeIdentify)
+import LibP2P.Protocol.Identify.Message (IdentifyInfo (..), decodeIdentify, encodeIdentify, maxIdentifySize)
 import LibP2P.Switch (newSwitch, setStreamHandler)
 import LibP2P.Switch.Types (Switch (..))
 import Data.Word (Word8)
@@ -73,6 +74,21 @@ mkClosableStreamPair = do
         }
   pure (streamA, streamB)
 
+-- | Read all raw bytes from a StreamIO until EOF (test helper).
+readAllBytes :: StreamIO -> IO (Either String BS.ByteString)
+readAllBytes stream = go []
+  where
+    go acc = do
+      result <- (Right <$> streamReadByte stream) `catch`
+                (\(_ :: SomeException) -> pure (Left ()))
+      case result of
+        Left () -> pure (Right (BS.pack (reverse acc)))
+        Right b -> go (b : acc)
+
+-- | Prepend the uvarint length prefix to an encoded message (test helper).
+frame :: BS.ByteString -> BS.ByteString
+frame payload = encodeUvarint (fromIntegral (BS.length payload)) <> payload
+
 spec :: Spec
 spec = do
   describe "Identify protocol" $ do
@@ -95,21 +111,26 @@ spec = do
       let expectedPubKey = encodePublicKey (kpPublic (swIdentityKey sw))
       idPublicKey info `shouldBe` Just expectedPubKey
 
-    it "handleIdentify sends decodable protobuf over stream" $ do
+    it "handleIdentify writes a varint-length-prefixed protobuf" $ do
       sw <- mkTestSwitch
       (streamA, streamB) <- mkClosableStreamPair
-      -- handleIdentify writes protobuf to streamA and closes it (EOF)
+      -- handleIdentify writes the framed protobuf to streamA and closes it (EOF)
       writer <- async $ handleIdentify sw streamA (PeerId "remote")
-      -- Read all bytes from streamB until EOF
-      bytesOrErr <- readUntilEOF streamB 65536
+      -- Read all raw bytes from streamB until EOF
+      bytesOrErr <- readAllBytes streamB
       wait writer
       case bytesOrErr of
-        Left err -> expectationFailure $ "readUntilEOF failed: " ++ err
-        Right bs -> case decodeIdentify bs of
-          Left parseErr -> expectationFailure $ "Decode failed: " ++ show parseErr
-          Right info -> do
-            idProtocolVersion info `shouldBe` Just "ipfs/0.1.0"
-            idAgentVersion info `shouldBe` Just "libp2p-hs/0.1.0"
+        Left err -> expectationFailure $ "reading stream failed: " ++ err
+        Right bs -> case decodeUvarint bs of
+          Left err -> expectationFailure $ "no varint length prefix: " ++ err
+          Right (len, payload) -> do
+            -- The varint prefix must describe exactly the protobuf payload
+            fromIntegral len `shouldBe` BS.length payload
+            case decodeIdentify payload of
+              Left parseErr -> expectationFailure $ "Decode failed: " ++ show parseErr
+              Right info -> do
+                idProtocolVersion info `shouldBe` Just "ipfs/0.1.0"
+                idAgentVersion info `shouldBe` Just "libp2p-hs/0.1.0"
 
     it "handleIdentify closes stream after writing (signals EOF)" $ do
       sw <- mkTestSwitch
@@ -143,7 +164,7 @@ spec = do
             }
       -- handleIdentify should write + close the stream
       writer <- async $ handleIdentify sw testStream (PeerId "remote")
-      bytesOrErr <- readUntilEOF readerStream 65536
+      bytesOrErr <- readAllBytes readerStream
       wait writer
       -- Stream close should have been called by handleIdentify
       closeCalled <- readIORef closeCalledRef
@@ -151,7 +172,7 @@ spec = do
       -- And the data should be readable
       case bytesOrErr of
         Right _ -> pure ()
-        Left err -> expectationFailure $ "readUntilEOF failed: " ++ err
+        Left err -> expectationFailure $ "reading stream failed: " ++ err
 
     it "handleIdentifyPush stores info in peer store" $ do
       sw <- mkTestSwitch
@@ -165,9 +186,9 @@ spec = do
             , idObservedAddr    = Nothing
             , idProtocols       = ["/test/proto"]
             }
-      -- Write encoded message then signal EOF
+      -- Write varint-length-prefixed message then signal EOF
       let encoded = encodeIdentify testInfo
-      streamWrite streamA encoded
+      streamWrite streamA (frame encoded)
       streamClose streamA
       -- handleIdentifyPush reads from streamB
       handleIdentifyPush sw streamB remotePeerId
@@ -178,6 +199,43 @@ spec = do
         Just storedInfo -> do
           idProtocolVersion storedInfo `shouldBe` Just "test/1.0"
           idAgentVersion storedInfo `shouldBe` Just "test-agent/0.1"
+
+    it "readFramedIdentify parses a varint-length-prefixed message" $ do
+      (streamA, streamB) <- mkClosableStreamPair
+      let testInfo = IdentifyInfo
+            { idProtocolVersion = Just "ipfs/0.1.0"
+            , idAgentVersion    = Just "framed-agent/1.0"
+            , idPublicKey       = Nothing
+            , idListenAddrs     = []
+            , idObservedAddr    = Nothing
+            , idProtocols       = ["/framed/1.0.0"]
+            }
+      streamWrite streamA (frame (encodeIdentify testInfo))
+      result <- readFramedIdentify streamB maxIdentifySize
+      result `shouldBe` Right testInfo
+
+    it "readFramedIdentify round-trips encodeFramedIdentify" $ do
+      (streamA, streamB) <- mkClosableStreamPair
+      let testInfo = IdentifyInfo
+            { idProtocolVersion = Just "ipfs/0.1.0"
+            , idAgentVersion    = Just "roundtrip/1.0"
+            , idPublicKey       = Just (BS.pack [1, 2, 3])
+            , idListenAddrs     = [BS.pack [4, 7, 0, 0, 0, 1]]
+            , idObservedAddr    = Nothing
+            , idProtocols       = ["/a/1.0.0", "/b/1.0.0"]
+            }
+      streamWrite streamA (encodeFramedIdentify testInfo)
+      result <- readFramedIdentify streamB maxIdentifySize
+      result `shouldBe` Right testInfo
+
+    it "readFramedIdentify rejects an oversized length prefix" $ do
+      (streamA, streamB) <- mkClosableStreamPair
+      -- Announce a length just above the limit, without sending a payload
+      streamWrite streamA (encodeUvarint (fromIntegral (maxIdentifySize + 1)))
+      result <- readFramedIdentify streamB maxIdentifySize
+      case result of
+        Left err -> err `shouldSatisfy` (not . null)
+        Right _  -> expectationFailure "expected oversized message to be rejected"
 
     it "registerIdentifyHandlers registers both protocol handlers" $ do
       sw <- mkTestSwitch

--- a/test/LibP2P/Protocol/Identify/MessageSpec.hs
+++ b/test/LibP2P/Protocol/Identify/MessageSpec.hs
@@ -64,7 +64,7 @@ spec = do
           info = IdentifyInfo Nothing Nothing (Just bigPubKey) [] Nothing []
           encoded = encodeIdentify info
       -- The encoded message should be parseable (proto3-wire doesn't enforce size)
-      -- Size check is done at read time by readUntilEOF, not at decode time
+      -- Size check is done at read time by readFramedIdentify, not at decode time
       BS.length encoded `shouldSatisfy` (> maxIdentifySize)
 
     it "decode skips unknown fields" $ do


### PR DESCRIPTION
## Root cause

Identify wrote the raw protobuf to the stream and relied on stream closure as the message boundary (`readUntilEOF`). Every other libp2p implementation (go-libp2p via `pbio`, rust-libp2p, js-libp2p) uses a varint-length-delimited protobuf, so neither direction interoperated: their leading varint bytes were fed to our protobuf parser, and our first protobuf byte (`0x0a`) was read by them as a length prefix of 10, yielding a truncated, misaligned message. Identify push (`/ipfs/id/push/1.0.0`) has no stream-close boundary at all to fall back on.

## Fix

- Write `uvarint(len) ++ protobuf` (`encodeFramedIdentify`) in `handleIdentify`, and read the same framing (`readFramedIdentify`) in `requestIdentify` and `handleIdentifyPush`, using the existing `LibP2P.Core.Varint` codec — same shape as the DHT's delimited reader/writer.
- `readFramedIdentify` enforces `maxIdentifySize` from the length prefix before reading the payload, and removes `readUntilEOF`.
- Tests (written first, red on the old behavior): wire bytes carry a correct varint length prefix, framed round-trip, framed identify-push, oversized-length rejection. Full suite: 620 examples, 0 failures.

Closes #144