### PR TITLE
fix(relay): enforce reservation expiry, circuit count and duration limits

### DIFF
--- a/src/LibP2P/NAT/Relay.hs
+++ b/src/LibP2P/NAT/Relay.hs
@@ -28,8 +28,10 @@ module LibP2P.NAT.Relay
 
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import Control.Concurrent.Async (race)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (race_)
 import Control.Concurrent.STM
+import Control.Exception (finally)
 import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
 import qualified Data.Map.Strict as Map
 import Data.Time.Clock.POSIX (getPOSIXTime)
@@ -66,16 +68,17 @@ data ActiveReservation = ActiveReservation
 
 -- | Mutable relay server state.
 data RelayState = RelayState
-  { rsConfig       :: !RelayConfig
-  , rsReservations :: !(TVar (Map.Map PeerId ActiveReservation))
-  , rsCircuitCount :: !(TVar Int)
+  { rsConfig        :: !RelayConfig
+  , rsReservations  :: !(TVar (Map.Map PeerId ActiveReservation))
+  , rsCircuitCounts :: !(TVar (Map.Map PeerId Int))
+    -- ^ Active relayed circuits per peer (both initiator and target sides)
   }
 
 -- | Create new relay state from configuration.
 newRelayState :: RelayConfig -> IO RelayState
 newRelayState config = RelayState config
   <$> newTVarIO Map.empty
-  <*> newTVarIO 0
+  <*> newTVarIO Map.empty
 
 -- | Handle a RESERVE request from a peer.
 handleReserve :: RelayState -> StreamIO -> PeerId -> IO ()
@@ -115,16 +118,59 @@ handleReserve state stream peerId = do
 -- | Handle a CONNECT request from a peer.
 -- The openStopStream callback is used to open a stop stream to the target.
 handleConnect :: RelayState -> StreamIO -> PeerId -> HopMessage -> (PeerId -> IO (Maybe StreamIO)) -> IO ()
-handleConnect state stream _sourcePeerId msg openStopStream = do
+handleConnect state stream sourcePeerId msg openStopStream = do
   case hopPeer msg of
     Nothing -> sendHopStatus stream MalformedMessage
     Just peer -> do
       let targetId = PeerId (rpId peer)
-      -- Check target has a reservation
-      reservations <- readTVarIO (rsReservations state)
-      case Map.lookup targetId reservations of
-        Nothing -> sendHopStatus stream NoReservation
-        Just _rsv -> do
+      now <- getPOSIXTime
+      let nowSecs = floor now :: Word64
+      -- Check target has an unexpired reservation; drop it if it has expired.
+      hasReservation <- atomically $ do
+        reservations <- readTVar (rsReservations state)
+        case Map.lookup targetId reservations of
+          Nothing -> pure False
+          Just rsv
+            | arExpiration rsv <= nowSecs -> do
+                modifyTVar' (rsReservations state) (Map.delete targetId)
+                pure False
+            | otherwise -> pure True
+      if not hasReservation
+        then sendHopStatus stream NoReservation
+        else do
+          -- Acquire a circuit slot for both peers, enforcing the advertised
+          -- per-peer circuit limit atomically with the check.
+          acquired <- atomically $ acquireCircuitSlots state sourcePeerId targetId
+          if not acquired
+            then sendHopStatus stream ResourceLimitExceeded
+            else establishCircuit state stream sourcePeerId targetId openStopStream
+                   `finally` atomically (releaseCircuitSlots state sourcePeerId targetId)
+
+-- | Reserve one circuit slot for each of the two peers if neither is at the
+-- configured per-peer limit. Returns False without modifying state otherwise.
+acquireCircuitSlots :: RelayState -> PeerId -> PeerId -> STM Bool
+acquireCircuitSlots state sourceId targetId = do
+  counts <- readTVar (rsCircuitCounts state)
+  let limit = rcMaxCircuits (rsConfig state)
+      countOf pid = Map.findWithDefault 0 pid counts
+  if countOf sourceId >= limit || countOf targetId >= limit
+    then pure False
+    else do
+      let bump = Map.insertWith (+) sourceId 1 . Map.insertWith (+) targetId 1
+      writeTVar (rsCircuitCounts state) (bump counts)
+      pure True
+
+-- | Release the circuit slots acquired by 'acquireCircuitSlots'.
+releaseCircuitSlots :: RelayState -> PeerId -> PeerId -> STM ()
+releaseCircuitSlots state sourceId targetId =
+  modifyTVar' (rsCircuitCounts state) (dropOne sourceId . dropOne targetId)
+  where
+    dropOne = Map.update (\n -> if n <= 1 then Nothing else Just (n - 1))
+
+-- | Open a stop stream to the target, exchange CONNECT/STATUS, and bridge the
+-- two streams until EOF or a limit is exceeded.
+establishCircuit :: RelayState -> StreamIO -> PeerId -> PeerId -> (PeerId -> IO (Maybe StreamIO)) -> IO ()
+establishCircuit state stream sourcePeerId targetId openStopStream = do
           -- Try to open stop stream to target
           mStopStream <- openStopStream targetId
           case mStopStream of
@@ -134,7 +180,7 @@ handleConnect state stream _sourcePeerId msg openStopStream = do
               let stopMsg = StopMessage
                     { stopType = Just StopConnect
                     , stopPeer = Just RelayPeer
-                        { rpId = let PeerId bs = _sourcePeerId in bs
+                        { rpId = let PeerId bs = sourcePeerId in bs
                         , rpAddrs = []
                         }
                     , stopLimit = Just RelayLimit
@@ -179,22 +225,31 @@ sendHopStatus stream status = writeHopMessage stream HopMessage
   }
 
 -- | Bridge two streams bidirectionally with optional data/duration limits.
--- Terminates when either direction closes or limits are exceeded.
+-- Terminates when either direction closes or limits are exceeded, then closes
+-- both streams so neither end is left with a half-open circuit.
 bridgeStreams :: Maybe RelayLimit -> StreamIO -> StreamIO -> IO ()
 bridgeStreams mLimit streamA streamB = do
-  let dataLimit = case mLimit of
-        Just lim -> case rlData lim of
-          Just n  -> fromIntegral n :: Int
-          Nothing -> maxBound
+  let dataLimit = case mLimit >>= rlData of
+        Just n  -> fromIntegral n :: Int
         Nothing -> maxBound
+      -- Duration limit in microseconds for threadDelay
+      mDurationMicros = case mLimit >>= rlDuration of
+        Just secs | secs > 0 -> Just (fromIntegral secs * 1000000 :: Int)
+        _                    -> Nothing
   -- Track bytes transferred in each direction
   countAtoB <- newIORef (0 :: Int)
   countBtoA <- newIORef (0 :: Int)
   -- Forward A→B and B→A concurrently; terminate when either finishes
-  _ <- race
-    (forwardWithLimit streamA streamB countAtoB dataLimit)
-    (forwardWithLimit streamB streamA countBtoA dataLimit)
-  pure ()
+  let forwarding = race_
+        (forwardWithLimit streamA streamB countAtoB dataLimit)
+        (forwardWithLimit streamB streamA countBtoA dataLimit)
+  -- Enforce the advertised duration limit: close the circuit when it elapses
+  (case mDurationMicros of
+     Nothing     -> forwarding
+     Just micros -> race_ (threadDelay micros) forwarding)
+    `finally` do
+      streamClose streamA
+      streamClose streamB
 
 -- | Forward bytes from source to destination with a byte limit.
 forwardWithLimit :: StreamIO -> StreamIO -> IORef Int -> Int -> IO ()

--- a/test/LibP2P/NAT/Relay/RelaySpec.hs
+++ b/test/LibP2P/NAT/Relay/RelaySpec.hs
@@ -3,7 +3,7 @@ module LibP2P.NAT.Relay.RelaySpec (spec) where
 import Test.Hspec
 
 import qualified Data.ByteString as BS
-import Control.Concurrent.Async (withAsync, race)
+import Control.Concurrent.Async (withAsync, race, wait)
 import Control.Concurrent.STM
 import Control.Concurrent (threadDelay)
 import qualified Data.Map.Strict as Map
@@ -115,6 +115,115 @@ spec = do
         Left err -> expectationFailure $ "Read failed: " ++ err
 
   describe "Relay server handleConnect" $ do
+    it "should reject CONNECT with NO_RESERVATION when the target reservation has expired" $ do
+      relayState <- newRelayState defaultRelayConfig
+      -- Insert an already-expired reservation for the target
+      now <- getPOSIXTime
+      let expired = ActiveReservation
+            { arPeerId = targetPeerId
+            , arExpiration = floor now - 10
+            }
+      atomically $ modifyTVar' (rsReservations relayState) (Map.insert targetPeerId expired)
+      (clientStream, serverStream) <- mkStreamPair
+      let connectReq = HopMessage
+            { hopType = Just HopConnect
+            , hopPeer = Just RelayPeer
+                { rpId = let PeerId bs = targetPeerId in bs
+                , rpAddrs = []
+                }
+            , hopReservation = Nothing
+            , hopLimit = Nothing
+            , hopStatus = Nothing
+            }
+      writeHopMessage clientStream connectReq
+      handleConnect relayState serverStream testPeerId connectReq (\_pid -> pure Nothing)
+      result <- readHopMessage clientStream maxRelayMessageSize
+      case result of
+        Right resp -> hopStatus resp `shouldBe` Just NoReservation
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      -- The expired reservation must be released from state
+      reservations <- readTVarIO (rsReservations relayState)
+      Map.member targetPeerId reservations `shouldBe` False
+
+    it "should reject CONNECT with RESOURCE_LIMIT_EXCEEDED when the per-peer circuit limit is reached" $ do
+      let config = defaultRelayConfig { rcMaxCircuits = 0 }
+      relayState <- newRelayState config
+      -- Insert a valid (unexpired) reservation for the target
+      now <- getPOSIXTime
+      let valid = ActiveReservation
+            { arPeerId = targetPeerId
+            , arExpiration = floor now + 3600
+            }
+      atomically $ modifyTVar' (rsReservations relayState) (Map.insert targetPeerId valid)
+      (clientStream, serverStream) <- mkStreamPair
+      let connectReq = HopMessage
+            { hopType = Just HopConnect
+            , hopPeer = Just RelayPeer
+                { rpId = let PeerId bs = targetPeerId in bs
+                , rpAddrs = []
+                }
+            , hopReservation = Nothing
+            , hopLimit = Nothing
+            , hopStatus = Nothing
+            }
+      writeHopMessage clientStream connectReq
+      handleConnect relayState serverStream testPeerId connectReq (\_pid -> pure Nothing)
+      result <- readHopMessage clientStream maxRelayMessageSize
+      case result of
+        Right resp -> hopStatus resp `shouldBe` Just ResourceLimitExceeded
+        Left err -> expectationFailure $ "Read failed: " ++ err
+
+    it "should release per-peer circuit slots when the circuit ends" $ do
+      -- 1 second duration limit so the bridged circuit ends on its own
+      let config = defaultRelayConfig { rcMaxCircuits = 1, rcDefaultDurationLimit = 1 }
+      relayState <- newRelayState config
+      now <- getPOSIXTime
+      let valid = ActiveReservation
+            { arPeerId = targetPeerId
+            , arExpiration = floor now + 3600
+            }
+      atomically $ modifyTVar' (rsReservations relayState) (Map.insert targetPeerId valid)
+      (clientStream, serverStream) <- mkStreamPair
+      (relayStopStream, targetStream) <- mkStreamPair
+      let connectReq = HopMessage
+            { hopType = Just HopConnect
+            , hopPeer = Just RelayPeer
+                { rpId = let PeerId bs = targetPeerId in bs
+                , rpAddrs = []
+                }
+            , hopReservation = Nothing
+            , hopLimit = Nothing
+            , hopStatus = Nothing
+            }
+      writeHopMessage clientStream connectReq
+      let runConnect = handleConnect relayState serverStream testPeerId connectReq
+                         (\_pid -> pure (Just relayStopStream))
+      withAsync runConnect $ \connectAsync -> do
+        -- Fake target: accept the STOP CONNECT
+        stopReq <- readStopMessage targetStream maxRelayMessageSize
+        case stopReq of
+          Right m -> stopType m `shouldBe` Just StopConnect
+          Left err -> expectationFailure $ "Stop read failed: " ++ err
+        writeStopMessage targetStream StopMessage
+          { stopType = Just StopStatus
+          , stopPeer = Nothing
+          , stopLimit = Nothing
+          , stopStatus = Just RelayOK
+          }
+        -- Source is notified of success
+        result <- readHopMessage clientStream maxRelayMessageSize
+        case result of
+          Right resp -> hopStatus resp `shouldBe` Just RelayOK
+          Left err -> expectationFailure $ "Read failed: " ++ err
+        -- While the circuit is active both peers hold one slot
+        counts <- readTVarIO (rsCircuitCounts relayState)
+        Map.lookup testPeerId counts `shouldBe` Just 1
+        Map.lookup targetPeerId counts `shouldBe` Just 1
+        -- The duration limit ends the circuit; the slots must be released
+        wait connectAsync
+        counts' <- readTVarIO (rsCircuitCounts relayState)
+        counts' `shouldBe` Map.empty
+
     it "rejects CONNECT when target has no reservation" $ do
       relayState <- newRelayState defaultRelayConfig
       (clientStream, serverStream) <- mkStreamPair
@@ -175,6 +284,22 @@ spec = do
       case result of
         Left () -> pure ()  -- bridge terminated first (expected after limit)
         Right bs -> bs `shouldBe` [1, 2, 3, 4, 5]
+
+    it "should close both streams when the duration limit elapses" $ do
+      (_streamA1, streamA2) <- mkStreamPair
+      (streamB1, _streamB2) <- mkStreamPair
+      closedA <- newIORef False
+      closedB <- newIORef False
+      let trackClose ref s = s { streamClose = modifyIORef' ref (const True) }
+          -- 1 second duration limit, no data limit
+          limitCfg = Just RelayLimit { rlDuration = Just 1, rlData = Nothing }
+      -- No data ever flows, so only the duration timer can end the bridge.
+      result <- race
+        (bridgeStreams limitCfg (trackClose closedA streamA2) (trackClose closedB streamB1))
+        (threadDelay 3000000)
+      result `shouldBe` Left ()
+      readIORef closedA `shouldReturn` True
+      readIORef closedB `shouldReturn` True
 
   describe "Relay address parsing" $ do
     it "buildRelayAddr constructs valid relay multiaddr bytes" $ do


### PR DESCRIPTION
## Summary

Circuit Relay v2 advertised resource limits but never enforced them (#151). This PR adds the three missing enforcement points required by the [circuit-v2 spec](https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md):

- **Reservation expiry**: `handleConnect` now checks `arExpiration` against the current time; an expired reservation is removed from state and the CONNECT is rejected with `NO_RESERVATION`.
- **Per-peer circuit count**: `RelayState` now tracks active circuits per peer (`rsCircuitCounts`). A CONNECT is rejected with `RESOURCE_LIMIT_EXCEEDED` when either the initiator or the target is at `rcMaxCircuits`; the check-and-increment is a single STM transaction, and slots are released (via `finally`) when the circuit ends.
- **Duration limit**: `bridgeStreams` races the forwarding loops against the advertised `Limit.duration` and closes both streams when it elapses (and on any other bridge termination), so circuits no longer run indefinitely.

Not in scope: the reservation-cap status-code bug is tracked separately in #180.

## Testing

TDD: four new tests (expired reservation → `NO_RESERVATION`, circuit limit → `RESOURCE_LIMIT_EXCEEDED`, duration limit closes both streams, end-to-end slot release after circuit end) were written first and confirmed failing, then the implementation turned them green. Full suite: 636 examples, 0 failures (GHC 9.10.1).

Closes #151