### PR TITLE
fix: enforce varint 9-byte/63-bit limit, minimal encoding, and mss message cap

### DIFF
--- a/src/LibP2P/Core/Varint.hs
+++ b/src/LibP2P/Core/Varint.hs
@@ -2,9 +2,15 @@
 --
 -- Used throughout libp2p for length-prefixed framing, protocol codes,
 -- and multiaddr/multihash encoding.
+--
+-- Follows the multiformats unsigned-varint spec
+-- (https://github.com/multiformats/unsigned-varint): varints are
+-- restricted to a maximum of 9 bytes (63 bits), and non-minimal
+-- (zero-padded) encodings are rejected on decode.
 module LibP2P.Core.Varint
   ( encodeUvarint
   , decodeUvarint
+  , maxVarintBytes
   ) where
 
 import Data.Bits (Bits (..))
@@ -14,23 +20,36 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as BL
 import Data.Word (Word64)
 
--- | Maximum number of bytes for a valid unsigned varint (ceil(64/7) = 10).
+-- | Maximum number of bytes for a valid unsigned varint.
+-- The spec mandates: "Implementations MUST restrict the size of the
+-- varint to a max of 9 bytes (63 bits)."
 maxVarintBytes :: Int
-maxVarintBytes = 10
+maxVarintBytes = 9
+
+-- | Largest value representable in a spec-compliant varint (2^63 - 1).
+maxVarintValue :: Word64
+maxVarintValue = (1 `shiftL` 63) - 1
 
 -- | Encode a Word64 as an unsigned LEB128 varint.
+-- Calls 'error' for values >= 2^63, which the spec makes unrepresentable
+-- (go-varint's PutUvarint panics identically).
 encodeUvarint :: Word64 -> ByteString
-encodeUvarint = BL.toStrict . Builder.toLazyByteString . go
+encodeUvarint n
+  | n > maxVarintValue =
+      error "encodeUvarint: value exceeds 63 bits (unsigned-varint spec maximum)"
+  | otherwise = BL.toStrict (Builder.toLazyByteString (go n))
   where
     go :: Word64 -> Builder.Builder
-    go n
-      | n < 0x80 = Builder.word8 (fromIntegral n)
+    go m
+      | m < 0x80 = Builder.word8 (fromIntegral m)
       | otherwise =
-          Builder.word8 (fromIntegral (n .&. 0x7f) .|. 0x80)
-            <> go (n `shiftR` 7)
+          Builder.word8 (fromIntegral (m .&. 0x7f) .|. 0x80)
+            <> go (m `shiftR` 7)
 
 -- | Decode an unsigned LEB128 varint from a ByteString.
 -- Returns the decoded value and remaining bytes, or an error message.
+-- Rejects varints longer than 9 bytes and non-minimal encodings
+-- (a multi-byte varint whose final byte is 0x00).
 decodeUvarint :: ByteString -> Either String (Word64, ByteString)
 decodeUvarint bs
   | BS.null bs = Left "decodeUvarint: empty input"
@@ -39,7 +58,7 @@ decodeUvarint bs
     go :: ByteString -> Int -> Word64 -> Either String (Word64, ByteString)
     go input bitShift acc
       | bitShift >= maxVarintBytes * 7 =
-          Left "decodeUvarint: varint too long (exceeds 10 bytes)"
+          Left "decodeUvarint: varint too long (exceeds 9 bytes / 63 bits)"
       | BS.null input =
           Left "decodeUvarint: unexpected end of input"
       | otherwise =
@@ -48,5 +67,11 @@ decodeUvarint bs
               val = fromIntegral (byte .&. 0x7f) :: Word64
               acc' = acc .|. (val `shiftL` bitShift)
            in if byte .&. 0x80 == 0
-                then Right (acc', rest)
+                then
+                  -- Spec: leading zeros "must be rejected when decoding.
+                  -- The only number that can end in a 0x00 is 0" — and 0
+                  -- is the single-byte encoding 0x00 (bitShift == 0).
+                  if byte == 0x00 && bitShift > 0
+                    then Left "decodeUvarint: non-minimal encoding (trailing zero byte)"
+                    else Right (acc', rest)
                 else go rest (bitShift + 7) acc'

--- a/src/LibP2P/MultistreamSelect/Negotiation.hs
+++ b/src/LibP2P/MultistreamSelect/Negotiation.hs
@@ -15,12 +15,20 @@ import Control.Concurrent.STM
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Text (Text)
-import Data.Word (Word8)
-import LibP2P.Core.Varint (decodeUvarint)
+import Data.Word (Word64, Word8)
+import LibP2P.Core.Varint (decodeUvarint, maxVarintBytes)
 import LibP2P.MultistreamSelect.Wire
 
 -- | A protocol identifier (e.g. "/noise", "/yamux/1.0.0").
 type ProtocolId = Text
+
+-- | Maximum accepted multistream-select message length in bytes.
+-- Negotiation runs on raw, unauthenticated connections before any
+-- handshake, so the declared length must be capped before allocating
+-- or reading the payload. go-multistream rejects messages over 1024
+-- bytes ("incoming message was too large"); protocol ids are far shorter.
+maxMessageLength :: Word64
+maxMessageLength = 1024
 
 -- | Result of a negotiation attempt.
 data NegotiationResult
@@ -54,28 +62,41 @@ readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]
 
 -- | Read a complete multistream-select message from a stream.
 -- Reads varint length byte-by-byte, then reads the full payload.
+-- The declared length is validated against 'maxMessageLength' before
+-- any payload byte is read.
 readMessage :: StreamIO -> IO (Either String Text)
 readMessage stream = do
-  varintBytes <- readVarint stream
-  case decodeUvarint varintBytes of
+  varintResult <- readVarint stream
+  case varintResult of
     Left err -> pure (Left err)
-    Right (len, _) -> do
-      let payloadLen = fromIntegral len :: Int
-      payload <- readExact stream payloadLen
-      case decodeMessage (varintBytes <> payload) of
+    Right varintBytes ->
+      case decodeUvarint varintBytes of
         Left err -> pure (Left err)
-        Right (msg, _) -> pure (Right msg)
+        Right (len, _)
+          | len > maxMessageLength ->
+              pure (Left "readMessage: incoming message too large (max 1024 bytes)")
+          | otherwise -> do
+              payload <- readExact stream (fromIntegral len)
+              case decodeMessage (varintBytes <> payload) of
+                Left err -> pure (Left err)
+                Right (msg, _) -> pure (Right msg)
 
 -- | Read a varint one byte at a time from the stream.
-readVarint :: StreamIO -> IO ByteString
-readVarint stream = go BS.empty
+-- The read loop is bounded at 'maxVarintBytes' (9 bytes per the
+-- unsigned-varint spec) so a peer streaming continuation bytes (0x80)
+-- cannot keep us reading and accumulating forever.
+readVarint :: StreamIO -> IO (Either String ByteString)
+readVarint stream = go 0 []
   where
-    go acc = do
-      b <- streamReadByte stream
-      let acc' = acc <> BS.singleton b
-      if b < 0x80
-        then pure acc'
-        else go acc'
+    go :: Int -> [Word8] -> IO (Either String ByteString)
+    go n acc
+      | n >= maxVarintBytes =
+          pure (Left "readVarint: varint too long (exceeds 9 bytes)")
+      | otherwise = do
+          b <- streamReadByte stream
+          if b < 0x80
+            then pure (Right (BS.pack (reverse (b : acc))))
+            else go (n + 1) (b : acc)
 
 -- | Write a multistream-select message to a stream.
 writeMessage :: StreamIO -> Text -> IO ()

--- a/test/LibP2P/Core/VarintSpec.hs
+++ b/test/LibP2P/Core/VarintSpec.hs
@@ -1,5 +1,6 @@
 module LibP2P.Core.VarintSpec (spec) where
 
+import Control.Exception (evaluate)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Word (Word64)
@@ -28,9 +29,14 @@ spec = do
     it "encodes 421 as 0xa5 0x03 (p2p protocol code)" $
       encodeUvarint 421 `shouldBe` BS.pack [0xa5, 0x03]
 
-    it "encodes maxBound (2^64-1)" $
-      -- 2^64-1 requires 10 bytes in LEB128
-      BS.length (encodeUvarint maxBound) `shouldBe` 10
+    -- multiformats unsigned-varint spec: max 9 bytes / 63 bits.
+    -- 2^63-1 is the largest encodable value and takes exactly 9 bytes.
+    it "encodes 2^63-1 (spec maximum) as 9 bytes" $
+      encodeUvarint (2 ^ (63 :: Int) - 1)
+        `shouldBe` BS.pack (replicate 8 0xff ++ [0x7f])
+
+    it "rejects values >= 2^63 (would need a 10-byte encoding)" $
+      evaluate (encodeUvarint maxBound) `shouldThrow` anyErrorCall
 
   describe "decodeUvarint" $ do
     it "decodes 0x00 as 0" $
@@ -58,14 +64,35 @@ spec = do
     it "fails on unterminated varint (all continuation bits)" $
       decodeUvarint (BS.pack [0x80, 0x80]) `shouldSatisfy` isLeft
 
-    it "fails on overlong varint (>10 bytes)" $
-      let overlong = BS.pack (replicate 11 0x80)
-       in decodeUvarint overlong `shouldSatisfy` isLeft
+    -- multiformats unsigned-varint spec: "Implementations MUST restrict
+    -- the size of the varint to a max of 9 bytes (63 bits)."
+    it "fails on 10-byte varint (spec max is 9 bytes / 63 bits)" $
+      let tenBytes = BS.pack (replicate 9 0x80 ++ [0x01])
+       in decodeUvarint tenBytes `shouldSatisfy` isLeft
+
+    it "accepts a 9-byte varint at the 63-bit maximum" $
+      decodeUvarint (BS.pack (replicate 8 0xff ++ [0x7f]))
+        `shouldBe` Right (2 ^ (63 :: Int) - 1, BS.empty)
+
+    -- multiformats unsigned-varint spec: "Leading zeros must be trimmed
+    -- when encoding and must be rejected when decoding." The only number
+    -- that can end in a 0x00 byte is 0.
+    it "rejects non-minimal encoding 0x81 0x00 (padded 1)" $
+      decodeUvarint (BS.pack [0x81, 0x00]) `shouldSatisfy` isLeft
+
+    it "rejects non-minimal encoding 0x80 0x00 (padded 0)" $
+      decodeUvarint (BS.pack [0x80, 0x00]) `shouldSatisfy` isLeft
+
+    it "rejects non-minimal encoding 0xff 0xff 0x00" $
+      decodeUvarint (BS.pack [0xff, 0xff, 0x00]) `shouldSatisfy` isLeft
 
   describe "round-trip property" $ do
-    it "decode(encode(x)) == x for all Word64" $
-      property $ \(w :: Word64) ->
-        decodeUvarint (encodeUvarint w) === Right (w, BS.empty)
+    -- Restricted to 63-bit values: the unsigned-varint spec caps varints
+    -- at 9 bytes (63 bits), so values >= 2^63 are not encodable.
+    it "decode(encode(x)) == x for all 63-bit values" $
+      property $
+        forAll (choose (0, 2 ^ (63 :: Int) - 1)) $ \(w :: Word64) ->
+          decodeUvarint (encodeUvarint w) === Right (w, BS.empty)
 
 -- | Helper to check if an Either is Left.
 isLeft :: Either a b -> Bool

--- a/test/LibP2P/MultistreamSelect/NegotiationSpec.hs
+++ b/test/LibP2P/MultistreamSelect/NegotiationSpec.hs
@@ -98,6 +98,34 @@ spec = do
           framed = BS.pack [0x02] <> truncated
       decodeMessage framed `shouldSatisfy` isLeft
 
+  describe "Negotiation - pre-handshake read limits" $ do
+    -- go-multistream rejects messages over 1024 bytes ("incoming message
+    -- was too large"). Without this cap an unauthenticated peer can declare
+    -- a huge length and make us allocate/read without bound.
+    it "rejects an oversized declared message length before reading the payload" $ do
+      (streamA, streamB) <- mkMemoryStreamPair
+      -- Declare a (2^32 - 1)-byte message; only the varint prefix is sent.
+      -- The responder must reject the length instead of blocking to read 4 GiB.
+      streamWrite streamA (BS.pack [0xff, 0xff, 0xff, 0xff, 0x0f])
+      result <- timeout 1000000 (negotiateResponder streamB ["/noise"])
+      result `shouldBe` Just NoProtocol
+
+    it "rejects a message length just above the 1024-byte cap" $ do
+      (streamA, streamB) <- mkMemoryStreamPair
+      -- varint(1025) = 0x81 0x08; no payload follows
+      streamWrite streamA (BS.pack [0x81, 0x08])
+      result <- timeout 1000000 (negotiateResponder streamB ["/noise"])
+      result `shouldBe` Just NoProtocol
+
+    -- The varint read loop itself must be bounded: the unsigned-varint spec
+    -- caps varints at 9 bytes, so a stream of continuation bytes (0x80) must
+    -- be aborted instead of being accumulated indefinitely.
+    it "aborts an unterminated varint prefix after the 9-byte spec limit" $ do
+      (streamA, streamB) <- mkMemoryStreamPair
+      streamWrite streamA (BS.pack (replicate 64 0x80))
+      result <- timeout 1000000 (negotiateResponder streamB ["/noise"])
+      result `shouldBe` Just NoProtocol
+
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True
 isLeft _ = False


### PR DESCRIPTION
## Summary

Fixes two related wire-parsing limit bugs on the pre-handshake path.

### Varint (#159)

Per the [multiformats unsigned-varint spec](https://github.com/multiformats/unsigned-varint):

- `decodeUvarint` now rejects varints longer than 9 bytes / 63 bits (was 10 bytes / 64 bits).
- Non-minimal encodings (multi-byte varint ending in `0x00`, e.g. `0x81 0x00`) are rejected, closing the peer-identity aliasing where two byte-distinct multihash encodings of the same peer produced distinct `PeerId` values.
- `encodeUvarint` errors on values >= 2^63 instead of emitting a 10-byte form (mirrors go-varint's overflow behaviour).

### multistream-select (#160)

- `readMessage` caps the declared message length at 1024 bytes (matching go-multistream's "incoming message was too large") before reading the payload, so an unauthenticated peer can no longer declare a 4 GiB message on a raw inbound connection and drip-feed bytes to grow memory without bound.
- `readVarint` bounds its byte-at-a-time loop at the spec's 9-byte varint maximum, so a peer streaming `0x80` continuation bytes forever can no longer keep the read loop alive.

## Tests

TDD: 8 new failing tests written first, then the fix. Existing tests asserting the old 10-byte/64-bit behaviour updated with spec references. Full suite: 637 examples, 0 failures (GHC 9.10.1).

Closes #159
Closes #160