### PR TITLE
fix: gossipsub subscription set — announce and accept GRAFTs for topics joined with no peers

### DIFF
--- a/src/LibP2P/Protocol/GossipSub/Handler.hs
+++ b/src/LibP2P/Protocol/GossipSub/Handler.hs
@@ -15,6 +15,7 @@ module LibP2P.Protocol.GossipSub.Handler
   , newGossipSubNode
     -- * Stream handling
   , handleGossipSubStream
+  , sendCurrentSubscriptions
     -- * Lifecycle
   , startGossipSub
   , stopGossipSub
@@ -227,8 +228,10 @@ onNewConnection node conn = do
 sendCurrentSubscriptions :: GossipSubNode -> StreamIO -> IO ()
 sendCurrentSubscriptions node stream = do
   let router = gsnRouter node
-  meshTopics <- atomically $ Map.keysSet <$> readTVar (gsMesh router)
-  let topics = Set.toList meshTopics
+  -- Read the subscription set, not mesh keys: a topic joined before any
+  -- peer was known has no mesh entry but must still be announced (#155).
+  subs <- atomically $ readTVar (gsSubscriptions router)
+  let topics = Set.toList subs
   if null topics
     then pure ()
     else do

--- a/src/LibP2P/Protocol/GossipSub/Heartbeat.hs
+++ b/src/LibP2P/Protocol/GossipSub/Heartbeat.hs
@@ -54,7 +54,12 @@ meshMaintenance :: GossipSubRouter -> IO ()
 meshMaintenance router = do
   now <- gsGetTime router
   meshMap <- readTVarIO (gsMesh router)
-  forM_ (Map.toList meshMap) $ \(topic, meshPeers) -> do
+  subs <- readTVarIO (gsSubscriptions router)
+  -- Maintain every subscribed topic, not just topics with a mesh entry:
+  -- a topic joined with no peers must be filled once peers appear (#155).
+  let topics = Set.union subs (Map.keysSet meshMap)
+  forM_ (Set.toList topics) $ \topic -> do
+    let meshPeers = Map.findWithDefault Set.empty topic meshMap
     -- Step 1: Remove negative-score peers
     remaining <- pruneNegativeScore router topic meshPeers now
     -- Step 2: Fill if undersubscribed (< D_lo)
@@ -180,12 +185,19 @@ fanoutMaintenance router = do
 emitGossip :: GossipSubRouter -> IO ()
 emitGossip router = do
   meshMap <- readTVarIO (gsMesh router)
+  fanoutMap <- readTVarIO (gsFanout router)
+  subs <- readTVarIO (gsSubscriptions router)
   cache <- readTVarIO (gsMessageCache router)
   peersMap <- readTVarIO (gsPeers router)
   let params = gsParams router
+      -- gossipsub-v1.0.md heartbeat: gossip covers "each topic in
+      -- mesh+fanout", so topics we publish to without subscribing
+      -- also emit IHAVE (#155).
+      topics = Set.unions
+        [ subs, Map.keysSet meshMap, Map.keysSet fanoutMap ]
 
-  -- For each topic in mesh, send IHAVE to non-mesh peers
-  forM_ (Map.keys meshMap) $ \topic -> do
+  -- For each topic in mesh+fanout, send IHAVE to non-mesh peers
+  forM_ (Set.toList topics) $ \topic -> do
     let gossipIds = cacheGetGossipIds topic cache
     unless (null gossipIds) $ do
       let meshPeers = Map.findWithDefault Set.empty topic meshMap

--- a/src/LibP2P/Protocol/GossipSub/Router.hs
+++ b/src/LibP2P/Protocol/GossipSub/Router.hs
@@ -57,6 +57,7 @@ newRouter :: GossipSubParams
           -> IO UTCTime                 -- ^ Time source
           -> IO GossipSubRouter
 newRouter params localPid sendRPC getTime = do
+  subs     <- newTVarIO Set.empty
   mesh     <- newTVarIO Map.empty
   fanout   <- newTVarIO Map.empty
   fanoutPub <- newTVarIO Map.empty
@@ -71,6 +72,7 @@ newRouter params localPid sendRPC getTime = do
   pure GossipSubRouter
     { gsParams         = params
     , gsLocalPeerId    = localPid
+    , gsSubscriptions  = subs
     , gsMesh           = mesh
     , gsFanout         = fanout
     , gsFanoutPub      = fanoutPub
@@ -133,13 +135,19 @@ removePeer router pid = atomically $ do
 -- | Subscribe to a topic (JOIN): announce, fanout→mesh transition, fill to D, GRAFT.
 join :: GossipSubRouter -> Topic -> IO ()
 join router topic = do
-  -- 1. Announce subscription to all known peers
+  -- 1. Record the subscription. This must happen regardless of how many
+  -- peers currently know the topic: the subscription set (not mesh key
+  -- presence) is what GRAFT acceptance and hello-packet announcements
+  -- consult (gossipsub-v1.0.md JOIN/GRAFT; issue #155).
+  atomically $ modifyTVar' (gsSubscriptions router) (Set.insert topic)
+
+  -- 2. Announce subscription to all known peers
   peers <- readTVarIO (gsPeers router)
   let allPeerIds = Map.keys peers
       subRPC = emptyRPC { rpcSubscriptions = [SubOpts True topic] }
   mapM_ (\pid -> gsSendRPC router pid subRPC) allPeerIds
 
-  -- 2. Check fanout and transition to mesh
+  -- 3. Check fanout and transition to mesh
   (fanoutPeers, topicPeers) <- atomically $ do
     fo <- readTVar (gsFanout router)
     let foPeers = Map.findWithDefault Set.empty topic fo
@@ -160,7 +168,7 @@ join router topic = do
           else acc) Set.empty peerMap
     pure (foPeers, eligible)
 
-  -- 3. Fill mesh to D if needed
+  -- 4. Fill mesh to D if needed
   currentMesh <- atomically $ do
     m <- readTVar (gsMesh router)
     pure (Map.findWithDefault Set.empty topic m)
@@ -174,20 +182,25 @@ join router topic = do
       pure newSet
     else pure Set.empty
 
-  -- 4. Send GRAFT to all new mesh peers (including former fanout peers)
-  let allNewMeshPeers = Set.union (Set.difference fanoutPeers currentMesh) newPeers
+  -- 5. Send GRAFT to all new mesh peers, including former fanout peers.
+  -- fanoutPeers was captured before the mesh insert; currentMesh already
+  -- contains the promoted peers, so it must not be subtracted here (#155).
+  let allNewMeshPeers = Set.union fanoutPeers newPeers
   mapM_ (\pid -> gsSendRPC router pid (graftRPC topic)) (Set.toList allNewMeshPeers)
 
 -- | Unsubscribe from a topic (LEAVE): announce, PRUNE with backoff, delete mesh.
 leave :: GossipSubRouter -> Topic -> IO ()
 leave router topic = do
-  -- 1. Announce unsubscription to all known peers
+  -- 1. Drop the subscription
+  atomically $ modifyTVar' (gsSubscriptions router) (Set.delete topic)
+
+  -- 2. Announce unsubscription to all known peers
   peers <- readTVarIO (gsPeers router)
   let allPeerIds = Map.keys peers
       unsubRPC = emptyRPC { rpcSubscriptions = [SubOpts False topic] }
   mapM_ (\pid -> gsSendRPC router pid unsubRPC) allPeerIds
 
-  -- 2. Send PRUNE with unsubscribe backoff to mesh peers, then delete
+  -- 3. Send PRUNE with unsubscribe backoff to mesh peers, then delete
   meshPeers <- atomically $ do
     m <- readTVar (gsMesh router)
     let mp = Map.findWithDefault Set.empty topic m
@@ -215,8 +228,11 @@ publish router topic payload mKeyPair = do
 
   let msgId = paramMessageIdFn (gsParams router) msg
 
-  -- Mark as seen
-  atomically $ modifyTVar' (gsSeen router) (Map.insert msgId now)
+  -- Mark as seen and cache for IWANT/IHAVE: gossipsub-v1.0.md answers
+  -- IWANT from the mcache, so our own messages must be cached too (#155).
+  atomically $ do
+    modifyTVar' (gsSeen router) (Map.insert msgId now)
+    modifyTVar' (gsMessageCache router) (cachePut msgId msg)
 
   -- Build RPC with published message
   let pubRPC = emptyRPC { rpcPublish = [msg] }
@@ -355,9 +371,11 @@ handleGraft router sender grafts = do
 -- | Handle a single GRAFT request.
 handleOneGraft :: GossipSubRouter -> PeerId -> UTCTime -> Graft -> IO [Prune]
 handleOneGraft router sender now (Graft topic) = do
-  -- Check if we are subscribed to this topic
-  meshMap <- readTVarIO (gsMesh router)
-  let subscribed = Map.member topic meshMap
+  -- Check the subscription set, not mesh key presence: a topic joined
+  -- with no peers has no mesh entry but its GRAFTs must be accepted
+  -- (gossipsub-v1.0.md GRAFT handling; issue #155).
+  subs <- readTVarIO (gsSubscriptions router)
+  let subscribed = Set.member topic subs
 
   if not subscribed
     then pure [Prune topic [] Nothing]  -- Not subscribed → PRUNE

--- a/src/LibP2P/Protocol/GossipSub/Types.hs
+++ b/src/LibP2P/Protocol/GossipSub/Types.hs
@@ -386,6 +386,11 @@ data MessageCache = MessageCache
 data GossipSubRouter = GossipSubRouter
   { gsParams      :: !GossipSubParams
   , gsLocalPeerId :: !PeerId
+    -- Subscription state
+  , gsSubscriptions :: !(TVar (Set Topic))
+    -- ^ Topics the local node is subscribed to. Kept independently of
+    -- mesh state: a topic joined before any peer announces it has an
+    -- empty (absent) mesh entry but is still subscribed (issue #155).
     -- Mesh and fanout state
   , gsMesh        :: !(TVar (Map Topic (Set PeerId)))
   , gsFanout      :: !(TVar (Map Topic (Set PeerId)))

--- a/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
@@ -34,6 +34,7 @@ import LibP2P.Protocol.GossipSub.Handler
   , gossipSubProtocolId
   , handleGossipSubStream
   , newGossipSubNode
+  , sendCurrentSubscriptions
   , startGossipSub
   , stopGossipSub
   )
@@ -215,6 +216,25 @@ spec = do
           rpcSubscriptions rpc1 `shouldBe` [SubOpts True "topic1"]
           rpcSubscriptions rpc2 `shouldBe` [SubOpts True "topic2"]
         _ -> expectationFailure "failed to read both RPCs"
+
+  describe "sendCurrentSubscriptions" $ do
+    -- Issue #155: a topic joined while no peers were known must still be
+    -- announced to peers that connect afterwards (the "hello packet",
+    -- pubsub/README.md). Before the fix, subscriptions were derived from
+    -- mesh-map keys and a peerless join left no trace.
+    it "announces a topic joined with no known peers to a later-connecting peer" $ do
+      (sw, _pid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      -- Join while the router knows no peers at all
+      gossipJoin node "early-topic"
+      -- A peer connects afterwards; its hello packet must carry the topic
+      (nodeStream, remoteReadStream) <- mkMemoryStreamPair
+      sendCurrentSubscriptions node nodeStream
+      result <- timeout 2000000 $ readRPCMessage remoteReadStream maxRPCSize
+      case result of
+        Just (Right rpc) ->
+          rpcSubscriptions rpc `shouldBe` [SubOpts True "early-topic"]
+        _ -> expectationFailure "expected a subscription announcement RPC"
 
   describe "startGossipSub" $ do
     it "registers handler and starts heartbeat" $ do

--- a/test/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
@@ -148,6 +148,23 @@ spec = do
                 Nothing -> False) sent
         length pruneMsgs `shouldBe` 9  -- 15 - 6 = 9
 
+      -- Issue #155: a topic joined with zero known peers must still be
+      -- maintained; when peers appear later, the heartbeat fills its mesh.
+      it "fills the mesh for a subscribed topic that had no peers at join time" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "t")
+        -- Peers discovered only after the join
+        mapM_ (\pid -> addSubscribedPeer router pid "t" fixedTime) (map mkPeerId [1..4])
+        heartbeatOnce router
+        mesh <- readTVarIO (gsMesh router)
+        Set.size (Map.findWithDefault Set.empty "t" mesh) `shouldSatisfy` (>= 1)
+        sent <- readIORef logRef
+        let graftMsgs = filter (\(_, rpc) ->
+              case rpcControl rpc of
+                Just ctrl -> not (null (ctrlGraft ctrl))
+                Nothing -> False) sent
+        length graftMsgs `shouldSatisfy` (>= 1)
+
     describe "Fanout maintenance" $ do
       it "expires old fanout entries" $ do
         (router, _, timeRef) <- mkHeartbeatRouter localPid fixedTime
@@ -222,6 +239,30 @@ spec = do
                 Just ctrl -> not (null (ctrlIHave ctrl))
                 Nothing -> False) sent
         length ihaveMsgs `shouldBe` 0
+
+      -- gossipsub-v1.0.md heartbeat: gossip is emitted "for each topic in
+      -- mesh+fanout"; fanout-only topics were previously skipped (#155).
+      it "emits IHAVE for fanout topics" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        let pids = map mkPeerId [1..3]
+        mapM_ (\pid -> addSubscribedPeer router pid "ftopic" fixedTime) pids
+        -- Fanout entry: we publish to "ftopic" without subscribing
+        atomically $ do
+          modifyTVar' (gsFanout router) $
+            Map.insert "ftopic" (Set.singleton (mkPeerId 1))
+          modifyTVar' (gsFanoutPub router) $
+            Map.insert "ftopic" fixedTime
+        let mid = BS.pack [7]
+            msg = PubSubMessage (Just (BS.pack [1])) (BS.pack [1]) (Just mid) "ftopic" Nothing Nothing
+        atomically $ modifyTVar' (gsMessageCache router) $
+          cachePut mid msg
+        heartbeatOnce router
+        sent <- readIORef logRef
+        let ihaveMsgs = filter (\(_, rpc) ->
+              case rpcControl rpc of
+                Just ctrl -> any (\(IHave t _) -> t == "ftopic") (ctrlIHave ctrl)
+                Nothing -> False) sent
+        length ihaveMsgs `shouldSatisfy` (>= 1)
 
       it "rotates message cache after gossip" $ do
         (router, _, _) <- mkHeartbeatRouter localPid fixedTime

--- a/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
@@ -215,6 +215,53 @@ spec = do
         -- Should have D=6 peers total (2 from fanout + 4 new)
         Set.size meshPeers `shouldBe` 6
 
+      -- gossipsub-v1.0.md JOIN: "notifies them with a GRAFT(topic) control
+      -- message" — this includes fanout peers promoted into the mesh (#155).
+      it "sends GRAFT to fanout peers promoted into the mesh" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let peerA = mkPeerId 1
+            peerB = mkPeerId 2
+        addSubscribedPeer router peerA "topic1"
+        addSubscribedPeer router peerB "topic1"
+        atomically $ modifyTVar' (gsFanout router) $
+          Map.insert "topic1" (Set.fromList [peerA, peerB])
+        join router "topic1"
+        sent <- readIORef logRef
+        let graftTargets = [ pid | (pid, rpc) <- sent
+                                 , Just ctrl <- [rpcControl rpc]
+                                 , any (\(Graft t) -> t == "topic1") (ctrlGraft ctrl) ]
+        Set.fromList graftTargets `shouldBe` Set.fromList [peerA, peerB]
+
+      -- Issue #155: a node maintains its own subscription set independent of
+      -- mesh state (gossipsub-v1.0.md "the router keeps track of the topics
+      -- its directly connected peers are subscribed to" and announces its own
+      -- subscriptions); joining with zero peers must still leave a trace.
+      it "records the subscription when the topic has no known peers" $ do
+        (router, _) <- mkTestRouter localPid
+        join router "empty-topic"
+        subs <- readTVarIO (gsSubscriptions router)
+        Set.member "empty-topic" subs `shouldBe` True
+
+      it "accepts a GRAFT for a topic joined with no peers at join time" $ do
+        -- gossipsub-v1.0.md GRAFT: "On receiving a GRAFT(topic) message, the
+        -- router will check to see if it is indeed subscribed to the topic
+        -- identified in the message. If so, the router will add the peer to
+        -- mesh[topic]." Mesh emptiness at join time is irrelevant (#155).
+        (router, logRef) <- mkTestRouter localPid
+        join router "empty-topic"
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        handleGraft router sender [Graft "empty-topic"]
+        mesh <- readTVarIO (gsMesh router)
+        Set.member sender (Map.findWithDefault Set.empty "empty-topic" mesh)
+          `shouldBe` True
+        sent <- readIORef logRef
+        let pruneMsgs = filter (\(_, rpc) ->
+              case rpcControl rpc of
+                Just ctrl -> not (null (ctrlPrune ctrl))
+                Nothing -> False) sent
+        length pruneMsgs `shouldBe` 0
+
     describe "leave" $ do
       it "announces unsubscription to all peers" $ do
         (router, logRef) <- mkTestRouter localPid
@@ -253,14 +300,21 @@ spec = do
         mesh <- readTVarIO (gsMesh router)
         Map.member "blocks" mesh `shouldBe` False
 
+      it "removes the topic from the subscription set" $ do
+        (router, _) <- mkTestRouter localPid
+        join router "blocks"
+        leave router "blocks"
+        subs <- readTVarIO (gsSubscriptions router)
+        Set.member "blocks" subs `shouldBe` False
+
     describe "handleGraft" $ do
       it "accepts graft when subscribed and no backoff" $ do
         (router, logRef) <- mkTestRouter localPid
         let sender = mkPeerId 1
         addPeer router sender GossipSubPeer False fixedTime
-        -- Create mesh entry (we're subscribed)
-        atomically $ modifyTVar' (gsMesh router) $
-          Map.insert "blocks" Set.empty
+        -- #155: subscription is tracked in gsSubscriptions, not inferred
+        -- from mesh-map key presence (gossipsub-v1.0.md GRAFT handling)
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "blocks")
         handleGraft router sender [Graft "blocks"]
         -- Sender should be in mesh
         mesh <- readTVarIO (gsMesh router)
@@ -291,8 +345,8 @@ spec = do
         (router, logRef, timeRef) <- mkTestRouterWithTime localPid fixedTime
         let sender = mkPeerId 1
         addPeer router sender GossipSubPeer False fixedTime
-        atomically $ modifyTVar' (gsMesh router) $
-          Map.insert "blocks" Set.empty
+        -- #155: mark ourselves subscribed via the subscription set
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "blocks")
         -- Set backoff that expires in the future
         let backoffExpiry = addUTCTime 60 fixedTime
         atomically $ modifyTVar' (gsBackoff router) $
@@ -426,6 +480,16 @@ spec = do
         let publishedTo = map fst $ filter (\(_, rpc) -> not (null (rpcPublish rpc))) sent
         Set.fromList publishedTo `shouldBe` Set.fromList [peerA, peerB]
 
+      -- gossipsub-v1.0.md: IWANT is answered from the mcache and IHAVE is
+      -- built from it; our own published messages must be cached too (#155).
+      it "caches own published message in the mcache" $ do
+        (router, _) <- mkTestRouter localPid
+        addSubscribedPeer router (mkPeerId 1) "blocks"
+        kp <- newKeyPair
+        publish router "blocks" (BS.pack [1, 2, 3]) (Just kp)
+        cache <- readTVarIO (gsMessageCache router)
+        Map.size (mcIndex cache) `shouldBe` 1
+
       it "marks published message as seen" $ do
         (router, _) <- mkTestRouter localPid
         let peerA = mkPeerId 1
@@ -499,9 +563,8 @@ spec = do
         (router, logRef) <- mkTestRouter localPid
         let sender = mkPeerId 1
         addPeer router sender GossipSubPeer False fixedTime
-        -- Create mesh so GRAFT can be accepted
-        atomically $ modifyTVar' (gsMesh router) $
-          Map.insert "blocks" Set.empty
+        -- #155: subscribe so GRAFT can be accepted
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "blocks")
         let rpc = RPC
               { rpcSubscriptions = [SubOpts True "blocks"]
               , rpcPublish = []
@@ -670,9 +733,8 @@ spec = do
             { psTopicState = Map.singleton "blocks"
                 (defaultTopicPeerState { tpsInvalidMessages = 10 })
             }) sender
-        -- Set up mesh entry for topic
-        atomically $ modifyTVar' (gsMesh routerWithParams) $
-          Map.insert "blocks" Set.empty
+        -- #155: mark ourselves subscribed via the subscription set
+        atomically $ modifyTVar' (gsSubscriptions routerWithParams) (Set.insert "blocks")
         handleGraft routerWithParams sender [Graft "blocks"]
         -- Sender should NOT be in mesh (rejected due to negative score)
         mesh <- readTVarIO (gsMesh routerWithParams)
@@ -689,8 +751,8 @@ spec = do
         (router, _) <- mkTestRouter localPid
         let sender = mkPeerId 1
         addPeer router sender GossipSubPeer False fixedTime
-        atomically $ modifyTVar' (gsMesh router) $
-          Map.insert "blocks" Set.empty
+        -- #155: mark ourselves subscribed via the subscription set
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "blocks")
         -- Set backoff
         let backoffExpiry = addUTCTime 60 fixedTime
         atomically $ modifyTVar' (gsBackoff router) $


### PR DESCRIPTION
## Problem

The router had no "topics we are subscribed to" state; mesh-map key presence was used as a proxy. `join` only created a mesh entry when it had peers to put in it, so subscribing to a topic before any peer announced it left no trace: the subscription was never announced to later-connecting peers, and GRAFTs for the topic were answered with PRUNE despite `gossipsub-v1.0.md` requiring acceptance when subscribed.

## Fix

- Add `gsSubscriptions :: TVar (Set Topic)` to `GossipSubRouter`; `join`/`leave` maintain it, `handleGraft` and the hello-packet announcement (`sendCurrentSubscriptions`) consult it instead of mesh keys.
- `join` now GRAFTs fanout peers promoted into the mesh (the previous `Set.difference` against the post-insert mesh was always empty, leaving those links one-directional).
- `publish` caches the node's own messages in the mcache so IWANT can be answered and IHAVE emitted for them.
- Heartbeat: mesh maintenance covers all subscribed topics (fills a mesh that was empty at join time once peers appear); gossip emission covers mesh+fanout topics per the spec.

## Tests

New cases: peerless join records subscription and is announced to later-connecting peers; GRAFT for such a topic is accepted; fanout promotion sends GRAFT; own publish is mcached; fanout topics emit IHAVE; heartbeat fills an empty-at-join mesh. Existing cases that inserted an empty mesh entry as a subscription proxy (issue #175) now use the subscription set, with spec-referencing comments. Full suite: 637 examples, 0 failures (GHC 9.10.1).

Closes #155