### PR TITLE
fix(dht): send raw keys on the wire and hash keys before XOR distance

### DIFF
--- a/src/LibP2P/DHT.hs
+++ b/src/LibP2P/DHT.hs
@@ -34,7 +34,7 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Data.Time (UTCTime, getCurrentTime)
 import LibP2P.Crypto.PeerId (PeerId (..), peerIdBytes)
-import LibP2P.DHT.Distance (peerIdToKey)
+import LibP2P.DHT.Distance (keyToDHTKey, peerIdToKey)
 import LibP2P.DHT.Message
 import LibP2P.DHT.RoutingTable (RoutingTable, closestPeers, newRoutingTable)
 import LibP2P.DHT.Types
@@ -124,7 +124,9 @@ processRequest node msg remotePeerId =
 handleFindNode :: DHTNode -> DHTMessage -> IO DHTMessage
 handleFindNode node msg = do
   rt <- readTVarIO (dhtRoutingTable node)
-  let targetKey = DHTKey (msgKey msg)
+  -- The wire key is raw (a binary peer ID); the spec distance metric is
+  -- XOR over SHA-256 digests, so hash before comparing.
+  let targetKey = keyToDHTKey (msgKey msg)
       closest = closestPeers targetKey kValue rt
       peers = map entryToDHTPeer closest
   pure emptyDHTMessage
@@ -138,7 +140,8 @@ handleGetValue node msg = do
   rt <- readTVarIO (dhtRoutingTable node)
   records <- readTVarIO (dhtRecordStore node)
   let key = msgKey msg
-      targetKey = DHTKey key
+      -- Store lookup uses the raw key; distance uses its SHA-256.
+      targetKey = keyToDHTKey key
       closest = closestPeers targetKey kValue rt
       peers = map entryToDHTPeer closest
       rec = Map.lookup key records
@@ -177,7 +180,8 @@ handleGetProviders node msg = do
   rt <- readTVarIO (dhtRoutingTable node)
   providerMap <- readTVarIO (dhtProviderStore node)
   let key = msgKey msg
-      targetKey = DHTKey key
+      -- Store lookup uses the raw key; distance uses its SHA-256.
+      targetKey = keyToDHTKey key
       closest = closestPeers targetKey kValue rt
       closerPeers = map entryToDHTPeer closest
       providers = Map.findWithDefault [] key providerMap

--- a/src/LibP2P/DHT/Distance.hs
+++ b/src/LibP2P/DHT/Distance.hs
@@ -3,7 +3,8 @@
 -- All distance computations operate on 256-bit SHA-256 keys.
 -- Distance is the XOR of two keys interpreted as a 256-bit unsigned integer.
 module LibP2P.DHT.Distance
-  ( peerIdToKey
+  ( keyToDHTKey
+  , peerIdToKey
   , xorDistance
   , commonPrefixLength
   , compareDistance
@@ -20,11 +21,20 @@ import Data.Word (Word8)
 import LibP2P.Crypto.PeerId (PeerId, peerIdBytes)
 import LibP2P.DHT.Types (BucketEntry (..), DHTKey (..))
 
+-- | Map a raw key (binary peer ID, record key, CID) into the DHT keyspace.
+--
+-- Per specs/kad-dht, the distance between two keys is
+-- @XOR(sha256(key1), sha256(key2))@ — every key must be hashed before any
+-- distance computation. Wire messages carry the raw key; only local
+-- comparisons use the digest.
+keyToDHTKey :: ByteString -> DHTKey
+keyToDHTKey bs =
+  let digest = hash bs :: Digest SHA256
+  in DHTKey (convert digest)
+
 -- | Convert a Peer ID to its DHT key by hashing with SHA-256.
 peerIdToKey :: PeerId -> DHTKey
-peerIdToKey pid =
-  let digest = hash (peerIdBytes pid) :: Digest SHA256
-  in DHTKey (convert digest)
+peerIdToKey = keyToDHTKey . peerIdBytes
 
 -- | Compute XOR distance between two DHT keys.
 xorDistance :: DHTKey -> DHTKey -> DHTKey

--- a/src/LibP2P/DHT/Lookup.hs
+++ b/src/LibP2P/DHT/Lookup.hs
@@ -26,9 +26,9 @@ import Data.ByteString (ByteString)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Time (UTCTime, getCurrentTime)
-import LibP2P.Crypto.PeerId (PeerId (..))
+import LibP2P.Crypto.PeerId (PeerId (..), peerIdBytes)
 import LibP2P.DHT (DHTNode (..), ProviderEntry (..), Validator (..))
-import LibP2P.DHT.Distance (peerIdToKey, sortByDistance)
+import LibP2P.DHT.Distance (keyToDHTKey, peerIdToKey, sortByDistance)
 import LibP2P.DHT.Message
 import LibP2P.DHT.RoutingTable (closestPeers, insertPeer, allPeers)
 import LibP2P.DHT.Types
@@ -40,17 +40,23 @@ data LookupResult
   | FoundProviders ![ProviderEntry] ![BucketEntry]
   deriving (Show)
 
--- | Iterative FIND_NODE: find the k closest peers to a target key.
+-- | Iterative FIND_NODE: find the k closest peers to a target peer.
+--
+-- Per specs/kad-dht, the FIND_NODE wire key must be the target's binary
+-- Peer ID; XOR distance is computed over SHA-256 digests, so only local
+-- comparisons use the hashed key.
 --
 -- Algorithm:
 -- 1. Seed candidates with k closest from local routing table
 -- 2. Query up to alpha unqueried candidates in parallel
 -- 3. Merge returned closerPeers into candidates
 -- 4. Terminate when top-k candidates all queried or no unqueried remain
-iterativeFindNode :: DHTNode -> DHTKey -> IO [BucketEntry]
-iterativeFindNode node targetKey = do
+iterativeFindNode :: DHTNode -> PeerId -> IO [BucketEntry]
+iterativeFindNode node targetPid = do
   rt <- readTVarIO (dhtRoutingTable node)
-  let seeds = closestPeers targetKey kValue rt
+  let wireKey = peerIdBytes targetPid   -- raw peer ID on the wire
+      targetKey = peerIdToKey targetPid -- SHA-256 for distance
+      seeds = closestPeers targetKey kValue rt
   now <- getCurrentTime
 
   -- State: candidates sorted by XOR distance, queried set, known set (for dedup)
@@ -58,19 +64,20 @@ iterativeFindNode node targetKey = do
   queriedVar    <- newTVarIO Set.empty
   knownVar      <- newTVarIO (Set.fromList (map entryPeerId seeds))
 
-  lookupLoop node targetKey candidatesVar queriedVar knownVar now FindNode
+  lookupLoop node wireKey targetKey candidatesVar queriedVar knownVar now FindNode
 
 -- | Core lookup loop shared by FIND_NODE, GET_VALUE, GET_PROVIDERS.
 lookupLoop
   :: DHTNode
-  -> DHTKey
+  -> ByteString           -- ^ Raw wire key sent in requests
+  -> DHTKey               -- ^ SHA-256 of the wire key, for distance
   -> TVar [BucketEntry]   -- ^ Candidates sorted by XOR distance to target
   -> TVar (Set PeerId)    -- ^ Already queried peers
   -> TVar (Set PeerId)    -- ^ Known peers (all candidates ever seen, for dedup)
   -> a                    -- ^ Timestamp placeholder (UTCTime)
   -> MessageType          -- ^ Query type
   -> IO [BucketEntry]
-lookupLoop node targetKey candidatesVar queriedVar knownVar _now queryType = go
+lookupLoop node wireKey targetKey candidatesVar queriedVar knownVar _now queryType = go
   where
     go = do
       -- Pick up to alpha unqueried candidates closest to target
@@ -91,7 +98,7 @@ lookupLoop node targetKey candidatesVar queriedVar knownVar _now queryType = go
           pure (take kValue candidates)
         else do
           -- Query each peer in parallel
-          results <- mapConcurrently (queryPeer node targetKey queryType) toQuery
+          results <- mapConcurrently (queryPeer node wireKey queryType) toQuery
 
           -- Merge results
           atomically $ do
@@ -122,15 +129,16 @@ lookupLoop node targetKey candidatesVar queriedVar knownVar _now queryType = go
               candidates <- readTVarIO candidatesVar
               pure (take kValue candidates)
 
-    _now = let DHTKey bs = targetKey in bs  -- placeholder, overridden by caller
-
 -- | Query a single peer and return the closerPeers from the response.
-queryPeer :: DHTNode -> DHTKey -> MessageType -> BucketEntry -> IO (Either String [DHTPeer])
-queryPeer node targetKey queryType entry = do
-  let (DHTKey keyBytes) = targetKey
-      request = emptyDHTMessage
+--
+-- The request carries the raw wire key (e.g. the binary Peer ID for
+-- FIND_NODE), never a SHA-256 digest: the remote hashes the key itself
+-- when computing distances (specs/kad-dht).
+queryPeer :: DHTNode -> ByteString -> MessageType -> BucketEntry -> IO (Either String [DHTPeer])
+queryPeer node wireKey queryType entry = do
+  let request = emptyDHTMessage
         { msgType = queryType
-        , msgKey  = keyBytes
+        , msgKey  = wireKey
         }
   result <- (dhtSendRequest node) (entryPeerId entry) request
     `catch` (\(e :: SomeException) -> pure (Left (show e)))
@@ -145,7 +153,8 @@ queryPeer node targetKey queryType entry = do
 iterativeGetValue :: DHTNode -> Validator -> ByteString -> IO (Either String DHTRecord)
 iterativeGetValue node validator key = do
   rt <- readTVarIO (dhtRoutingTable node)
-  let targetKey = DHTKey key
+  -- The raw record key goes on the wire; distance uses its SHA-256.
+  let targetKey = keyToDHTKey key
       seeds = closestPeers targetKey kValue rt
   now <- getCurrentTime
 
@@ -156,12 +165,13 @@ iterativeGetValue node validator key = do
   bestPeersVar  <- newTVarIO (Set.empty :: Set PeerId)
   outdatedVar   <- newTVarIO (Set.empty :: Set PeerId)
 
-  valueLoop node targetKey candidatesVar queriedVar knownVar bestVar bestPeersVar outdatedVar validator now
+  valueLoop node key targetKey candidatesVar queriedVar knownVar bestVar bestPeersVar outdatedVar validator now
 
 -- | Value lookup loop with best/outdated tracking.
 valueLoop
   :: DHTNode
-  -> DHTKey
+  -> ByteString           -- ^ Raw wire key sent in requests
+  -> DHTKey               -- ^ SHA-256 of the wire key, for distance
   -> TVar [BucketEntry]
   -> TVar (Set PeerId)
   -> TVar (Set PeerId)    -- ^ Known peers (dedup)
@@ -171,7 +181,7 @@ valueLoop
   -> Validator
   -> a
   -> IO (Either String DHTRecord)
-valueLoop node targetKey candidatesVar queriedVar knownVar bestVar bestPeersVar outdatedVar validator _now = go
+valueLoop node wireKey targetKey candidatesVar queriedVar knownVar bestVar bestPeersVar outdatedVar validator _now = go
   where
     go = do
       toQuery <- atomically $ do
@@ -186,7 +196,7 @@ valueLoop node targetKey candidatesVar queriedVar knownVar bestVar bestPeersVar 
       if null toQuery
         then finalize
         else do
-          results <- mapConcurrently (queryPeerForValue node targetKey) toQuery
+          results <- mapConcurrently (queryPeerForValue node wireKey) toQuery
 
           -- Process each result
           mapM_ (processValueResult node targetKey bestVar bestPeersVar outdatedVar validator _now) results
@@ -231,14 +241,11 @@ valueLoop node targetKey candidatesVar queriedVar knownVar bestVar bestPeersVar 
                 (Set.toList outdated)
           pure (Right rec)
 
-    _now = let DHTKey bs = targetKey in bs  -- placeholder
-
 -- | Query a peer for a value and return (peerId, closerPeers, Maybe record).
-queryPeerForValue :: DHTNode -> DHTKey -> BucketEntry
+queryPeerForValue :: DHTNode -> ByteString -> BucketEntry
                   -> IO (PeerId, Either String [DHTPeer], Maybe DHTRecord)
-queryPeerForValue node targetKey entry = do
-  let (DHTKey keyBytes) = targetKey
-      request = emptyDHTMessage { msgType = GetValue, msgKey = keyBytes }
+queryPeerForValue node wireKey entry = do
+  let request = emptyDHTMessage { msgType = GetValue, msgKey = wireKey }
   result <- (dhtSendRequest node) (entryPeerId entry) request
     `catch` (\(e :: SomeException) -> pure (Left (show e)))
   pure $ case result of
@@ -282,7 +289,8 @@ processValueResult _ _ _ _ _ _ _ (_, _, Nothing) = pure ()
 iterativeGetProviders :: DHTNode -> ByteString -> IO [ProviderEntry]
 iterativeGetProviders node key = do
   rt <- readTVarIO (dhtRoutingTable node)
-  let targetKey = DHTKey key
+  -- The raw content key goes on the wire; distance uses its SHA-256.
+  let targetKey = keyToDHTKey key
       seeds = closestPeers targetKey kValue rt
   now <- getCurrentTime
 
@@ -291,19 +299,20 @@ iterativeGetProviders node key = do
   knownVar      <- newTVarIO (Set.fromList (map entryPeerId seeds))
   providersVar  <- newTVarIO ([] :: [ProviderEntry])
 
-  providerLoop node targetKey candidatesVar queriedVar knownVar providersVar now
+  providerLoop node key targetKey candidatesVar queriedVar knownVar providersVar now
 
 -- | Provider lookup loop.
 providerLoop
   :: DHTNode
-  -> DHTKey
+  -> ByteString           -- ^ Raw wire key sent in requests
+  -> DHTKey               -- ^ SHA-256 of the wire key, for distance
   -> TVar [BucketEntry]
   -> TVar (Set PeerId)
   -> TVar (Set PeerId)    -- ^ Known peers (dedup)
   -> TVar [ProviderEntry]
   -> a
   -> IO [ProviderEntry]
-providerLoop node targetKey candidatesVar queriedVar knownVar providersVar _now = go
+providerLoop node wireKey targetKey candidatesVar queriedVar knownVar providersVar _now = go
   where
     go = do
       toQuery <- atomically $ do
@@ -318,7 +327,7 @@ providerLoop node targetKey candidatesVar queriedVar knownVar providersVar _now 
       if null toQuery
         then readTVarIO providersVar
         else do
-          results <- mapConcurrently (queryPeerForProviders node targetKey) toQuery
+          results <- mapConcurrently (queryPeerForProviders node wireKey) toQuery
 
           -- Collect providers and closer peers
           atomically $ do
@@ -345,14 +354,11 @@ providerLoop node targetKey candidatesVar queriedVar knownVar providersVar _now 
 
           if shouldContinue then go else readTVarIO providersVar
 
-    _now = let DHTKey bs = targetKey in bs
-
 -- | Query a peer for providers.
-queryPeerForProviders :: DHTNode -> DHTKey -> BucketEntry
+queryPeerForProviders :: DHTNode -> ByteString -> BucketEntry
                       -> IO (PeerId, Either String [DHTPeer], [DHTPeer])
-queryPeerForProviders node targetKey entry = do
-  let (DHTKey keyBytes) = targetKey
-      request = emptyDHTMessage { msgType = GetProviders, msgKey = keyBytes }
+queryPeerForProviders node wireKey entry = do
+  let request = emptyDHTMessage { msgType = GetProviders, msgKey = wireKey }
   result <- (dhtSendRequest node) (entryPeerId entry) request
     `catch` (\(e :: SomeException) -> pure (Left (show e)))
   pure $ case result of
@@ -369,8 +375,8 @@ bootstrap node seeds = do
       rt' = foldl (\r e -> fst (insertPeer e r)) rt seedEntries
   atomically $ writeTVar (dhtRoutingTable node) rt'
 
-  -- Step 2: Self-lookup (FIND_NODE for our own key)
-  _ <- iterativeFindNode node (dhtLocalKey node)
+  -- Step 2: Self-lookup (FIND_NODE for our own peer ID)
+  _ <- iterativeFindNode node (dhtLocalPeerId node)
 
   -- Step 3: Refresh non-empty buckets
   -- (simplified: just do another lookup for a peer in each occupied bucket)
@@ -378,7 +384,7 @@ bootstrap node seeds = do
   let peers = allPeers rt''
   -- For each unique bucket, pick a representative peer and do a lookup
   let bucketReps = take 10 peers  -- limit to avoid excessive lookups during bootstrap
-  mapM_ (\entry -> iterativeFindNode node (entryKey entry)
+  mapM_ (\entry -> iterativeFindNode node (entryPeerId entry)
                      `catch` (\(_ :: SomeException) -> pure []))
         bucketReps
 

--- a/src/LibP2P/DHT/Types.hs
+++ b/src/LibP2P/DHT/Types.hs
@@ -18,6 +18,10 @@ import LibP2P.Crypto.PeerId (PeerId)
 import LibP2P.Multiaddr (Multiaddr)
 
 -- | 256-bit key in the DHT keyspace (always exactly 32 bytes, SHA-256 output).
+--
+-- Construct via 'LibP2P.DHT.Distance.keyToDHTKey' (or 'peerIdToKey' for peer
+-- IDs) — never wrap raw wire bytes directly. Per specs/kad-dht the distance
+-- metric is XOR over SHA-256 digests, while RPC messages carry the raw key.
 newtype DHTKey = DHTKey ByteString
   deriving (Eq, Ord, Show)
 

--- a/test/LibP2P/DHT/DHTSpec.hs
+++ b/test/LibP2P/DHT/DHTSpec.hs
@@ -8,6 +8,8 @@ module LibP2P.DHT.DHTSpec
 import Test.Hspec
 
 import Control.Concurrent.STM
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.ByteArray (convert)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import Data.Time (getCurrentTime)
@@ -15,7 +17,7 @@ import Data.Word (Word8)
 import LibP2P.Crypto.Key (KeyPair (..), PublicKey (..), PrivateKey (..), KeyType (..))
 import LibP2P.Crypto.PeerId (PeerId (..), peerIdBytes)
 import LibP2P.DHT
-import LibP2P.DHT.Distance (peerIdToKey)
+import LibP2P.DHT.Distance (peerIdToKey, sortByDistance)
 import LibP2P.DHT.Message
 import LibP2P.DHT.RoutingTable (insertPeer)
 import LibP2P.DHT.Types
@@ -74,6 +76,10 @@ mkMockSwitch pid = do
 -- | Create a mock resource manager with no limits (tests don't need resource enforcement).
 mkMockResourceMgr :: IO ResourceManager
 mkMockResourceMgr = newResourceManager (DefaultLimits noLimits noLimits)
+
+-- | Independent SHA-256 (not via DHT.Distance) for asserting the spec metric.
+sha256 :: BS.ByteString -> BS.ByteString
+sha256 bs = convert (hash bs :: Digest SHA256)
 
 -- | Dummy key pair for mock Switch (DHT never accesses identity key).
 dummyKeyPair :: KeyPair
@@ -143,6 +149,78 @@ spec = do
       result <- readFramedMessage clientStream maxDHTMessageSize
       case result of
         Right resp -> length (msgCloserPeers resp) `shouldSatisfy` (>= 0)
+        Left err -> expectationFailure $ "Failed: " ++ err
+
+    -- Per specs/kad-dht: "the distance between two keys is
+    -- XOR(sha256(key1), sha256(key2))". The wire key arrives raw and must be
+    -- hashed before comparing against routing-table entries (which cache
+    -- sha256 of the peer ID). Wrapping raw wire bytes in DHTKey (the old
+    -- behaviour) sorts by a different, non-spec metric.
+    it "FIND_NODE orders closerPeers by XOR distance over SHA-256 of the wire key" $ do
+      node <- mkTestNode localPid
+      now <- getCurrentTime
+      let peers = [mkPeerId (BS.pack [i]) | i <- [2..10]]
+          entries = map (\pid -> BucketEntry pid (peerIdToKey pid) [] now NotConnected) peers
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        foldl (\r e -> fst (insertPeer e r)) rt entries
+
+      -- Raw wire key, as a remote peer would send it (a binary peer ID).
+      let wireKey = BS.pack [42, 42, 42]
+          hashedTarget = DHTKey (sha256 wireKey)
+          expectedOrder = map (peerIdBytes . entryPeerId) (sortByDistance hashedTarget entries)
+
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage { msgType = FindNode, msgKey = wireKey }
+      writeFramedMessage clientStream request
+      handleDHTRequest node serverStream remotePid
+
+      result <- readFramedMessage clientStream maxDHTMessageSize
+      case result of
+        Right resp -> map dhtPeerId (msgCloserPeers resp) `shouldBe` expectedOrder
+        Left err -> expectationFailure $ "Failed: " ++ err
+
+    it "GET_VALUE orders closerPeers by XOR distance over SHA-256 of the wire key" $ do
+      node <- mkTestNode localPid
+      now <- getCurrentTime
+      let peers = [mkPeerId (BS.pack [i]) | i <- [2..10]]
+          entries = map (\pid -> BucketEntry pid (peerIdToKey pid) [] now NotConnected) peers
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        foldl (\r e -> fst (insertPeer e r)) rt entries
+
+      let wireKey = BS.pack [0xCA, 0xFE, 0x01]
+          hashedTarget = DHTKey (sha256 wireKey)
+          expectedOrder = map (peerIdBytes . entryPeerId) (sortByDistance hashedTarget entries)
+
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage { msgType = GetValue, msgKey = wireKey }
+      writeFramedMessage clientStream request
+      handleDHTRequest node serverStream remotePid
+
+      result <- readFramedMessage clientStream maxDHTMessageSize
+      case result of
+        Right resp -> map dhtPeerId (msgCloserPeers resp) `shouldBe` expectedOrder
+        Left err -> expectationFailure $ "Failed: " ++ err
+
+    it "GET_PROVIDERS orders closerPeers by XOR distance over SHA-256 of the wire key" $ do
+      node <- mkTestNode localPid
+      now <- getCurrentTime
+      let peers = [mkPeerId (BS.pack [i]) | i <- [2..10]]
+          entries = map (\pid -> BucketEntry pid (peerIdToKey pid) [] now NotConnected) peers
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        foldl (\r e -> fst (insertPeer e r)) rt entries
+
+      let wireKey = BS.pack [0xDD, 0xEE]
+          hashedTarget = DHTKey (sha256 wireKey)
+          expectedOrder = map (peerIdBytes . entryPeerId) (sortByDistance hashedTarget entries)
+
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage { msgType = GetProviders, msgKey = wireKey }
+      writeFramedMessage clientStream request
+      handleDHTRequest node serverStream remotePid
+
+      result <- readFramedMessage clientStream maxDHTMessageSize
+      case result of
+        Right resp -> map dhtPeerId (msgCloserPeers resp) `shouldBe` expectedOrder
         Left err -> expectationFailure $ "Failed: " ++ err
 
     it "GET_VALUE with stored record returns it" $ do

--- a/test/LibP2P/DHT/DistanceSpec.hs
+++ b/test/LibP2P/DHT/DistanceSpec.hs
@@ -2,10 +2,13 @@ module LibP2P.DHT.DistanceSpec (spec) where
 
 import Test.Hspec
 
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.ByteArray (convert)
 import qualified Data.ByteString as BS
-import LibP2P.Crypto.PeerId (PeerId (..))
+import LibP2P.Crypto.PeerId (PeerId (..), peerIdBytes)
 import LibP2P.DHT.Distance
-  ( peerIdToKey
+  ( keyToDHTKey
+  , peerIdToKey
   , xorDistance
   , commonPrefixLength
   , compareDistance
@@ -35,6 +38,17 @@ zeroKey = DHTKey (BS.replicate 32 0)
 
 spec :: Spec
 spec = do
+  describe "keyToDHTKey" $ do
+    it "is the SHA-256 digest of the raw key bytes" $ do
+      let raw = BS.pack [1, 2, 3, 4]
+          (DHTKey keyBytes) = keyToDHTKey raw
+      keyBytes `shouldBe` convert (hash raw :: Digest SHA256)
+      BS.length keyBytes `shouldBe` 32
+
+    it "peerIdToKey is keyToDHTKey applied to the raw peer ID bytes" $ do
+      let pid = mkPeerId (BS.pack [10, 20, 30])
+      peerIdToKey pid `shouldBe` keyToDHTKey (peerIdBytes pid)
+
   describe "peerIdToKey" $ do
     it "produces 32-byte output" $ do
       let pid = mkPeerId (BS.pack [1, 2, 3, 4])

--- a/test/LibP2P/DHT/LookupSpec.hs
+++ b/test/LibP2P/DHT/LookupSpec.hs
@@ -39,6 +39,27 @@ mockSendFromNetwork network pid msg =
 spec :: Spec
 spec = do
   describe "iterativeFindNode" $ do
+    -- Issue #146: per specs/kad-dht the FIND_NODE wire key must be the
+    -- binary Peer ID. The old code sent sha256(peer id); a remote hashes
+    -- the key again, landing the query at sha256(sha256(peer id)).
+    it "sends the raw target peer ID as the wire key, not its SHA-256 digest" $ do
+      now <- getCurrentTime
+      sentKeysRef <- newIORef ([] :: [BS.ByteString])
+      let targetPid = mkPeerId (BS.pack [42, 42, 42, 42])
+          mockSend _pid msg = do
+            atomicModifyIORef' sentKeysRef (\ks -> (ks ++ [msgKey msg], ()))
+            pure (Right (emptyDHTMessage { msgType = FindNode, msgCloserPeers = [] }))
+      node <- mkNodeWithMock localPid mockSend
+      let pidA = mkPeerId (BS.pack [10])
+          entryA = BucketEntry pidA (peerIdToKey pidA) [] now NotConnected
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        fst (insertPeer entryA rt)
+
+      _ <- iterativeFindNode node targetPid
+      sentKeys <- readIORef sentKeysRef
+      sentKeys `shouldSatisfy` (not . null)
+      mapM_ (`shouldBe` peerIdBytes targetPid) sentKeys
+
     it "with local-only routing table returns local peers" $ do
       now <- getCurrentTime
       -- Create node with some peers in routing table, no network
@@ -48,8 +69,7 @@ spec = do
       atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
         foldl (\r e -> fst (insertPeer e r)) rt entries
 
-      let targetKey = peerIdToKey (mkPeerId (BS.pack [42]))
-      result <- iterativeFindNode node targetKey
+      result <- iterativeFindNode node (mkPeerId (BS.pack [42]))
       -- Should return peers even though network queries fail
       length result `shouldSatisfy` (> 0)
       length result `shouldSatisfy` (<= kValue)
@@ -60,7 +80,7 @@ spec = do
       let pidA = mkPeerId (BS.pack [10])
           pidB = mkPeerId (BS.pack [20])
           pidC = mkPeerId (BS.pack [30])
-          target = BS.pack [42, 42, 42, 42]
+          targetPid = mkPeerId (BS.pack [42, 42, 42, 42])
           -- Mock network: A returns B as closer, B returns C as closer
           network = Map.fromList
             [ (pidA, \_ -> emptyDHTMessage
@@ -82,7 +102,7 @@ spec = do
       atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
         fst (insertPeer entryA rt)
 
-      result <- iterativeFindNode node (DHTKey target)
+      result <- iterativeFindNode node targetPid
       -- Should have discovered A, B, C through the lookup chain
       let foundPids = map entryPeerId result
       foundPids `shouldSatisfy` (\ps -> pidA `elem` ps)
@@ -101,7 +121,7 @@ spec = do
       atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
         foldl (\r e -> fst (insertPeer e r)) rt entries
 
-      result <- iterativeFindNode node (DHTKey (BS.pack [0xFF, 0xFF]))
+      result <- iterativeFindNode node (mkPeerId (BS.pack [0xFF, 0xFF]))
       length result `shouldBe` length peers
 
     it "handles query failures gracefully" $ do
@@ -113,7 +133,7 @@ spec = do
       atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
         foldl (\r e -> fst (insertPeer e r)) rt entries
 
-      result <- iterativeFindNode node (DHTKey (BS.pack [42]))
+      result <- iterativeFindNode node (mkPeerId (BS.pack [42]))
       -- Should still return the local peers
       length result `shouldSatisfy` (> 0)
 
@@ -129,7 +149,7 @@ spec = do
       atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
         foldl (\r e -> fst (insertPeer e r)) rt entries
 
-      result <- iterativeFindNode node (DHTKey (BS.pack [99]))
+      result <- iterativeFindNode node (mkPeerId (BS.pack [99]))
       length result `shouldBe` 3  -- only 3 peers total, less than k=20
 
     it "queries peers in XOR distance order, not lexicographic key order" $ do
@@ -138,7 +158,10 @@ spec = do
 
       -- Create 15 peers so that alpha (10) < total, forcing batch selection
       let peers = [mkPeerId (BS.pack [i]) | i <- [10..24]]
-          targetKey = DHTKey (BS.replicate 32 0xFF)
+          targetPid = mkPeerId (BS.replicate 32 0xFF)
+          -- Distance is over sha256(key) (specs/kad-dht), so the expected
+          -- ordering must use the hashed target, matching the lookup.
+          targetKey = peerIdToKey targetPid
 
       -- Compute expected first batch: the 10 closest by XOR distance
       let entries = map (\pid -> BucketEntry pid (peerIdToKey pid) [] now NotConnected) peers
@@ -154,7 +177,7 @@ spec = do
       atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
         foldl (\r e -> fst (insertPeer e r)) rt entries
 
-      _ <- iterativeFindNode node targetKey
+      _ <- iterativeFindNode node targetPid
 
       -- The first alpha peers queried should be the closest by XOR distance
       -- (mapConcurrently doesn't preserve order within batch, so compare as sets)
@@ -165,7 +188,9 @@ spec = do
     it "returns results sorted by XOR distance to target" $ do
       now <- getCurrentTime
       let peers = [mkPeerId (BS.pack [i]) | i <- [10..20]]
-          targetKey = DHTKey (BS.replicate 32 0xAA)
+          targetPid = mkPeerId (BS.replicate 32 0xAA)
+          -- Expected order uses sha256(target peer id), the spec metric.
+          targetKey = peerIdToKey targetPid
           entries = map (\pid -> BucketEntry pid (peerIdToKey pid) [] now NotConnected) peers
           expectedOrder = map entryPeerId (sortByDistance targetKey entries)
 
@@ -176,11 +201,32 @@ spec = do
       atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
         foldl (\r e -> fst (insertPeer e r)) rt entries
 
-      result <- iterativeFindNode node targetKey
+      result <- iterativeFindNode node targetPid
       -- Results should be sorted by XOR distance to the target
       map entryPeerId result `shouldBe` expectedOrder
 
   describe "iterativeGetValue" $ do
+    it "sends the raw record key as the wire key" $ do
+      now <- getCurrentTime
+      sentKeysRef <- newIORef ([] :: [BS.ByteString])
+      let key = BS.pack [0xCA, 0xFE]
+          record = DHTRecord key (BS.pack [0xDE, 0xAD]) "2024-01-01T00:00:00Z"
+          mockSend _pid msg = do
+            atomicModifyIORef' sentKeysRef (\ks -> (ks ++ [msgKey msg], ()))
+            pure (Right (emptyDHTMessage
+              { msgType = GetValue, msgRecord = Just record, msgCloserPeers = [] }))
+          validator = Validator (\_ _ -> Right ()) (\_ _ -> Right 0)
+      node <- mkNodeWithMock localPid mockSend
+      let pidA = mkPeerId (BS.pack [10])
+          entryA = BucketEntry pidA (peerIdToKey pidA) [] now NotConnected
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        fst (insertPeer entryA rt)
+
+      _ <- iterativeGetValue node validator key
+      sentKeys <- readIORef sentKeysRef
+      sentKeys `shouldSatisfy` (not . null)
+      mapM_ (`shouldBe` key) sentKeys
+
     it "finds value from mock network" $ do
       now <- getCurrentTime
       let pidA = mkPeerId (BS.pack [10])
@@ -287,6 +333,25 @@ spec = do
         Left err -> expectationFailure $ "Expected value, got: " ++ err
 
   describe "iterativeGetProviders" $ do
+    it "sends the raw content key as the wire key" $ do
+      now <- getCurrentTime
+      sentKeysRef <- newIORef ([] :: [BS.ByteString])
+      let key = BS.pack [0xDD, 0xEE, 0xFF]
+          mockSend _pid msg = do
+            atomicModifyIORef' sentKeysRef (\ks -> (ks ++ [msgKey msg], ()))
+            pure (Right (emptyDHTMessage
+              { msgType = GetProviders, msgCloserPeers = [], msgProviderPeers = [] }))
+      node <- mkNodeWithMock localPid mockSend
+      let pidA = mkPeerId (BS.pack [10])
+          entryA = BucketEntry pidA (peerIdToKey pidA) [] now NotConnected
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        fst (insertPeer entryA rt)
+
+      _ <- iterativeGetProviders node key
+      sentKeys <- readIORef sentKeysRef
+      sentKeys `shouldSatisfy` (not . null)
+      mapM_ (`shouldBe` key) sentKeys
+
     it "collects providers from multiple hops" $ do
       now <- getCurrentTime
       let pidA = mkPeerId (BS.pack [10])
@@ -316,6 +381,24 @@ spec = do
       length result `shouldSatisfy` (>= 2)
 
   describe "bootstrap" $ do
+    it "self-lookup sends raw peer IDs as wire keys" $ do
+      sentKeysRef <- newIORef ([] :: [BS.ByteString])
+      let seedPid = mkPeerId (BS.pack [10])
+          mockSend _pid msg = do
+            atomicModifyIORef' sentKeysRef (\ks -> (ks ++ [msgKey msg], ()))
+            pure (Right (emptyDHTMessage { msgType = FindNode, msgCloserPeers = [] }))
+      node <- mkNodeWithMock localPid mockSend
+
+      bootstrap node [seedPid]
+
+      sentKeys <- readIORef sentKeysRef
+      sentKeys `shouldSatisfy` (not . null)
+      -- The self-lookup queries for our own binary peer ID (not its digest).
+      take 1 sentKeys `shouldBe` [peerIdBytes localPid]
+      -- Bucket refresh queries also carry raw peer IDs.
+      mapM_ (\k -> k `shouldSatisfy` (`elem` [peerIdBytes localPid, peerIdBytes seedPid]))
+            sentKeys
+
     it "performs self-lookup and populates nearby buckets" $ do
       now <- getCurrentTime
       let seedPid = mkPeerId (BS.pack [10])


### PR DESCRIPTION
## Root cause

Two mutually masking defects put DHT queries in the wrong part of the keyspace (see #146):

1. `queryPeer` unwrapped the already-hashed `DHTKey` and sent the SHA-256 digest as the FIND_NODE wire key. The spec requires the binary Peer ID; a remote hashes the key itself, so it answered with peers near `sha256(sha256(peerid))`.
2. Inbound `FIND_NODE`/`GET_VALUE`/`GET_PROVIDERS` handlers (and the value/provider lookup seeds) wrapped raw wire bytes in `DHTKey` without hashing, then XOR'd them against routing-table entries that cache `sha256(peer id)` — a non-spec metric, silently truncated by `BS.zipWith` for keys longer than 32 bytes.

Both defects break interop in each direction while cancelling out in the local-only test suite, so they land as one change.

## Fix

- `iterativeFindNode` now takes a `PeerId`: raw bytes go on the wire, `sha256` is used only for local distance comparisons.
- `iterativeGetValue` / `iterativeGetProviders` send the raw record/content key and hash it for candidate sorting.
- Inbound handlers hash the wire key via the new `keyToDHTKey` (DHT.Distance) before selecting `closerPeers`; store lookups still use the raw key.
- `bootstrap` passes peer IDs (self and bucket representatives) instead of cached digests.
- `keyToDHTKey` enforces the documented `DHTKey` invariant (32-byte SHA-256 digest); `peerIdToKey` delegates to it.

## Tests (TDD)

- New red-first tests assert the spec behaviour: handlers order `closerPeers` by `XOR(sha256(key), sha256(peer id))` (verified against an independent SHA-256), and every outbound query (`FIND_NODE`, `GET_VALUE`, `GET_PROVIDERS`, bootstrap self-lookup) carries the raw key, never a digest.
- Existing lookup-ordering tests updated: expected orderings now use the hashed target key, since distance is defined over digests.
- 626 examples, 0 failures.

Closes #146