### PR TITLE
fix(multiaddr): quic-v1 code 461, remove unregistered yamux, accept /ipfs alias

### DIFF
--- a/src/LibP2P/Multiaddr/Codec.hs
+++ b/src/LibP2P/Multiaddr/Codec.hs
@@ -48,7 +48,6 @@ encodeProtocols = BS.concat . map encodeOne
     encodeAddress P2PCircuit = BS.empty
     encodeAddress WebTransport = BS.empty
     encodeAddress NoiseProto = BS.empty
-    encodeAddress YamuxProto = BS.empty
 
     encodeVarText :: Text -> ByteString
     encodeVarText t =
@@ -114,13 +113,12 @@ decodeProtocols bs
     buildVarProtocol _ _ = Nothing
 
     buildNoAddrProtocol :: Word64 -> Maybe Protocol
-    buildNoAddrProtocol 460 = Just QuicV1
+    buildNoAddrProtocol 461 = Just QuicV1
     buildNoAddrProtocol 477 = Just WS
     buildNoAddrProtocol 478 = Just WSS
     buildNoAddrProtocol 290 = Just P2PCircuit
     buildNoAddrProtocol 465 = Just WebTransport
     buildNoAddrProtocol 454 = Just NoiseProto
-    buildNoAddrProtocol 467 = Just YamuxProto
     buildNoAddrProtocol _ = Nothing
 
 -- | Convert a list of protocols to human-readable text form.
@@ -178,9 +176,12 @@ textToProtocols input
       "udp" -> withAddr rest $ \addr remaining -> do
         port <- parsePort addr
         Right (UDP port, remaining)
-      "p2p" -> withAddr rest $ \addr remaining -> do
-        mh <- parsePeerIdAddr addr
-        Right (P2P mh, remaining)
+      -- "ipfs" is the legacy name for "p2p"; both map to code 421 and are
+      -- equivalent in binary form. Rendering always emits "p2p".
+      _ | name == "p2p" || name == "ipfs" ->
+        withAddr rest $ \addr remaining -> do
+          mh <- parsePeerIdAddr addr
+          Right (P2P mh, remaining)
       "dns" -> withAddr rest $ \addr remaining ->
         Right (DNS addr, remaining)
       "dns4" -> withAddr rest $ \addr remaining ->
@@ -207,9 +208,6 @@ textToProtocols input
       "noise" -> do
         more <- parseParts rest
         Right (NoiseProto : more)
-      "yamux" -> do
-        more <- parseParts rest
-        Right (YamuxProto : more)
       other -> Left $ "textToProtocols: unknown protocol " <> T.unpack other
 
     withAddr :: [Text] -> (Text -> [Text] -> Either String (Protocol, [Text])) -> Either String [Protocol]

--- a/src/LibP2P/Multiaddr/Protocol.hs
+++ b/src/LibP2P/Multiaddr/Protocol.hs
@@ -1,7 +1,7 @@
 -- | Protocol definitions for multiaddr.
 --
 -- Each protocol has a numeric code and an address format.
--- See: https://github.com/multiformats/multicodec/blob/master/table.csv
+-- See: https://github.com/multiformats/multiaddr/blob/master/protocols.csv
 module LibP2P.Multiaddr.Protocol
   ( Protocol (..)
   , protocolCode
@@ -32,7 +32,6 @@ data Protocol
   | P2PCircuit         -- ^ Circuit relay marker (no address)
   | WebTransport       -- ^ WebTransport (no address)
   | NoiseProto         -- ^ Noise protocol marker (no address)
-  | YamuxProto         -- ^ Yamux protocol marker (no address)
   deriving (Show, Eq)
 
 -- | Address size specification for a protocol.
@@ -49,7 +48,7 @@ protocolCode (IP6 _) = 41
 protocolCode (TCP _) = 6
 protocolCode (UDP _) = 273
 protocolCode (P2P _) = 421
-protocolCode QuicV1 = 460
+protocolCode QuicV1 = 461
 protocolCode WS = 477
 protocolCode WSS = 478
 protocolCode (DNS _) = 53
@@ -59,7 +58,6 @@ protocolCode (DNSAddr _) = 56
 protocolCode P2PCircuit = 290
 protocolCode WebTransport = 465
 protocolCode NoiseProto = 454
-protocolCode YamuxProto = 467
 
 -- | Get the human-readable name for a protocol.
 protocolName :: Protocol -> Text
@@ -78,7 +76,6 @@ protocolName (DNSAddr _) = "dnsaddr"
 protocolName P2PCircuit = "p2p-circuit"
 protocolName WebTransport = "webtransport"
 protocolName NoiseProto = "noise"
-protocolName YamuxProto = "yamux"
 
 -- | Get the address size specification for a protocol code.
 protocolAddressSize :: Word64 -> Maybe AddressSize
@@ -87,7 +84,7 @@ protocolAddressSize 41 = Just (Fixed 16)      -- ip6
 protocolAddressSize 6 = Just (Fixed 2)        -- tcp
 protocolAddressSize 273 = Just (Fixed 2)      -- udp
 protocolAddressSize 421 = Just VarIntPrefixed -- p2p
-protocolAddressSize 460 = Just NoAddress      -- quic-v1
+protocolAddressSize 461 = Just NoAddress      -- quic-v1
 protocolAddressSize 477 = Just NoAddress      -- ws
 protocolAddressSize 478 = Just NoAddress      -- wss
 protocolAddressSize 53 = Just VarIntPrefixed  -- dns
@@ -97,7 +94,6 @@ protocolAddressSize 56 = Just VarIntPrefixed  -- dnsaddr
 protocolAddressSize 290 = Just NoAddress      -- p2p-circuit
 protocolAddressSize 465 = Just NoAddress      -- webtransport
 protocolAddressSize 454 = Just NoAddress      -- noise
-protocolAddressSize 467 = Just NoAddress      -- yamux
 protocolAddressSize _ = Nothing
 
 -- | Map protocol code to name (for text parsing).
@@ -107,7 +103,7 @@ codeToProtocolName 41 = Just "ip6"
 codeToProtocolName 6 = Just "tcp"
 codeToProtocolName 273 = Just "udp"
 codeToProtocolName 421 = Just "p2p"
-codeToProtocolName 460 = Just "quic-v1"
+codeToProtocolName 461 = Just "quic-v1"
 codeToProtocolName 477 = Just "ws"
 codeToProtocolName 478 = Just "wss"
 codeToProtocolName 53 = Just "dns"
@@ -117,5 +113,4 @@ codeToProtocolName 56 = Just "dnsaddr"
 codeToProtocolName 290 = Just "p2p-circuit"
 codeToProtocolName 465 = Just "webtransport"
 codeToProtocolName 454 = Just "noise"
-codeToProtocolName 467 = Just "yamux"
 codeToProtocolName _ = Nothing

--- a/test/LibP2P/Multiaddr/MultiaddrSpec.hs
+++ b/test/LibP2P/Multiaddr/MultiaddrSpec.hs
@@ -1,7 +1,9 @@
 module LibP2P.Multiaddr.MultiaddrSpec (spec) where
 
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base58 as B58
 import Data.Text (Text)
+import qualified Data.Text.Encoding as TE
 import LibP2P.Core.Varint (encodeUvarint)
 import LibP2P.Crypto.PeerId (PeerId (..))
 import LibP2P.Multiaddr.Codec
@@ -19,9 +21,12 @@ spec = do
 
     it "encodes /ip4/198.51.100.0/udp/9090/quic-v1 to correct bytes" $ do
       let ps = [IP4 0xc6336400, UDP 9090, QuicV1]
-      -- 04 c6336400 9102 2382 cc03
+      -- 04 c6336400 9102 2382 cd03 (quic-v1 = 461 = varint cd 03)
       encodeProtocols ps
-        `shouldBe` BS.pack [0x04, 0xc6, 0x33, 0x64, 0x00, 0x91, 0x02, 0x23, 0x82, 0xcc, 0x03]
+        `shouldBe` BS.pack [0x04, 0xc6, 0x33, 0x64, 0x00, 0x91, 0x02, 0x23, 0x82, 0xcd, 0x03]
+
+    it "encodes quic-v1 as protocol code 461, not legacy quic 460" $
+      encodeProtocols [QuicV1] `shouldBe` encodeUvarint 461
 
     it "encodes zero-address protocols (ws, wss, p2p-circuit)" $ do
       let ps = [QuicV1, WS, P2PCircuit]
@@ -35,8 +40,14 @@ spec = do
       decodeProtocols bytes `shouldBe` Right [IP4 0x7f000001, TCP 4001]
 
     it "decodes /ip4/198.51.100.0/udp/9090/quic-v1 from bytes" $ do
-      let bytes = BS.pack [0x04, 0xc6, 0x33, 0x64, 0x00, 0x91, 0x02, 0x23, 0x82, 0xcc, 0x03]
+      let bytes = BS.pack [0x04, 0xc6, 0x33, 0x64, 0x00, 0x91, 0x02, 0x23, 0x82, 0xcd, 0x03]
       decodeProtocols bytes `shouldBe` Right [IP4 0xc6336400, UDP 9090, QuicV1]
+
+    it "does not decode legacy quic code 460 as quic-v1" $
+      decodeProtocols (encodeUvarint 460) `shouldNotBe` Right [QuicV1]
+
+    it "rejects unassigned code 467 (formerly used for yamux)" $
+      decodeProtocols (encodeUvarint 467) `shouldSatisfy` isLeft
 
     it "fails on empty input" $
       decodeProtocols BS.empty `shouldBe` Right []
@@ -85,6 +96,22 @@ spec = do
     it "parses /dns4/example.com/tcp/443/wss" $ do
       textToProtocols "/dns4/example.com/tcp/443/wss"
         `shouldBe` Right [DNS4 "example.com", TCP 443, WSS]
+
+    it "parses /ipfs/<peer-id> as the legacy alias of /p2p/<peer-id>" $ do
+      let mh = BS.pack $ [0x12, 0x20] <> replicate 32 0xAB
+      let b58 = TE.decodeUtf8 (B58.encode mh)
+      textToProtocols ("/ipfs/" <> b58) `shouldBe` Right [P2P mh]
+      textToProtocols ("/ipfs/" <> b58) `shouldBe` textToProtocols ("/p2p/" <> b58)
+
+    it "renders /ipfs input back as /p2p" $ do
+      let mh = BS.pack $ [0x12, 0x20] <> replicate 32 0xAB
+      let b58 = TE.decodeUtf8 (B58.encode mh)
+      case textToProtocols ("/ipfs/" <> b58) of
+        Right ps -> protocolsToText ps `shouldBe` ("/p2p/" <> b58)
+        Left err -> expectationFailure err
+
+    it "fails on /yamux (not a registered multiaddr protocol)" $
+      textToProtocols "/yamux" `shouldSatisfy` isLeft
 
     it "fails on invalid protocol name" $
       textToProtocols "/invalid/foo" `shouldSatisfy` isLeft


### PR DESCRIPTION
## Summary

Aligns multiaddr protocol codes with [multiformats/multiaddr protocols.csv](https://github.com/multiformats/multiaddr/blob/master/protocols.csv):

- **quic-v1 = 461** (was 460, the legacy draft-29 `quic` code). We previously serialized `/quic-v1` as `quic` and rejected genuine inbound 461 components — interop-breaking for any real bootstrap address.
- **`YamuxProto` removed.** Code 467 is unassigned, and yamux has no entry in protocols.csv or the multicodec table (0x0200 is `json`/ipld). Muxer selection is negotiated via multistream-select / Noise early data, not a multiaddr component, so the constructor is removed rather than renumbered.
- **`/ipfs/<peer-id>` parses as the legacy alias of `/p2p/<peer-id>`** (both code 421, per the addressing spec). Rendering still emits `/p2p`.

## Testing

- New tests: quic-v1 encodes as varint 461 (byte-exact), legacy 460 no longer decodes as quic-v1, code 467 and `/yamux` are rejected, `/ipfs/Qm...` parses equivalently to `/p2p/Qm...` and renders back as `/p2p`.
- Updated byte-level fixtures asserting the old 460 encoding.
- Full suite: 635 examples, 0 failures (GHC 9.10.1).

Item 4 of the issue (/p2p-suffixed addresses not dialable) and the smaller items (missing protocols, decapsulate, strict text parsing) are left for follow-up issues, as they are separate behaviors outside the protocol-code table.

Closes #158