### PR TITLE
fix(autonat): refuse dial-back when observed IP is unknown; support IPv6 matching

### DIFF
--- a/src/LibP2P/NAT/AutoNAT.hs
+++ b/src/LibP2P/NAT/AutoNAT.hs
@@ -5,11 +5,15 @@
 --
 -- Security rules (from specs/autonat):
 --   - Server MUST NOT dial addresses unless they match the requester's observed IP
+--     (both IPv4 and IPv6; if the observed IP cannot be determined, refuse)
 --   - Server MUST NOT accept dial requests over relayed connections
+--   - Server rejects requests whose claimed peer id differs from the
+--     authenticated peer id of the connection
 module LibP2P.NAT.AutoNAT
   ( -- * Types
     NATStatus (..)
   , AutoNATConfig (..)
+  , maxDialBackAddrs
     -- * Server
   , handleAutoNAT
     -- * Client
@@ -20,7 +24,6 @@ module LibP2P.NAT.AutoNAT
 
 import Data.ByteString (ByteString)
 import qualified Data.Text as T
-import Data.Word (Word32)
 import LibP2P.NAT.AutoNAT.Message
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
 import LibP2P.Multiaddr (Multiaddr (..), toBytes, fromBytes)
@@ -53,20 +56,36 @@ handleAutoNAT config stream remotePeerId remoteObservedAddr = do
       resp <- processDialRequest config msg remotePeerId remoteObservedAddr
       writeAutoNATMessage stream resp
 
+-- | Maximum number of addresses dialled back per request.
+-- Bounds the work a single request can trigger (go-libp2p applies a
+-- similar per-request address cap).
+maxDialBackAddrs :: Int
+maxDialBackAddrs = 16
+
 -- | Process a DIAL request and produce a response.
 processDialRequest :: AutoNATConfig -> AutoNATMessage -> PeerId -> Multiaddr -> IO AutoNATMessage
-processDialRequest config msg _remotePeerId remoteObservedAddr
+processDialRequest config msg remotePeerId remoteObservedAddr
   -- Reject requests from relayed connections
   | isRelayedAddr remoteObservedAddr = pure $ mkDialResponse EDialRefused (Just "relayed connection") Nothing
   | otherwise = case anMsgDial msg of
       Nothing -> pure $ mkDialResponse EBadRequest (Just "missing dial field") Nothing
       Just dial -> case anDialPeer dial of
         Nothing -> pure $ mkDialResponse EBadRequest (Just "missing peer info") Nothing
-        Just peerInfo -> do
+        Just peerInfo
+          -- The dial-back target identity must be the authenticated peer,
+          -- not whatever the message claims (go-libp2p behaves the same)
+          | PeerId (anPeerId peerInfo) /= remotePeerId ->
+              pure $ mkDialResponse EBadRequest (Just "peer id mismatch") Nothing
+          | otherwise -> do
           let requestedAddrs = mapMaybe' fromBytes (anAddrs peerInfo)
-              filteredAddrs = filterByObservedIP remoteObservedAddr requestedAddrs
-          if null filteredAddrs
+              filteredAddrs = take maxDialBackAddrs
+                                (filterByObservedIP remoteObservedAddr requestedAddrs)
+          if null requestedAddrs
             then pure $ mkDialResponse EBadRequest (Just "no valid addresses") Nothing
+            else if null filteredAddrs
+            -- Amplification guard: nothing matches the observed IP → refuse,
+            -- never fall back to dialling unverified addresses
+            then pure $ mkDialResponse EDialRefused (Just "no dialable addresses") Nothing
             else do
               let peerId = PeerId (anPeerId peerInfo)
               dialResult <- natDialBack config peerId filteredAddrs
@@ -139,26 +158,26 @@ isRelayedAddr (Multiaddr ps) = any isCircuit ps
     isCircuit P2PCircuit = True
     isCircuit _          = False
 
--- | Extract IP address (as Word32 for IPv4) from a multiaddr.
-extractIP4 :: Multiaddr -> Maybe Word32
-extractIP4 (Multiaddr ps) = go ps
+-- | Extract the first IP component (IPv4 or IPv6) from a multiaddr.
+extractIP :: Multiaddr -> Maybe Protocol
+extractIP (Multiaddr ps) = go ps
   where
     go [] = Nothing
-    go (IP4 addr : _) = Just addr
+    go (p@(IP4 _) : _) = Just p
+    go (p@(IP6 _) : _) = Just p
     go (_ : rest) = go rest
 
--- | Filter addresses to only those matching the observed IP.
+-- | Filter addresses to only those whose IP equals the observed IP.
+--
+-- Spec (autonat-v1): the server MUST NOT dial any multiaddress unless it is
+-- based on the IP address the requesting node is observed as. If the observed
+-- IP cannot be determined, no address is dialable — return the empty list so
+-- the caller refuses the request instead of amplifying it.
 filterByObservedIP :: Multiaddr -> [Multiaddr] -> [Multiaddr]
 filterByObservedIP observed addrs =
-  case extractIP4 observed of
-    Nothing -> addrs  -- can't determine IP, pass all through
-    Just obsIP -> filter (matchesIP obsIP) addrs
-  where
-    matchesIP :: Word32 -> Multiaddr -> Bool
-    matchesIP obsIP addr =
-      case extractIP4 addr of
-        Just ip -> ip == obsIP
-        Nothing -> False  -- non-IP4 addresses are filtered out
+  case extractIP observed of
+    Nothing -> []
+    Just obsIP -> filter (\addr -> extractIP addr == Just obsIP) addrs
 
 -- | mapMaybe for Either (keeping only Right values).
 mapMaybe' :: (a -> Either e b) -> [a] -> [b]

--- a/test/LibP2P/NAT/AutoNAT/AutoNATSpec.hs
+++ b/test/LibP2P/NAT/AutoNAT/AutoNATSpec.hs
@@ -3,6 +3,7 @@ module LibP2P.NAT.AutoNAT.AutoNATSpec (spec) where
 import Test.Hspec
 
 import qualified Data.ByteString as BS
+import qualified Data.Text as T
 import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM (newTQueueIO, atomically, writeTQueue, readTQueue, TQueue)
 import Data.Word (Word8)
@@ -56,6 +57,43 @@ relayedAddr = Multiaddr [IP4 0xCB007101, TCP 4001, P2P (BS.pack [1,2,3]), P2PCir
 remoteObservedAddr :: Multiaddr
 remoteObservedAddr = Multiaddr [IP4 0xCB007105, TCP 12345]
 
+-- | IPv6 host 2001:db8::1 (16 bytes).
+ip6HostA :: BS.ByteString
+ip6HostA = BS.pack [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+
+-- | IPv6 host 2001:db8::2 (16 bytes).
+ip6HostB :: BS.ByteString
+ip6HostB = BS.pack [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]
+
+-- | Remote observed IPv6 address: /ip6/2001:db8::1/tcp/12345
+ipv6ObservedAddr :: Multiaddr
+ipv6ObservedAddr = Multiaddr [IP6 ip6HostA, TCP 12345]
+
+-- | Candidate matching the observed IPv6 host: /ip6/2001:db8::1/tcp/4001
+ipv6MatchAddr :: Multiaddr
+ipv6MatchAddr = Multiaddr [IP6 ip6HostA, TCP 4001]
+
+-- | Candidate with a different IPv6 host: /ip6/2001:db8::2/tcp/4001
+ipv6OtherAddr :: Multiaddr
+ipv6OtherAddr = Multiaddr [IP6 ip6HostB, TCP 4001]
+
+-- | Observed address without any IP component: /dns/example.com/tcp/4001
+dnsObservedAddr :: Multiaddr
+dnsObservedAddr = Multiaddr [DNS (T.pack "example.com"), TCP 4001]
+
+-- | Build a DIAL message claiming the given peer id and addresses.
+mkDialMsg :: PeerId -> [Multiaddr] -> AutoNATMessage
+mkDialMsg (PeerId pidBytes) addrs = AutoNATMessage
+  { anMsgType = Just DIAL
+  , anMsgDial = Just AutoNATDial
+      { anDialPeer = Just AutoNATPeerInfo
+          { anPeerId = pidBytes
+          , anAddrs = map toBytes addrs
+          }
+      }
+  , anMsgDialResponse = Nothing
+  }
+
 spec :: Spec
 spec = do
   describe "AutoNAT handler (server side)" $ do
@@ -71,7 +109,7 @@ spec = do
             { anMsgType = Just DIAL
             , anMsgDial = Just AutoNATDial
                 { anDialPeer = Just AutoNATPeerInfo
-                    { anPeerId = let PeerId bs = testPeerId in bs
+                    { anPeerId = let PeerId bs = remotePeerId in bs
                     , anAddrs = [addrBytes]
                     }
                 }
@@ -101,7 +139,7 @@ spec = do
             { anMsgType = Just DIAL
             , anMsgDial = Just AutoNATDial
                 { anDialPeer = Just AutoNATPeerInfo
-                    { anPeerId = let PeerId bs = testPeerId in bs
+                    { anPeerId = let PeerId bs = remotePeerId in bs
                     , anAddrs = [addrBytes]
                     }
                 }
@@ -128,7 +166,7 @@ spec = do
             { anMsgType = Just DIAL
             , anMsgDial = Just AutoNATDial
                 { anDialPeer = Just AutoNATPeerInfo
-                    { anPeerId = let PeerId bs = testPeerId in bs
+                    { anPeerId = let PeerId bs = remotePeerId in bs
                     , anAddrs = []
                     }
                 }
@@ -182,7 +220,7 @@ spec = do
             { anMsgType = Just DIAL
             , anMsgDial = Just AutoNATDial
                 { anDialPeer = Just AutoNATPeerInfo
-                    { anPeerId = let PeerId bs = testPeerId in bs
+                    { anPeerId = let PeerId bs = remotePeerId in bs
                     , anAddrs = [matchAddr, nonMatchAddr]
                     }
                 }
@@ -200,6 +238,115 @@ spec = do
           addrs `shouldBe` [publicAddr]
         _ -> expectationFailure $ "Expected 1 dial-back call, got " ++ show (length dialed)
 
+    it "dials back only candidates matching the observed IPv6 host" $ do
+      dialedRef <- newIORef ([] :: [[Multiaddr]])
+      (clientStream, serverStream) <- mkStreamPair
+      let config = AutoNATConfig
+            { natThreshold = 3
+            , natDialBack = \_pid addrs -> do
+                modifyIORef' dialedRef (addrs :)
+                pure (Right ())
+            }
+          -- Same IPv6 host, different IPv6 host, and an IPv4 address
+          dialMsg = mkDialMsg remotePeerId [ipv6MatchAddr, ipv6OtherAddr, publicAddr]
+      writeAutoNATMessage clientStream dialMsg
+      handleAutoNAT config serverStream remotePeerId ipv6ObservedAddr
+      _ <- readAutoNATMessage clientStream maxAutoNATMessageSize
+      dialed <- readIORef dialedRef
+      case dialed of
+        [addrs] -> addrs `shouldBe` [ipv6MatchAddr]
+        _ -> expectationFailure $ "Expected 1 dial-back call, got " ++ show (length dialed)
+
+    it "responds E_DIAL_REFUSED when no candidate matches the observed IP" $ do
+      dialedRef <- newIORef ([] :: [[Multiaddr]])
+      (clientStream, serverStream) <- mkStreamPair
+      let config = AutoNATConfig
+            { natThreshold = 3
+            , natDialBack = \_pid addrs -> do
+                modifyIORef' dialedRef (addrs :)
+                pure (Right ())
+            }
+          -- Observed over IPv6, but only IPv4 candidates are offered
+          dialMsg = mkDialMsg remotePeerId [publicAddr, privateAddr]
+      writeAutoNATMessage clientStream dialMsg
+      handleAutoNAT config serverStream remotePeerId ipv6ObservedAddr
+      result <- readAutoNATMessage clientStream maxAutoNATMessageSize
+      case result of
+        Right resp ->
+          case anMsgDialResponse resp of
+            Just dr -> anRespStatus dr `shouldBe` Just EDialRefused
+            Nothing -> expectationFailure "Expected DialResponse"
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      dialed <- readIORef dialedRef
+      dialed `shouldBe` []
+
+    it "responds E_DIAL_REFUSED when the observed address has no IP component" $ do
+      dialedRef <- newIORef ([] :: [[Multiaddr]])
+      (clientStream, serverStream) <- mkStreamPair
+      let config = AutoNATConfig
+            { natThreshold = 3
+            , natDialBack = \_pid addrs -> do
+                modifyIORef' dialedRef (addrs :)
+                pure (Right ())
+            }
+          dialMsg = mkDialMsg remotePeerId [publicAddr, ipv6MatchAddr]
+      writeAutoNATMessage clientStream dialMsg
+      -- Observed address carries no IP: the filter must drop everything,
+      -- never fall through to dialling all requested addresses
+      handleAutoNAT config serverStream remotePeerId dnsObservedAddr
+      result <- readAutoNATMessage clientStream maxAutoNATMessageSize
+      case result of
+        Right resp ->
+          case anMsgDialResponse resp of
+            Just dr -> anRespStatus dr `shouldBe` Just EDialRefused
+            Nothing -> expectationFailure "Expected DialResponse"
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      dialed <- readIORef dialedRef
+      dialed `shouldBe` []
+
+    it "responds E_BAD_REQUEST when the claimed peer id differs from the connected peer" $ do
+      dialedRef <- newIORef ([] :: [[Multiaddr]])
+      (clientStream, serverStream) <- mkStreamPair
+      let config = AutoNATConfig
+            { natThreshold = 3
+            , natDialBack = \_pid addrs -> do
+                modifyIORef' dialedRef (addrs :)
+                pure (Right ())
+            }
+          -- Message claims testPeerId, but the connection is authenticated as remotePeerId
+          dialMsg = mkDialMsg testPeerId [publicAddr]
+      writeAutoNATMessage clientStream dialMsg
+      handleAutoNAT config serverStream remotePeerId remoteObservedAddr
+      result <- readAutoNATMessage clientStream maxAutoNATMessageSize
+      case result of
+        Right resp ->
+          case anMsgDialResponse resp of
+            Just dr -> anRespStatus dr `shouldBe` Just EBadRequest
+            Nothing -> expectationFailure "Expected DialResponse"
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      dialed <- readIORef dialedRef
+      dialed `shouldBe` []
+
+    it "caps the number of dial-back addresses per request" $ do
+      dialedRef <- newIORef ([] :: [[Multiaddr]])
+      (clientStream, serverStream) <- mkStreamPair
+      let config = AutoNATConfig
+            { natThreshold = 3
+            , natDialBack = \_pid addrs -> do
+                modifyIORef' dialedRef (addrs :)
+                pure (Right ())
+            }
+          -- Many same-IP addresses on different ports; all pass the IP filter
+          manyAddrs = [Multiaddr [IP4 0xCB007105, TCP p] | p <- [4001 .. 4064]]
+          dialMsg = mkDialMsg remotePeerId manyAddrs
+      writeAutoNATMessage clientStream dialMsg
+      handleAutoNAT config serverStream remotePeerId remoteObservedAddr
+      _ <- readAutoNATMessage clientStream maxAutoNATMessageSize
+      dialed <- readIORef dialedRef
+      case dialed of
+        [addrs] -> length addrs `shouldBe` maxDialBackAddrs
+        _ -> expectationFailure $ "Expected 1 dial-back call, got " ++ show (length dialed)
+
     it "rejects requests from relayed connections" $ do
       (clientStream, serverStream) <- mkStreamPair
       let config = AutoNATConfig
@@ -211,7 +358,7 @@ spec = do
             { anMsgType = Just DIAL
             , anMsgDial = Just AutoNATDial
                 { anDialPeer = Just AutoNATPeerInfo
-                    { anPeerId = let PeerId bs = testPeerId in bs
+                    { anPeerId = let PeerId bs = remotePeerId in bs
                     , anAddrs = [addrBytes]
                     }
                 }


### PR DESCRIPTION
## Summary

The AutoNAT dial-back filter only understood IPv4. When the observed address of the requesting peer was IPv6 or DNS, `filterByObservedIP` fell through to passing every requested address unchanged — the exact DDoS amplification that autonat-v1 forbids with a MUST ("implementations MUST NOT dial any multiaddress unless it is based on the IP address the requesting node is observed as"). The IPv4-only match also rejected legitimate IPv6 dial-back requests.

## Changes

- `filterByObservedIP` returns `[]` when the observed IP cannot be extracted; the handler responds `E_DIAL_REFUSED` ("no dialable addresses") instead of dialling everything
- IP extraction now covers `IP6` alongside `IP4`, so same-host IPv6 candidates pass the filter
- `E_BAD_REQUEST` when the claimed `PeerInfo.id` differs from the authenticated remote peer id (matches go-libp2p)
- Dialled addresses capped at `maxDialBackAddrs` (16) per request

## Tests

TDD: new failing specs first, then the fix. New cases: IPv6 observed address matches only same-host candidates; unmatched candidates dropped; zero survivors → `E_DIAL_REFUSED` with no dial-back call; DNS-only observed address refused; peer-id mismatch rejected; per-request address cap. Full suite: 634 examples, 0 failures (GHC 9.10.1).

Closes #150