### PR TITLE
fix(yamux): honour FIN in pre-established states and validate data length before reading payload

### DIFF
--- a/src/LibP2P/Switch/Upgrade.hs
+++ b/src/LibP2P/Switch/Upgrade.hs
@@ -26,6 +26,7 @@ module LibP2P.Switch.Upgrade
 
 import Control.Concurrent.Async (async)
 import Control.Concurrent.STM (newTVarIO)
+import Control.Monad (replicateM)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -33,6 +34,7 @@ import Data.Word (Word8)
 import LibP2P.Core.Binary (readWord16BE)
 import LibP2P.Crypto.Key (KeyPair (..))
 import LibP2P.Crypto.PeerId (fromPublicKey)
+import LibP2P.Yamux.Frame (maxStreamWindowSize)
 import LibP2P.Yamux.Session (closeSession, newSession, recvLoop, sendLoop)
 import qualified LibP2P.Yamux.Session as Yamux
 import LibP2P.Yamux.Stream (streamRead)
@@ -74,8 +76,25 @@ import qualified LibP2P.Crypto.Protobuf as Proto
 import qualified LibP2P.Noise.Handshake as HS
 
 -- | Read exactly n bytes from a StreamIO.
+--
+-- Defence in depth against remote memory exhaustion: the request size is
+-- bounded by maxStreamWindowSize (callers must validate lengths against
+-- flow control before reading), and bytes are packed in fixed-size chunks
+-- so memory use is proportional to the chunk size, not to n.
 readExact :: StreamIO -> Int -> IO ByteString
-readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]
+readExact stream n
+  | n <= 0 = pure BS.empty
+  | n > fromIntegral maxStreamWindowSize =
+      fail ("readExact: requested size exceeds bound: " <> show n)
+  | otherwise = BS.concat <$> go n
+  where
+    chunkSize = 32768 :: Int
+    go 0 = pure []
+    go remaining = do
+      let m = min chunkSize remaining
+      chunk <- BS.pack <$> replicateM m (streamReadByte stream)
+      rest <- go (remaining - m)
+      pure (chunk : rest)
 
 -- | Read a 2-byte-BE-length-prefixed Noise frame from a StreamIO.
 readFramedMessage :: StreamIO -> IO ByteString

--- a/src/LibP2P/Yamux/Frame.hs
+++ b/src/LibP2P/Yamux/Frame.hs
@@ -12,6 +12,7 @@ module LibP2P.Yamux.Frame
   , defaultFlags
   , headerSize
   , initialWindowSize
+  , maxStreamWindowSize
   ) where
 
 import Data.Bits (shiftL, shiftR, (.&.), (.|.))
@@ -26,6 +27,12 @@ headerSize = 12
 -- | Default initial window size: 256 KiB (262144 bytes).
 initialWindowSize :: Word32
 initialWindowSize = 262144
+
+-- | Absolute upper bound for any receive window (16 MiB), matching
+-- go-yamux's MaxStreamWindowSize. No conforming peer may declare a
+-- data frame length beyond this, whatever the per-stream window is.
+maxStreamWindowSize :: Word32
+maxStreamWindowSize = 16777216
 
 -- | Yamux frame types.
 data FrameType

--- a/src/LibP2P/Yamux/Session.hs
+++ b/src/LibP2P/Yamux/Session.hs
@@ -108,8 +108,13 @@ acceptStream sess = do
           , yhLength = 0
           }
   atomically $ writeTQueue (ysessSendCh sess) (hdr, BS.empty)
-  -- Transition to Established
-  atomically $ writeTVar (ysState stream) StreamEstablished
+  -- Transition to Established only from SYNReceived. The remote may have
+  -- already half-closed (FIN) before we accepted; that state must survive.
+  atomically $ do
+    st <- readTVar (ysState stream)
+    case st of
+      StreamSYNReceived -> writeTVar (ysState stream) StreamEstablished
+      _ -> pure ()
   pure (Right stream)
 
 -- | Send a Ping and wait for the ACK response.
@@ -172,133 +177,174 @@ recvLoop sess = go
           if yhVersion hdr /= 0
             then pure () -- Protocol error
             else do
-              dispatchFrame sess hdr
-              go
+              continue <- dispatchFrame sess hdr
+              when continue go
 
 -- | Dispatch a decoded frame to the appropriate handler.
-dispatchFrame :: YamuxSession -> YamuxHeader -> IO ()
+-- Returns False when a fatal protocol error occurred and the receive
+-- loop must terminate (go-yamux treats these as session-fatal).
+dispatchFrame :: YamuxSession -> YamuxHeader -> IO Bool
 dispatchFrame sess hdr = case yhType hdr of
   FrameData -> handleDataFrame sess hdr
   FrameWindowUpdate -> handleWindowUpdate sess hdr
-  FramePing -> handlePing sess hdr
-  FrameGoAway -> handleGoAway sess hdr
+  FramePing -> handlePing sess hdr >> pure True
+  FrameGoAway -> handleGoAway sess hdr >> pure True
 
--- | Handle a Data frame: read payload, manage stream state, deliver data.
-handleDataFrame :: YamuxSession -> YamuxHeader -> IO ()
+-- | Handle a Data frame: validate declared length, read payload, manage
+-- stream state, deliver data. Returns False on fatal protocol error.
+handleDataFrame :: YamuxSession -> YamuxHeader -> IO Bool
 handleDataFrame sess hdr = do
-  -- Read payload
-  payload <-
-    if yhLength hdr > 0
-      then ysessRead sess (fromIntegral (yhLength hdr))
-      else pure BS.empty
   let sid = yhStreamId hdr
       flags = yhFlags hdr
-  -- Handle SYN flag: create new inbound stream (with parity + duplicate validation)
-  when (flagSYN flags) $ do
-    valid <- atomically $ validateInboundSYN sess sid
-    if not valid
-      then sendGoAway sess GoAwayProtocol
-      else do
-        stream <- newStream sess sid StreamSYNReceived
-        atomically $ do
-          modifyTVar' (ysessStreams sess) (Map.insert sid stream)
-          writeTQueue (ysessAcceptCh sess) stream
-  -- Handle ACK flag: transition SYNSent -> Established
-  when (flagACK flags) $ do
-    mStream <- atomically $ Map.lookup sid <$> readTVar (ysessStreams sess)
-    case mStream of
-      Just stream -> atomically $ do
-        st <- readTVar (ysState stream)
-        case st of
-          StreamSYNSent -> writeTVar (ysState stream) StreamEstablished
-          _ -> pure ()
-      Nothing -> pure ()
-  -- Deliver payload to stream buffer (with flow-control check)
-  when (BS.length payload > 0) $ do
-    mStream <- atomically $ Map.lookup sid <$> readTVar (ysessStreams sess)
-    case mStream of
-      Just stream -> do
-        let payloadLen = fromIntegral (BS.length payload)
-        overWindow <- atomically $ do
-          w <- readTVar (ysRecvWindow stream)
-          if w < payloadLen
-            then pure True
-            else do
-              writeTQueue (ysRecvBuf stream) payload
-              writeTVar (ysRecvWindow stream) (w - payloadLen)
-              pure False
-        when overWindow $ sendGoAway sess GoAwayProtocol
-      Nothing -> pure ()
-  -- Handle FIN flag
-  when (flagFIN flags) $ do
-    mStream <- atomically $ Map.lookup sid <$> readTVar (ysessStreams sess)
-    case mStream of
-      Just stream -> atomically $ do
-        st <- readTVar (ysState stream)
-        case st of
-          StreamEstablished -> writeTVar (ysState stream) StreamRemoteClose
-          StreamLocalClose -> writeTVar (ysState stream) StreamClosed
-          StreamSYNSent -> writeTVar (ysState stream) StreamRemoteClose
-          _ -> pure ()
-      Nothing -> pure ()
-  -- Handle RST flag
-  when (flagRST flags) $ do
-    mStream <- atomically $ Map.lookup sid <$> readTVar (ysessStreams sess)
-    case mStream of
-      Just stream -> atomically $ writeTVar (ysState stream) StreamReset
-      Nothing -> pure ()
+      declaredLen = yhLength hdr
+  -- Handle SYN first so the flow-control check below sees the new stream
+  synOk <-
+    if flagSYN flags
+      then acceptInboundSYN sess sid
+      else pure True
+  if not synOk
+    then do
+      sendGoAway sess GoAwayProtocol
+      pure False
+    else do
+      -- Flow control: validate the declared length against the receive
+      -- window BEFORE reading the payload off the transport. A frame that
+      -- overruns the window is a protocol error and must not cause the
+      -- session to buffer attacker-controlled amounts of memory.
+      reserved <- reserveRecvWindow sess sid declaredLen
+      if not reserved
+        then do
+          sendGoAway sess GoAwayProtocol
+          pure False
+        else do
+          payload <-
+            if declaredLen > 0
+              then ysessRead sess (fromIntegral declaredLen)
+              else pure BS.empty
+          -- Handle ACK flag: transition SYNSent -> Established
+          when (flagACK flags) $ handleAckFlag sess sid
+          -- Deliver payload to stream buffer (window already reserved)
+          when (BS.length payload > 0) $ do
+            mStream <- lookupStream sess sid
+            case mStream of
+              Just stream -> atomically $ writeTQueue (ysRecvBuf stream) payload
+              Nothing -> pure () -- unknown stream: discard
+          -- Handle FIN flag
+          when (flagFIN flags) $ applyRemoteFin sess sid
+          -- Handle RST flag
+          when (flagRST flags) $ applyRemoteRst sess sid
+          pure True
 
--- | Handle a WindowUpdate frame: update send window, manage stream lifecycle.
-handleWindowUpdate :: YamuxSession -> YamuxHeader -> IO ()
+-- | Handle a WindowUpdate frame: update send window, manage stream
+-- lifecycle. Returns False on fatal protocol error.
+handleWindowUpdate :: YamuxSession -> YamuxHeader -> IO Bool
 handleWindowUpdate sess hdr = do
   let sid = yhStreamId hdr
       flags = yhFlags hdr
       delta = yhLength hdr
   -- Handle SYN flag: create new inbound stream (with parity + duplicate validation)
-  when (flagSYN flags) $ do
-    valid <- atomically $ validateInboundSYN sess sid
-    if not valid
-      then sendGoAway sess GoAwayProtocol
-      else do
-        stream <- newStream sess sid StreamSYNReceived
-        atomically $ do
-          modifyTVar' (ysessStreams sess) (Map.insert sid stream)
-          writeTQueue (ysessAcceptCh sess) stream
-  -- Handle ACK flag
-  when (flagACK flags) $ do
-    mStream <- atomically $ Map.lookup sid <$> readTVar (ysessStreams sess)
-    case mStream of
-      Just stream -> atomically $ do
-        st <- readTVar (ysState stream)
-        case st of
-          StreamSYNSent -> writeTVar (ysState stream) StreamEstablished
-          _ -> pure ()
-      Nothing -> pure ()
-  -- Update send window
-  when (delta > 0) $ do
-    mStream <- atomically $ Map.lookup sid <$> readTVar (ysessStreams sess)
-    case mStream of
-      Just stream -> atomically $ do
-        w <- readTVar (ysSendWindow stream)
-        writeTVar (ysSendWindow stream) (w + delta)
-      Nothing -> pure ()
-  -- Handle FIN flag
-  when (flagFIN flags) $ do
-    mStream <- atomically $ Map.lookup sid <$> readTVar (ysessStreams sess)
-    case mStream of
-      Just stream -> atomically $ do
-        st <- readTVar (ysState stream)
-        case st of
-          StreamEstablished -> writeTVar (ysState stream) StreamRemoteClose
-          StreamLocalClose -> writeTVar (ysState stream) StreamClosed
-          _ -> pure ()
-      Nothing -> pure ()
-  -- Handle RST flag
-  when (flagRST flags) $ do
-    mStream <- atomically $ Map.lookup sid <$> readTVar (ysessStreams sess)
-    case mStream of
-      Just stream -> atomically $ writeTVar (ysState stream) StreamReset
-      Nothing -> pure ()
+  synOk <-
+    if flagSYN flags
+      then acceptInboundSYN sess sid
+      else pure True
+  if not synOk
+    then do
+      sendGoAway sess GoAwayProtocol
+      pure False
+    else do
+      -- Handle ACK flag
+      when (flagACK flags) $ handleAckFlag sess sid
+      -- Update send window
+      when (delta > 0) $ do
+        mStream <- lookupStream sess sid
+        case mStream of
+          Just stream -> atomically $ do
+            w <- readTVar (ysSendWindow stream)
+            writeTVar (ysSendWindow stream) (w + delta)
+          Nothing -> pure ()
+      -- Handle FIN flag
+      when (flagFIN flags) $ applyRemoteFin sess sid
+      -- Handle RST flag
+      when (flagRST flags) $ applyRemoteRst sess sid
+      pure True
+
+-- | Look up a stream by ID.
+lookupStream :: YamuxSession -> Word32 -> IO (Maybe YamuxStream)
+lookupStream sess sid = Map.lookup sid <$> readTVarIO (ysessStreams sess)
+
+-- | Validate and register an inbound SYN (parity + duplicate check).
+-- Returns False on protocol error; the caller sends GoAway and stops.
+acceptInboundSYN :: YamuxSession -> Word32 -> IO Bool
+acceptInboundSYN sess sid = do
+  valid <- atomically $ validateInboundSYN sess sid
+  if not valid
+    then pure False
+    else do
+      stream <- newStream sess sid StreamSYNReceived
+      atomically $ do
+        modifyTVar' (ysessStreams sess) (Map.insert sid stream)
+        writeTQueue (ysessAcceptCh sess) stream
+      pure True
+
+-- | Reserve receive window for a declared Data-frame length before the
+-- payload is read off the transport. Returns False on a flow-control
+-- violation (declared length exceeds the stream's receive window or the
+-- absolute maxStreamWindowSize bound); the session must then terminate.
+reserveRecvWindow :: YamuxSession -> Word32 -> Word32 -> IO Bool
+reserveRecvWindow sess sid len
+  | len == 0 = pure True
+  | len > maxStreamWindowSize = pure False
+  | otherwise = atomically $ do
+      streams <- readTVar (ysessStreams sess)
+      case Map.lookup sid streams of
+        -- Unknown stream: payload is read and discarded, bounded by the
+        -- maxStreamWindowSize check above (defence in depth)
+        Nothing -> pure True
+        Just stream -> do
+          w <- readTVar (ysRecvWindow stream)
+          if len > w
+            then pure False
+            else do
+              writeTVar (ysRecvWindow stream) (w - len)
+              pure True
+
+-- | ACK flag: transition SYNSent -> Established.
+handleAckFlag :: YamuxSession -> Word32 -> IO ()
+handleAckFlag sess sid = do
+  mStream <- lookupStream sess sid
+  case mStream of
+    Just stream -> atomically $ do
+      st <- readTVar (ysState stream)
+      case st of
+        StreamSYNSent -> writeTVar (ysState stream) StreamEstablished
+        _ -> pure ()
+    Nothing -> pure ()
+
+-- | Shared FIN transition (spec.md, Closing a stream). The remote may
+-- half-close from any pre-close state: nothing in the spec ties FIN to
+-- the local ACK state, and go-libp2p pipelines SYN, data and FIN in one
+-- burst, so SYNSent/SYNReceived must transition like Established.
+applyRemoteFin :: YamuxSession -> Word32 -> IO ()
+applyRemoteFin sess sid = do
+  mStream <- lookupStream sess sid
+  case mStream of
+    Just stream -> atomically $ do
+      st <- readTVar (ysState stream)
+      case st of
+        StreamSYNSent -> writeTVar (ysState stream) StreamRemoteClose
+        StreamSYNReceived -> writeTVar (ysState stream) StreamRemoteClose
+        StreamEstablished -> writeTVar (ysState stream) StreamRemoteClose
+        StreamLocalClose -> writeTVar (ysState stream) StreamClosed
+        _ -> pure ()
+    Nothing -> pure ()
+
+-- | Shared RST transition: any state -> Reset.
+applyRemoteRst :: YamuxSession -> Word32 -> IO ()
+applyRemoteRst sess sid = do
+  mStream <- lookupStream sess sid
+  case mStream of
+    Just stream -> atomically $ writeTVar (ysState stream) StreamReset
+    Nothing -> pure ()
 
 -- | Handle a Ping frame (StreamID must be 0).
 -- SYN: echo back with ACK flag and same opaque value.

--- a/test/LibP2P/Yamux/SessionSpec.hs
+++ b/test/LibP2P/Yamux/SessionSpec.hs
@@ -1,8 +1,10 @@
 module LibP2P.Yamux.SessionSpec (spec) where
 
-import Control.Concurrent.Async (async, concurrently, concurrently_, withAsync)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (async, concurrently, concurrently_, wait, withAsync)
 import Control.Concurrent.STM
 import qualified Data.ByteString as BS
+import System.Timeout (timeout)
 import LibP2P.Yamux.Frame
 import LibP2P.Yamux.Session
 import LibP2P.Yamux.Stream (streamClose, streamRead, streamReset, streamWrite)
@@ -338,6 +340,165 @@ spec = do
               results <- mapM (\s -> streamRead s >>= \(Right d) -> pure d) streams
               mapM_ (\d -> BS.length d `shouldBe` 100) results
           )
+
+  describe "FIN handling in pre-established states (issue #142)" $ do
+    it "should signal EOF when Data-frame FIN arrives while stream is in SYNReceived" $ do
+      ((writeA, _readA), (writeB, readB)) <- mkMemoryTransportPair
+      server <- newSession RoleServer writeB readB
+      let synHdr =
+            YamuxHeader
+              { yhVersion = 0
+              , yhType = FrameData
+              , yhFlags = defaultFlags {flagSYN = True}
+              , yhStreamId = 1
+              , yhLength = 0
+              }
+          dataHdr =
+            YamuxHeader
+              { yhVersion = 0
+              , yhType = FrameData
+              , yhFlags = defaultFlags
+              , yhStreamId = 1
+              , yhLength = 5
+              }
+          finHdr =
+            YamuxHeader
+              { yhVersion = 0
+              , yhType = FrameData
+              , yhFlags = defaultFlags {flagFIN = True}
+              , yhStreamId = 1
+              , yhLength = 0
+              }
+      writeA (encodeHeader synHdr)
+      writeA (encodeHeader dataHdr)
+      writeA "hello"
+      writeA (encodeHeader finHdr)
+      withAsync (sendLoop server) $ \_ ->
+        withAsync (recvLoop server) $ \_ -> do
+          -- Let recvLoop process all frames before accepting, so the FIN
+          -- is handled while the stream is still in StreamSYNReceived
+          threadDelay 100000
+          result <- timeout 1000000 $ do
+            Right stream <- acceptStream server
+            Right received <- streamRead stream
+            received `shouldBe` "hello"
+            eof <- streamRead stream
+            eof `shouldBe` Left YamuxStreamClosed
+          result `shouldBe` Just ()
+
+    it "should signal EOF when WindowUpdate FIN arrives while stream is in SYNReceived (go-libp2p open pattern)" $ do
+      ((writeA, _readA), (writeB, readB)) <- mkMemoryTransportPair
+      server <- newSession RoleServer writeB readB
+      let synHdr =
+            YamuxHeader
+              { yhVersion = 0
+              , yhType = FrameWindowUpdate
+              , yhFlags = defaultFlags {flagSYN = True}
+              , yhStreamId = 1
+              , yhLength = 0
+              }
+          dataHdr =
+            YamuxHeader
+              { yhVersion = 0
+              , yhType = FrameData
+              , yhFlags = defaultFlags
+              , yhStreamId = 1
+              , yhLength = 5
+              }
+          finHdr =
+            YamuxHeader
+              { yhVersion = 0
+              , yhType = FrameWindowUpdate
+              , yhFlags = defaultFlags {flagFIN = True}
+              , yhStreamId = 1
+              , yhLength = 0
+              }
+      writeA (encodeHeader synHdr)
+      writeA (encodeHeader dataHdr)
+      writeA "hello"
+      writeA (encodeHeader finHdr)
+      withAsync (sendLoop server) $ \_ ->
+        withAsync (recvLoop server) $ \_ -> do
+          threadDelay 100000
+          result <- timeout 1000000 $ do
+            Right stream <- acceptStream server
+            Right received <- streamRead stream
+            received `shouldBe` "hello"
+            eof <- streamRead stream
+            eof `shouldBe` Left YamuxStreamClosed
+          result `shouldBe` Just ()
+
+    it "should transition SYNSent to RemoteClose when WindowUpdate FIN arrives" $ do
+      ((writeA, readA), (writeB, _readB)) <- mkMemoryTransportPair
+      client <- newSession RoleClient writeA readA
+      withAsync (sendLoop client) $ \_ ->
+        withAsync (recvLoop client) $ \_ -> do
+          Right stream <- openStream client
+          -- Remote half-closes with WindowUpdate+FIN before ACKing the SYN
+          let finHdr =
+                YamuxHeader
+                  { yhVersion = 0
+                  , yhType = FrameWindowUpdate
+                  , yhFlags = defaultFlags {flagFIN = True}
+                  , yhStreamId = 1
+                  , yhLength = 0
+                  }
+          writeB (encodeHeader finHdr)
+          result <- timeout 1000000 $ atomically $ do
+            st <- readTVar (ysState stream)
+            check (st == StreamRemoteClose)
+          result `shouldBe` Just ()
+
+  describe "Flow control: declared length validated before payload read (issue #143)" $ do
+    it "should reject a data frame declaring more than the recv window without reading its payload" $ do
+      ((writeA, _readA), (writeB, readB)) <- mkMemoryTransportPair
+      server <- newSession RoleServer writeB readB
+      let synHdr =
+            YamuxHeader
+              { yhVersion = 0
+              , yhType = FrameWindowUpdate
+              , yhFlags = defaultFlags {flagSYN = True}
+              , yhStreamId = 1
+              , yhLength = 0
+              }
+          -- Declares 1 MiB (> 256 KiB initial window); no payload bytes follow.
+          -- The violation must be detected on the header alone.
+          bigHdr =
+            YamuxHeader
+              { yhVersion = 0
+              , yhType = FrameData
+              , yhFlags = defaultFlags
+              , yhStreamId = 1
+              , yhLength = 1048576
+              }
+      writeA (encodeHeader synHdr)
+      writeA (encodeHeader bigHdr)
+      withAsync (sendLoop server) $ \_ ->
+        withAsync (recvLoop server) $ \recvA -> do
+          result <- timeout 1000000 $ do
+            atomically $ readTVar (ysessShutdown server) >>= check
+            -- The violation must also terminate the receive loop
+            wait recvA
+          result `shouldBe` Just ()
+
+    it "should reject a length of 0xFFFFFFFF on an unknown stream and stop the session" $ do
+      ((writeA, _readA), (writeB, readB)) <- mkMemoryTransportPair
+      server <- newSession RoleServer writeB readB
+      let hugeHdr =
+            YamuxHeader
+              { yhVersion = 0
+              , yhType = FrameData
+              , yhFlags = defaultFlags
+              , yhStreamId = 1
+              , yhLength = 0xFFFFFFFF
+              }
+      writeA (encodeHeader hugeHdr)
+      withAsync (sendLoop server) $ \_ ->
+        withAsync (recvLoop server) $ \recvA -> do
+          result <- timeout 1000000 $ do
+            atomically $ readTVar (ysessShutdown server) >>= check
+            wait recvA
+          result `shouldBe` Just ()
 
 -- | Read exactly n bytes from a stream by accumulating chunks.
 readAll :: YamuxStream -> Int -> IO BS.ByteString


### PR DESCRIPTION
## Summary

Fixes two critical bugs in the yamux frame-receive path.

### #142 — FIN ignored in pre-established states

The FIN handlers dropped the flag when a stream was in `StreamSYNReceived` (Data path) or `StreamSYNSent`/`StreamSYNReceived` (WindowUpdate path). Inbound streams sit in `StreamSYNReceived` until `acceptStream` runs, so a peer that pipelines SYN + data + FIN — go-libp2p's default single-shot RPC pattern, opened via WindowUpdate+SYN — left the stream permanently open and `streamRead` retrying forever.

**Fix:** the FIN transition is extracted into one shared `applyRemoteFin` used by both handlers, covering every pre-close state (`SYNSent`/`SYNReceived`/`Established` → `RemoteClose`, `LocalClose` → `Closed`), per the spec's "Closing a stream" section which does not condition FIN on local ACK state. `acceptStream` now only transitions `SYNReceived` → `Established`, so a `RemoteClose` set by an early FIN survives the accept.

### #143 — payload read before the flow-control check

`handleDataFrame` read the full declared payload off the transport before checking it against the receive window, so a 12-byte header declaring `length = 0xFFFFFFFF` made the session try to buffer 4 GiB — remote memory exhaustion reachable by any peer that completes the handshake. A violation also only queued a GoAway while `recvLoop` kept running.

**Fix:** `reserveRecvWindow` validates the declared length against the stream's receive window and an absolute `maxStreamWindowSize` bound (16 MiB, matching go-yamux) **before** any payload byte is read. A violation sends `GoAway(protocol)` and terminates `recvLoop`, matching go-yamux's session-fatal handling. `readExact` in the upgrade pipeline is additionally bounded and reads in 32 KiB chunks instead of materializing one boxed list per request, as defence in depth.

## Tests

5 new regression tests (raw-frame injection for the go-libp2p open pattern, early-FIN EOF signalling, over-window and 4 GiB header rejection with recvLoop termination). Full suite: 622 examples, 0 failures.

Closes #142
Closes #143