### PR TITLE
fix(dcutr): dial all addresses in parallel and retry the exchange per spec

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -190,3 +190,4 @@ test-suite libp2p-hs-test
     QuickCheck >= 2.14 && < 2.16
   build-tool-depends:
     hspec-discover:hspec-discover
+  ghc-options: -threaded

--- a/src/LibP2P/NAT/DCUtR.hs
+++ b/src/LibP2P/NAT/DCUtR.hs
@@ -11,6 +11,10 @@
 --   B waits RTT/2, then dials A's addresses
 --   A receives SYNC, then dials B's addresses immediately
 --   Both peers attempt direct connections at approximately the same time
+--
+-- Per the spec, every exchanged address is dialled in parallel (hole punching
+-- depends on near-simultaneous packets), and on failure the whole exchange is
+-- re-run from the CONNECT step so RTT is re-measured (3 attempts total).
 module LibP2P.NAT.DCUtR
   ( -- * Types
     DCUtRConfig (..)
@@ -27,6 +31,8 @@ module LibP2P.NAT.DCUtR
 import qualified Data.ByteString as BS
 import Data.IORef (IORef, newIORef, writeIORef)
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (async, waitAny, cancel)
+import Control.Exception (bracket)
 import Data.Time.Clock (getCurrentTime, diffUTCTime, NominalDiffTime)
 import LibP2P.NAT.DCUtR.Message
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
@@ -34,8 +40,10 @@ import LibP2P.Multiaddr (Multiaddr, toBytes, fromBytes)
 
 -- | DCUtR configuration.
 data DCUtRConfig = DCUtRConfig
-  { dcMaxRetries :: !Int
-    -- ^ Maximum number of retry attempts (spec says 3 total = 1 initial + 2 retries)
+  { dcMaxAttempts :: !Int
+    -- ^ Total number of hole punch attempts; the full CONNECT/SYNC exchange
+    -- is re-run for each attempt so RTT is re-measured (spec: 3 total =
+    -- 1 initial + 2 retries)
   , dcDialer     :: !(Multiaddr -> IO (Either String ()))
     -- ^ Injectable dial function for testing
   }
@@ -44,13 +52,17 @@ data DCUtRConfig = DCUtRConfig
 data DCUtRResult = DCUtRSuccess | DCUtRFailed String
   deriving (Show, Eq)
 
+-- | Outcome of a single hole punch attempt. Only dial failures are
+-- retryable; protocol errors abort the upgrade immediately.
+data AttemptError = FatalError String | DialError String
+
 -- | Peer B (initiator): run the DCUtR exchange over a relayed stream.
 --
--- Flow:
+-- Flow (repeated up to 'dcMaxAttempts' times while the hole punch fails):
 --   1. Send CONNECT with own observed addresses
 --   2. Read A's CONNECT (measure RTT)
 --   3. Send SYNC
---   4. Wait RTT/2, then dial A's addresses
+--   4. Wait RTT/2, then dial all of A's addresses in parallel
 initiateDCUtR :: DCUtRConfig -> StreamIO -> [Multiaddr] -> IO DCUtRResult
 initiateDCUtR config stream addrs = do
   rttRef <- newIORef Nothing
@@ -58,113 +70,109 @@ initiateDCUtR config stream addrs = do
 
 -- | Initiator variant that captures RTT for testing.
 initiateDCUtRWithRTT :: DCUtRConfig -> StreamIO -> [Multiaddr] -> IORef (Maybe NominalDiffTime) -> IO DCUtRResult
-initiateDCUtRWithRTT config stream addrs rttRef = do
-  let addrBytes = map toBytes addrs
-  -- Step 1: Send CONNECT with our observed addresses
-  let connectOut = HolePunchMessage { hpType = HPConnect, hpObsAddrs = addrBytes }
-  writeHolePunchMessage stream connectOut
-  t0 <- getCurrentTime
-  -- Step 2: Read A's CONNECT response (this measures RTT)
-  result <- readHolePunchMessage stream maxDCUtRMessageSize
-  case result of
-    Left err -> pure (DCUtRFailed $ "failed to read CONNECT: " ++ err)
-    Right msg
-      | hpType msg /= HPConnect -> pure (DCUtRFailed "expected CONNECT message")
-      | otherwise -> do
-          t1 <- getCurrentTime
-          let rtt = diffUTCTime t1 t0
-          writeIORef rttRef (Just rtt)
-          -- Step 3: Send SYNC
-          let syncOut = HolePunchMessage { hpType = HPSync, hpObsAddrs = [] }
-          writeHolePunchMessage stream syncOut
-          -- Step 4: Wait RTT/2, then dial A's addresses
-          let halfRTTMicros = max 0 (round (rtt * 1000000 / 2) :: Int)
-          threadDelay halfRTTMicros
-          let remoteAddrs = parseAddrs (hpObsAddrs msg)
-          dialResult <- tryDialAddrs config remoteAddrs
-          case dialResult of
-            Right () -> pure DCUtRSuccess
-            Left err -> pure (DCUtRFailed $ "dial failed: " ++ err)
+initiateDCUtRWithRTT config stream addrs rttRef =
+  runAttempts config (initiatorAttempt config stream addrs (Just rttRef) Nothing)
 
 -- | Initiator variant that captures received addresses for testing.
 initiateDCUtRCapture :: DCUtRConfig -> StreamIO -> [Multiaddr] -> IORef [BS.ByteString] -> IO DCUtRResult
-initiateDCUtRCapture config stream addrs receivedRef = do
-  let addrBytes = map toBytes addrs
-  let connectOut = HolePunchMessage { hpType = HPConnect, hpObsAddrs = addrBytes }
-  writeHolePunchMessage stream connectOut
-  result <- readHolePunchMessage stream maxDCUtRMessageSize
-  case result of
-    Left err -> pure (DCUtRFailed $ "failed to read CONNECT: " ++ err)
-    Right msg
-      | hpType msg /= HPConnect -> pure (DCUtRFailed "expected CONNECT message")
-      | otherwise -> do
-          writeIORef receivedRef (hpObsAddrs msg)
-          let syncOut = HolePunchMessage { hpType = HPSync, hpObsAddrs = [] }
-          writeHolePunchMessage stream syncOut
-          let remoteAddrs = parseAddrs (hpObsAddrs msg)
-          dialResult <- tryDialAddrs config remoteAddrs
-          case dialResult of
-            Right () -> pure DCUtRSuccess
-            Left err -> pure (DCUtRFailed $ "dial failed: " ++ err)
+initiateDCUtRCapture config stream addrs receivedRef =
+  runAttempts config (initiatorAttempt config stream addrs Nothing (Just receivedRef))
 
 -- | Peer A (handler): handle the DCUtR exchange over a relayed stream.
 --
--- Flow:
+-- Flow (repeated up to 'dcMaxAttempts' times while the hole punch fails,
+-- matching the initiator's retries of the exchange):
 --   1. Read B's CONNECT
 --   2. Send CONNECT with own observed addresses
 --   3. Read SYNC
---   4. Dial B's addresses immediately
+--   4. Dial all of B's addresses in parallel immediately
 handleDCUtR :: DCUtRConfig -> StreamIO -> [Multiaddr] -> IO DCUtRResult
-handleDCUtR config stream addrs = do
-  let addrBytes = map toBytes addrs
-  -- Step 1: Read B's CONNECT
-  result <- readHolePunchMessage stream maxDCUtRMessageSize
-  case result of
-    Left err -> pure (DCUtRFailed $ "failed to read CONNECT: " ++ err)
-    Right msg
-      | hpType msg /= HPConnect -> pure (DCUtRFailed "expected CONNECT message")
-      | otherwise -> do
-          -- Step 2: Send our CONNECT response
-          let connectResp = HolePunchMessage { hpType = HPConnect, hpObsAddrs = addrBytes }
-          writeHolePunchMessage stream connectResp
-          -- Step 3: Read SYNC
-          syncResult <- readHolePunchMessage stream maxDCUtRMessageSize
-          case syncResult of
-            Left err -> pure (DCUtRFailed $ "failed to read SYNC: " ++ err)
-            Right syncMsg
-              | hpType syncMsg /= HPSync -> pure (DCUtRFailed "expected SYNC message")
-              | otherwise -> do
-                  -- Step 4: Dial B's addresses immediately
-                  let remoteAddrs = parseAddrs (hpObsAddrs msg)
-                  dialResult <- tryDialAddrs config remoteAddrs
-                  case dialResult of
-                    Right () -> pure DCUtRSuccess
-                    Left err -> pure (DCUtRFailed $ "dial failed: " ++ err)
+handleDCUtR config stream addrs =
+  runAttempts config (handlerAttempt config stream addrs Nothing)
 
 -- | Handler variant that captures received addresses for testing.
 handleDCUtRCapture :: DCUtRConfig -> StreamIO -> [Multiaddr] -> IORef [BS.ByteString] -> IO DCUtRResult
-handleDCUtRCapture config stream addrs receivedRef = do
-  let addrBytes = map toBytes addrs
+handleDCUtRCapture config stream addrs receivedRef =
+  runAttempts config (handlerAttempt config stream addrs (Just receivedRef))
+
+-- Attempt loop
+
+-- | Run hole punch attempts until one succeeds, a protocol error occurs, or
+-- the attempt budget is exhausted.
+runAttempts :: DCUtRConfig -> IO (Either AttemptError ()) -> IO DCUtRResult
+runAttempts config attempt = go 1
+  where
+    maxAttempts = max 1 (dcMaxAttempts config)
+    go n = do
+      result <- attempt
+      case result of
+        Right () -> pure DCUtRSuccess
+        Left (FatalError err) -> pure (DCUtRFailed err)
+        Left (DialError err)
+          | n >= maxAttempts -> pure (DCUtRFailed err)
+          | otherwise -> go (n + 1)
+
+-- | One initiator attempt: full CONNECT/CONNECT/SYNC exchange followed by the
+-- synchronized parallel dial.
+initiatorAttempt
+  :: DCUtRConfig
+  -> StreamIO
+  -> [Multiaddr]
+  -> Maybe (IORef (Maybe NominalDiffTime))
+  -> Maybe (IORef [BS.ByteString])
+  -> IO (Either AttemptError ())
+initiatorAttempt config stream addrs mRttRef mCaptureRef = do
+  let connectOut = HolePunchMessage { hpType = HPConnect, hpObsAddrs = map toBytes addrs }
+  -- Step 1: Send CONNECT with our observed addresses. The spec starts the
+  -- RTT timer when the CONNECT is sent, so take t0 before the (possibly
+  -- blocking) relayed write.
+  t0 <- getCurrentTime
+  writeHolePunchMessage stream connectOut
+  -- Step 2: Read A's CONNECT response (this measures RTT)
   result <- readHolePunchMessage stream maxDCUtRMessageSize
   case result of
-    Left err -> pure (DCUtRFailed $ "failed to read CONNECT: " ++ err)
+    Left err -> pure (Left (FatalError ("failed to read CONNECT: " ++ err)))
     Right msg
-      | hpType msg /= HPConnect -> pure (DCUtRFailed "expected CONNECT message")
+      | hpType msg /= HPConnect -> pure (Left (FatalError "expected CONNECT message"))
       | otherwise -> do
-          writeIORef receivedRef (hpObsAddrs msg)
-          let connectResp = HolePunchMessage { hpType = HPConnect, hpObsAddrs = addrBytes }
-          writeHolePunchMessage stream connectResp
+          t1 <- getCurrentTime
+          let rtt = diffUTCTime t1 t0
+          mapM_ (`writeIORef` Just rtt) mRttRef
+          mapM_ (`writeIORef` hpObsAddrs msg) mCaptureRef
+          -- Step 3: Send SYNC
+          writeHolePunchMessage stream (HolePunchMessage { hpType = HPSync, hpObsAddrs = [] })
+          -- Step 4: Wait RTT/2, then dial all of A's addresses in parallel
+          threadDelay (max 0 (round (rtt * 1000000 / 2)))
+          dialAllConcurrently config (parseAddrs (hpObsAddrs msg))
+
+-- | One handler attempt: answer the CONNECT/SYNC exchange, then dial all of
+-- the initiator's addresses in parallel.
+handlerAttempt
+  :: DCUtRConfig
+  -> StreamIO
+  -> [Multiaddr]
+  -> Maybe (IORef [BS.ByteString])
+  -> IO (Either AttemptError ())
+handlerAttempt config stream addrs mCaptureRef = do
+  -- Step 1: Read B's CONNECT
+  result <- readHolePunchMessage stream maxDCUtRMessageSize
+  case result of
+    Left err -> pure (Left (FatalError ("failed to read CONNECT: " ++ err)))
+    Right msg
+      | hpType msg /= HPConnect -> pure (Left (FatalError "expected CONNECT message"))
+      | otherwise -> do
+          mapM_ (`writeIORef` hpObsAddrs msg) mCaptureRef
+          -- Step 2: Send our CONNECT response
+          writeHolePunchMessage stream (HolePunchMessage { hpType = HPConnect, hpObsAddrs = map toBytes addrs })
+          -- Step 3: Read SYNC
           syncResult <- readHolePunchMessage stream maxDCUtRMessageSize
           case syncResult of
-            Left err -> pure (DCUtRFailed $ "failed to read SYNC: " ++ err)
+            Left err -> pure (Left (FatalError ("failed to read SYNC: " ++ err)))
             Right syncMsg
-              | hpType syncMsg /= HPSync -> pure (DCUtRFailed "expected SYNC message")
-              | otherwise -> do
-                  let remoteAddrs = parseAddrs (hpObsAddrs msg)
-                  dialResult <- tryDialAddrs config remoteAddrs
-                  case dialResult of
-                    Right () -> pure DCUtRSuccess
-                    Left err -> pure (DCUtRFailed $ "dial failed: " ++ err)
+              | hpType syncMsg /= HPSync -> pure (Left (FatalError "expected SYNC message"))
+              | otherwise ->
+                  -- Step 4: Dial all of B's addresses in parallel immediately
+                  dialAllConcurrently config (parseAddrs (hpObsAddrs msg))
 
 -- Helpers
 
@@ -172,13 +180,17 @@ handleDCUtRCapture config stream addrs receivedRef = do
 parseAddrs :: [BS.ByteString] -> [Multiaddr]
 parseAddrs = foldr (\bs acc -> case fromBytes bs of Right a -> a : acc; Left _ -> acc) []
 
--- | Try to dial any of the given addresses. Returns Right () on first success.
-tryDialAddrs :: DCUtRConfig -> [Multiaddr] -> IO (Either String ())
-tryDialAddrs _config [] = pure (Left "no addresses to dial")
-tryDialAddrs config (addr:rest) = do
-  result <- dcDialer config addr
-  case result of
-    Right () -> pure (Right ())
-    Left _err
-      | null rest -> pure (Left "all dial attempts failed")
-      | otherwise -> tryDialAddrs config rest
+-- | Dial all addresses concurrently. The first successful dial wins and the
+-- remaining dials are cancelled; if every dial fails the attempt is a
+-- retryable 'DialError'.
+dialAllConcurrently :: DCUtRConfig -> [Multiaddr] -> IO (Either AttemptError ())
+dialAllConcurrently _config [] = pure (Left (DialError "no addresses to dial"))
+dialAllConcurrently config addrs =
+  bracket (mapM (async . dcDialer config) addrs) (mapM_ cancel) waitFirstSuccess
+  where
+    waitFirstSuccess [] = pure (Left (DialError "all dial attempts failed"))
+    waitFirstSuccess pending = do
+      (finished, result) <- waitAny pending
+      case result of
+        Right () -> pure (Right ())
+        Left _err -> waitFirstSuccess (filter (/= finished) pending)

--- a/src/LibP2P/NAT/DCUtR/Message.hs
+++ b/src/LibP2P/NAT/DCUtR/Message.hs
@@ -32,7 +32,8 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.Text (Text)
 import Data.Word (Word32)
-import Proto3.Wire.Decode (Parser, RawMessage, ParseError, at, one, repeated, parse)
+import qualified Data.Text.Lazy as TL
+import Proto3.Wire.Decode (Parser (..), RawMessage, ParseError (..), at, one, repeated, parse)
 import qualified Proto3.Wire.Decode as Decode
 import qualified Proto3.Wire.Encode as Encode
 import Proto3.Wire.Types (FieldNumber (..))
@@ -83,14 +84,15 @@ decodeHolePunchMessage :: ByteString -> Either ParseError HolePunchMessage
 decodeHolePunchMessage = parse holePunchParser
 
 holePunchParser :: Parser RawMessage HolePunchMessage
-holePunchParser = HolePunchMessage
-  <$> (toHPType <$> at (one Decode.uint32 0) (FieldNumber 1))
-  <*> at (repeated Decode.byteString) (FieldNumber 2)
-  where
-    toHPType :: Word32 -> HolePunchType
-    toHPType w = case wordToHolePunchType w of
-      Just t  -> t
-      Nothing -> HPConnect  -- default for unknown (should not happen per spec)
+holePunchParser = do
+  -- The type field is required; an absent field decodes as the default 0,
+  -- which is not a valid HolePunch type and is rejected below.
+  typeWord <- at (one Decode.uint32 0) (FieldNumber 1)
+  obsAddrs <- at (repeated Decode.byteString) (FieldNumber 2)
+  case wordToHolePunchType typeWord of
+    Just t  -> pure (HolePunchMessage t obsAddrs)
+    Nothing -> Parser $ const $ Left $
+      WireTypeError (TL.pack ("unknown or missing HolePunch type: " ++ show typeWord))
 
 -- Wire framing
 

--- a/test/LibP2P/NAT/DCUtR/DCUtRSpec.hs
+++ b/test/LibP2P/NAT/DCUtR/DCUtRSpec.hs
@@ -3,9 +3,15 @@ module LibP2P.NAT.DCUtR.DCUtRSpec (spec) where
 import Test.Hspec
 
 import qualified Data.ByteString as BS
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (withAsync, wait)
-import Control.Concurrent.STM (newTQueueIO, atomically, writeTQueue, readTQueue, TQueue)
-import Data.IORef (newIORef, readIORef, modifyIORef')
+import Control.Concurrent.STM
+  ( newTQueueIO, atomically, writeTQueue, readTQueue, TQueue
+  , newTVarIO, readTVarIO, readTVar, writeTVar, modifyTVar', registerDelay, retry
+  )
+import Control.Monad (when)
+import Data.IORef (newIORef, readIORef, modifyIORef', atomicModifyIORef')
+import Data.Time.Clock (getCurrentTime, diffUTCTime)
 import Data.Word (Word8)
 import LibP2P.NAT.DCUtR.Message
 import LibP2P.NAT.DCUtR
@@ -45,13 +51,13 @@ spec = do
       dialedByA <- newIORef ([] :: [Multiaddr])
       dialedByB <- newIORef ([] :: [Multiaddr])
       let configA = DCUtRConfig
-            { dcMaxRetries = 3
+            { dcMaxAttempts = 3
             , dcDialer = \addr -> do
                 modifyIORef' dialedByA (addr :)
                 pure (Right ())
             }
           configB = DCUtRConfig
-            { dcMaxRetries = 3
+            { dcMaxAttempts = 3
             , dcDialer = \addr -> do
                 modifyIORef' dialedByB (addr :)
                 pure (Right ())
@@ -78,8 +84,8 @@ spec = do
 
     it "initiator sends CONNECT, handler responds with CONNECT" $ do
       (streamA, streamB) <- mkStreamPair
-      let configA = DCUtRConfig { dcMaxRetries = 1, dcDialer = \_ -> pure (Right ()) }
-          configB = DCUtRConfig { dcMaxRetries = 1, dcDialer = \_ -> pure (Right ()) }
+      let configA = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
+          configB = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
           addrsA = [addrA]
           addrsB = [addrB]
       withAsync (initiateDCUtR configB streamB addrsB) $ \_ ->
@@ -92,11 +98,11 @@ spec = do
     it "handles dial failure gracefully" $ do
       (streamA, streamB) <- mkStreamPair
       let configA = DCUtRConfig
-            { dcMaxRetries = 1
+            { dcMaxAttempts = 1
             , dcDialer = \_ -> pure (Left "dial failed")
             }
           configB = DCUtRConfig
-            { dcMaxRetries = 1
+            { dcMaxAttempts = 1
             , dcDialer = \_ -> pure (Left "dial failed")
             }
           addrsA = [addrA]
@@ -117,8 +123,8 @@ spec = do
     it "measures non-negative RTT" $ do
       (streamA, streamB) <- mkStreamPair
       rttRef <- newIORef Nothing
-      let configA = DCUtRConfig { dcMaxRetries = 1, dcDialer = \_ -> pure (Right ()) }
-          configB = DCUtRConfig { dcMaxRetries = 1, dcDialer = \_ -> pure (Right ()) }
+      let configA = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
+          configB = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
           addrsA = [addrA]
           addrsB = [addrB]
       withAsync (initiateDCUtRWithRTT configB streamB addrsB rttRef) $ \_ ->
@@ -133,9 +139,9 @@ spec = do
     it "initiator receives correct addresses from handler" $ do
       (streamA, streamB) <- mkStreamPair
       receivedAddrsRef <- newIORef ([] :: [BS.ByteString])
-      let configA = DCUtRConfig { dcMaxRetries = 1, dcDialer = \_ -> pure (Right ()) }
+      let configA = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
           configB = DCUtRConfig
-            { dcMaxRetries = 1
+            { dcMaxAttempts = 1
             , dcDialer = \_ -> pure (Right ())
             }
           addrsA = [addrA]
@@ -152,8 +158,8 @@ spec = do
     it "handler receives correct addresses from initiator" $ do
       (streamA, streamB) <- mkStreamPair
       receivedAddrsRef <- newIORef ([] :: [BS.ByteString])
-      let configA = DCUtRConfig { dcMaxRetries = 1, dcDialer = \_ -> pure (Right ()) }
-          configB = DCUtRConfig { dcMaxRetries = 1, dcDialer = \_ -> pure (Right ()) }
+      let configA = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
+          configB = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
           addrsA = [addrA]
           addrsB = [addrB]
       withAsync (initiateDCUtR configB streamB addrsB) $ \_ ->
@@ -163,6 +169,132 @@ spec = do
           -- Handler should have received B's addresses
           length received `shouldSatisfy` (> 0)
           received `shouldBe` [toBytes addrB]
+
+  describe "DCUtR parallel dialing" $ do
+    it "dials all exchanged addresses concurrently" $ do
+      (streamA, streamB) <- mkStreamPair
+      let n = 3 :: Int
+      inFlight <- newTVarIO (0 :: Int)
+      allConcurrent <- newTVarIO False
+      -- Barrier dialer: succeeds only if all n dials are in flight at the
+      -- same time. A sequential dialer never has more than one in flight
+      -- and times out.
+      let barrierDialer _addr = do
+            atomically $ modifyTVar' inFlight (+ 1)
+            timedOut <- registerDelay 1000000
+            ok <- atomically $ do
+              c <- readTVar inFlight
+              expired <- readTVar timedOut
+              if c >= n
+                then pure True
+                else if expired then pure False else retry
+            atomically $ modifyTVar' inFlight (subtract 1)
+            when ok $ atomically $ writeTVar allConcurrent True
+            pure (if ok then Right () else Left "dial did not overlap with the others")
+          configA = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
+          configB = DCUtRConfig { dcMaxAttempts = 1, dcDialer = barrierDialer }
+          -- Handler advertises three addresses; initiator must dial them all
+          -- simultaneously.
+          addrsA = [Multiaddr [IP4 0xCB007105, TCP p] | p <- [4001, 4002, 4003]]
+      withAsync (initiateDCUtR configB streamB [addrB]) $ \initiatorAsync ->
+        withAsync (handleDCUtR configA streamA addrsA) $ \handlerAsync -> do
+          resultB <- wait initiatorAsync
+          _ <- wait handlerAsync
+          resultB `shouldBe` DCUtRSuccess
+          wasConcurrent <- readTVarIO allConcurrent
+          wasConcurrent `shouldBe` True
+
+    it "first successful dial wins without waiting for slow addresses" $ do
+      (streamA, streamB) <- mkStreamPair
+      let slowAddr = Multiaddr [IP4 0xCB007105, TCP 4001]
+          fastAddr = Multiaddr [IP4 0xCB007105, TCP 4002]
+          dialerB addr
+            | addr == slowAddr = threadDelay 3000000 >> pure (Left "slow dial timed out")
+            | otherwise = pure (Right ())
+          configA = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
+          configB = DCUtRConfig { dcMaxAttempts = 1, dcDialer = dialerB }
+      t0 <- getCurrentTime
+      withAsync (initiateDCUtR configB streamB [addrB]) $ \initiatorAsync ->
+        withAsync (handleDCUtR configA streamA [slowAddr, fastAddr]) $ \handlerAsync -> do
+          resultB <- wait initiatorAsync
+          _ <- wait handlerAsync
+          resultB `shouldBe` DCUtRSuccess
+      t1 <- getCurrentTime
+      diffUTCTime t1 t0 `shouldSatisfy` (< 2)
+
+  describe "DCUtR retries" $ do
+    it "retries the full exchange up to the configured attempt count" $ do
+      (streamA, streamB) <- mkStreamPair
+      bWrites <- newIORef (0 :: Int)
+      bDials <- newIORef (0 :: Int)
+      aDials <- newIORef (0 :: Int)
+      -- Count initiator writes: each attempt re-runs the CONNECT/SYNC
+      -- exchange, so 3 attempts must produce 6 writes (CONNECT + SYNC each).
+      let streamB' = streamB
+            { streamWrite = \bs -> modifyIORef' bWrites (+ 1) >> streamWrite streamB bs }
+          configB = DCUtRConfig
+            { dcMaxAttempts = 3
+            , dcDialer = \_ -> modifyIORef' bDials (+ 1) >> pure (Left "punch failed")
+            }
+          configA = DCUtRConfig
+            { dcMaxAttempts = 3
+            , dcDialer = \_ -> modifyIORef' aDials (+ 1) >> pure (Left "punch failed")
+            }
+      withAsync (initiateDCUtR configB streamB' [addrB]) $ \initiatorAsync ->
+        withAsync (handleDCUtR configA streamA [addrA]) $ \handlerAsync -> do
+          resultB <- wait initiatorAsync
+          resultA <- wait handlerAsync
+          case resultB of
+            DCUtRFailed _ -> pure ()
+            DCUtRSuccess -> expectationFailure "Initiator should fail after all attempts"
+          case resultA of
+            DCUtRFailed _ -> pure ()
+            DCUtRSuccess -> expectationFailure "Handler should fail after all attempts"
+          readIORef bDials >>= (`shouldBe` 3)
+          readIORef aDials >>= (`shouldBe` 3)
+          readIORef bWrites >>= (`shouldBe` 6)
+
+    it "succeeds when a retry attempt connects" $ do
+      (streamA, streamB) <- mkStreamPair
+      bCalls <- newIORef (0 :: Int)
+      aCalls <- newIORef (0 :: Int)
+      -- Both sides fail the first punch and succeed on the second.
+      let flakyDialer ref _ = do
+            n <- atomicModifyIORef' ref (\c -> (c + 1, c + 1))
+            pure (if n >= 2 then Right () else Left "first punch failed")
+          configB = DCUtRConfig { dcMaxAttempts = 3, dcDialer = flakyDialer bCalls }
+          configA = DCUtRConfig { dcMaxAttempts = 3, dcDialer = flakyDialer aCalls }
+      withAsync (initiateDCUtR configB streamB [addrB]) $ \initiatorAsync ->
+        withAsync (handleDCUtR configA streamA [addrA]) $ \handlerAsync -> do
+          resultB <- wait initiatorAsync
+          resultA <- wait handlerAsync
+          resultB `shouldBe` DCUtRSuccess
+          resultA `shouldBe` DCUtRSuccess
+          readIORef bCalls >>= (`shouldBe` 2)
+          readIORef aCalls >>= (`shouldBe` 2)
+
+  describe "DCUtR RTT timer placement" $ do
+    it "includes time spent writing CONNECT in the RTT measurement" $ do
+      (streamA, streamB) <- mkStreamPair
+      firstWrite <- newIORef True
+      -- Simulate a relayed write that blocks for 100 ms on the CONNECT.
+      let slowStreamB = streamB
+            { streamWrite = \bs -> do
+                isFirst <- atomicModifyIORef' firstWrite (\f -> (False, f))
+                when isFirst (threadDelay 100000)
+                streamWrite streamB bs
+            }
+          configA = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
+          configB = DCUtRConfig { dcMaxAttempts = 1, dcDialer = \_ -> pure (Right ()) }
+      rttRef <- newIORef Nothing
+      withAsync (initiateDCUtRWithRTT configB slowStreamB [addrB] rttRef) $ \initiatorAsync ->
+        withAsync (handleDCUtR configA streamA [addrA]) $ \handlerAsync -> do
+          _ <- wait initiatorAsync
+          _ <- wait handlerAsync
+          mRTT <- readIORef rttRef
+          case mRTT of
+            Just rtt -> rtt `shouldSatisfy` (>= 0.1)
+            Nothing -> expectationFailure "RTT not measured"
 
   describe "DCUtR constants" $ do
     it "max message size is 4096 bytes" $ do

--- a/test/LibP2P/NAT/DCUtR/MessageSpec.hs
+++ b/test/LibP2P/NAT/DCUtR/MessageSpec.hs
@@ -80,6 +80,18 @@ spec = do
           decoded = decodeHolePunchMessage encoded
       decoded `shouldBe` Right connectManyAddrs
 
+    it "rejects a message with an unknown type value" $ do
+      -- field 1 (varint): tag 0x08, value 200 (not CONNECT=100 or SYNC=300)
+      let bytes = BS.pack [0x08, 0xC8, 0x01]
+      case decodeHolePunchMessage bytes of
+        Left _ -> pure ()
+        Right msg -> expectationFailure $ "Decoded unknown type as: " ++ show msg
+
+    it "rejects a message missing the type field" $ do
+      case decodeHolePunchMessage BS.empty of
+        Left _ -> pure ()
+        Right msg -> expectationFailure $ "Decoded missing type as: " ++ show msg
+
   describe "DCUtR Message type wire values" $ do
     it "CONNECT maps to wire value 100" $ do
       holePunchTypeToWord HPConnect `shouldBe` 100


### PR DESCRIPTION
## Summary

DCUtR dialled candidate addresses sequentially, so any address after the first was out of sync by one dial timeout — breaking the simultaneous-open property hole punching depends on. `dcMaxRetries` was configured but never read.

## Changes

- **Parallel dials**: all exchanged addresses are now dialled concurrently via `async`; the first successful dial wins and the remaining dials are cancelled (spec: the steps run "in parallel for every address").
- **Retries**: `dcMaxRetries` renamed to `dcMaxAttempts` and implemented — the full CONNECT/SYNC exchange is re-run per attempt so RTT is re-measured (spec: 3 attempts total = 1 initial + 2 retries). Only dial failures retry; protocol errors abort immediately.
- **RTT timer placement**: the timer now starts before writing CONNECT, so a blocking relayed write counts towards the RTT (matches go-libp2p).
- **Strict decode**: HolePunch messages with an unknown or missing `type` field are now a decode error instead of silently becoming CONNECT.
- Test suite built with `-threaded` for the new concurrency tests.

## Testing

TDD: 7 new tests written first (concurrent dial barrier, first-success-wins timing, retry attempt/exchange counts, retry-then-succeed, RTT timer placement, 2 strict-decode cases), confirmed red, then implemented. Full suite: 636 examples, 0 failures (GHC 9.10.1).

Closes #153