### PR TITLE
fix: import private keys from other libp2p implementations

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -136,6 +136,7 @@ test-suite libp2p-hs-test
     LibP2P.Crypto.RSASpec
     LibP2P.Crypto.Secp256k1Spec
     LibP2P.Crypto.ECDSASpec
+    LibP2P.Crypto.KeyImportSpec
     LibP2P.MultistreamSelect.NegotiationSpec
     LibP2P.Yamux.FrameSpec
     LibP2P.Yamux.StreamSpec

--- a/src/LibP2P/Crypto/ECDSA.hs
+++ b/src/LibP2P/Crypto/ECDSA.hs
@@ -2,7 +2,9 @@
 --
 -- Wire formats follow the libp2p peer-ids spec (matching go-libp2p):
 -- - Public key: DER-encoded SubjectPublicKeyInfo (PKIX), uncompressed point.
--- - Private key: 32-byte big-endian scalar.
+-- - Private key: DER-encoded RFC 5915 ECPrivateKey (SEC1), with the named
+--   curve parameters and the public key included, as emitted by Go's
+--   x509.MarshalECPrivateKey.
 -- - Signatures: ECDSA over SHA-256, DER-encoded (SEQUENCE { r, s }).
 --
 -- Operates on raw 'ByteString' so this module has no dependency on
@@ -11,6 +13,7 @@ module LibP2P.Crypto.ECDSA
   ( generate
   , signIO
   , verify
+  , derivePublicKey
   ) where
 
 import Crypto.Hash.Algorithms (SHA256 (..))
@@ -27,8 +30,9 @@ import Crypto.PubKey.ECC.Types
   )
 import Crypto.Random (getRandomBytes)
 import Data.ASN1.BinaryEncoding (DER (..))
+import Data.ASN1.BitArray (toBitArray)
 import Data.ASN1.Encoding (decodeASN1', encodeASN1')
-import Data.ASN1.Types (ASN1 (..), ASN1ConstructionType (..), fromASN1, toASN1)
+import Data.ASN1.Types (ASN1 (..), ASN1Class (..), ASN1ConstructionType (..), fromASN1, toASN1)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.X509 (PubKey (PubKeyEC), PubKeyEC (PubKeyEC_Named), SerializedPoint (..))
@@ -42,12 +46,16 @@ curve = getCurveByName SEC_p256r1
 curveOrder :: Integer
 curveOrder = ecc_n (common_curve curve)
 
--- | Generate a new P-256 key pair, returning (public SPKI DER, 32-byte private).
+-- | ASN.1 OID for prime256v1 / secp256r1.
+p256Oid :: [Integer]
+p256Oid = [1, 2, 840, 10045, 3, 1, 7]
+
+-- | Generate a new P-256 key pair, returning (public SPKI DER, private SEC1 DER).
 generate :: IO (ByteString, ByteString)
 generate = do
   d <- randomScalar
   let q = generateQ curve d
-  pure (encodePublicKey q, i2ospOf_ 32 d)
+  pure (encodePublicKey q, encodePrivateKey d q)
 
 -- | Draw a private scalar in [1, n-1] via rejection sampling.
 randomScalar :: IO Integer
@@ -56,15 +64,20 @@ randomScalar = do
   let d = os2ip bytes
   if d >= 1 && d < curveOrder then pure d else randomScalar
 
--- | Sign a message with a 32-byte private scalar (ECDSA/SHA-256, DER output).
+-- | Sign a message with a SEC1-DER private key (ECDSA/SHA-256, DER output).
 -- Runs in IO because ECDSA signing requires a random nonce.
 signIO :: ByteString -> ByteString -> IO (Either String ByteString)
-signIO privRaw msg
-  | BS.length privRaw /= 32 = pure (Left "ECDSA.signIO: private key must be 32 bytes")
-  | otherwise = do
-      let priv = ECDSA.PrivateKey curve (os2ip privRaw)
+signIO privDer msg =
+  case decodePrivateKey privDer of
+    Left err -> pure (Left err)
+    Right d -> do
+      let priv = ECDSA.PrivateKey curve d
       sig <- ECDSA.sign priv SHA256 msg
       pure (Right (encodeSignature sig))
+
+-- | Derive the SPKI-DER public key from a SEC1-DER private key.
+derivePublicKey :: ByteString -> Either String ByteString
+derivePublicKey privDer = encodePublicKey . generateQ curve <$> decodePrivateKey privDer
 
 -- | Verify a DER signature against an SPKI-DER public key (ECDSA/SHA-256).
 verify :: ByteString -> ByteString -> ByteString -> Bool
@@ -76,10 +89,14 @@ verify pubDer msg sigDer =
 -- | Encode a curve point as DER SubjectPublicKeyInfo (uncompressed point).
 encodePublicKey :: Point -> ByteString
 encodePublicKey PointO = BS.empty
-encodePublicKey (Point x y) =
-  let uncompressed = BS.cons 0x04 (i2ospOf_ 32 x <> i2ospOf_ 32 y)
-      pub = PubKeyEC (PubKeyEC_Named SEC_p256r1 (SerializedPoint uncompressed))
+encodePublicKey q =
+  let pub = PubKeyEC (PubKeyEC_Named SEC_p256r1 (SerializedPoint (uncompressedPoint q)))
    in encodeASN1' DER (toASN1 pub [])
+
+-- | SEC1 uncompressed point encoding (0x04 || X || Y).
+uncompressedPoint :: Point -> ByteString
+uncompressedPoint PointO = BS.empty
+uncompressedPoint (Point x y) = BS.cons 0x04 (i2ospOf_ 32 x <> i2ospOf_ 32 y)
 
 -- | Decode a DER SubjectPublicKeyInfo into a curve point.
 decodePublicKey :: ByteString -> Either String Point
@@ -93,6 +110,43 @@ decodePublicKey bs =
           Nothing -> Left "ECDSA.decodePublicKey: invalid EC point"
       Right _ -> Left "ECDSA.decodePublicKey: not a named EC public key"
       Left err -> Left $ "ECDSA.decodePublicKey: " <> err
+
+-- | Encode a private scalar as an RFC 5915 ECPrivateKey DER, including the
+-- named-curve parameters and the public key (Go's x509.MarshalECPrivateKey
+-- layout, which the peer-ids spec test vector uses).
+encodePrivateKey :: Integer -> Point -> ByteString
+encodePrivateKey d q =
+  encodeASN1'
+    DER
+    [ Start Sequence
+    , IntVal 1 -- ecPrivkeyVer1
+    , OctetString (i2ospOf_ 32 d)
+    , Start (Container Context 0)
+    , OID p256Oid
+    , End (Container Context 0)
+    , Start (Container Context 1)
+    , BitString (toBitArray (uncompressedPoint q) 0)
+    , End (Container Context 1)
+    , End Sequence
+    ]
+
+-- | Decode an RFC 5915 ECPrivateKey DER into the private scalar.
+-- The curve parameters and public key fields are optional; when the curve
+-- is present it must be P-256.
+decodePrivateKey :: ByteString -> Either String Integer
+decodePrivateKey bs =
+  case decodeASN1' DER bs of
+    Left err -> Left $ "ECDSA.decodePrivateKey: " <> show err
+    Right (Start Sequence : IntVal 1 : OctetString priv : rest)
+      | BS.length priv /= 32 ->
+          Left "ECDSA.decodePrivateKey: expected a 32-byte P-256 scalar"
+      | otherwise -> os2ip priv <$ checkCurveOid rest
+    Right _ -> Left "ECDSA.decodePrivateKey: not an RFC 5915 ECPrivateKey"
+  where
+    checkCurveOid (Start (Container Context 0) : OID oid : End (Container Context 0) : _)
+      | oid == p256Oid = Right ()
+      | otherwise = Left "ECDSA.decodePrivateKey: unsupported curve (expected P-256)"
+    checkCurveOid _ = Right ()
 
 -- | Encode an ECDSA signature as DER SEQUENCE { r, s }.
 encodeSignature :: ECDSA.Signature -> ByteString

--- a/src/LibP2P/Crypto/Ed25519.hs
+++ b/src/LibP2P/Crypto/Ed25519.hs
@@ -20,6 +20,9 @@ generateKeyPair = do
   pure (keyPairFromSeed seed)
 
 -- | Create an Ed25519 key pair from a 32-byte seed.
+--
+-- The private key bytes are stored in the 64-byte wire form required by the
+-- peer-ids spec: @seed || public key@.
 keyPairFromSeed :: ByteString -> Either String KeyPair
 keyPairFromSeed seed
   | BS.length seed /= 32 = Left "keyPairFromSeed: seed must be 32 bytes"
@@ -31,5 +34,5 @@ keyPairFromSeed seed
            in Right $
                 KeyPair
                   { kpPublic = PublicKey Ed25519 (convert pk)
-                  , kpPrivate = PrivateKey Ed25519 (convert sk)
+                  , kpPrivate = PrivateKey Ed25519 (convert sk <> convert pk)
                   }

--- a/src/LibP2P/Crypto/Key.hs
+++ b/src/LibP2P/Crypto/Key.hs
@@ -7,6 +7,7 @@ module LibP2P.Crypto.Key
   , publicKey
   , sign
   , verify
+  , keyPairFromPrivateKey
   , generateRSAKeyPair
   , generateSecp256k1KeyPair
   , generateECDSAKeyPair
@@ -16,6 +17,7 @@ import qualified Crypto.Error as CE
 import qualified Crypto.PubKey.Ed25519 as Ed
 import Data.ByteArray (convert)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import qualified LibP2P.Crypto.ECDSA as ECDSA
 import qualified LibP2P.Crypto.RSA as RSA
 import qualified LibP2P.Crypto.Secp256k1 as Secp256k1
@@ -58,13 +60,16 @@ publicKey = kpPublic
 -- ('LibP2P.Crypto.Secp256k1.signIO'); local peer identities in this
 -- implementation are Ed25519. Returns Left on invalid key bytes.
 sign :: PrivateKey -> ByteString -> Either String ByteString
-sign (PrivateKey Ed25519 skRaw) msg =
-  case CE.eitherCryptoError (Ed.secretKey skRaw) of
-    Left err -> Left $ "sign: invalid secret key: " <> show err
-    Right sk ->
-      let pk = Ed.toPublic sk
-          sig = Ed.sign sk pk msg
-       in Right (convert sig)
+sign (PrivateKey Ed25519 skRaw) msg
+  | BS.length skRaw /= 64 =
+      Left "sign: Ed25519 private key must be 64 bytes (seed || public key)"
+  | otherwise =
+      case CE.eitherCryptoError (Ed.secretKey (BS.take 32 skRaw)) of
+        Left err -> Left $ "sign: invalid secret key: " <> show err
+        Right sk ->
+          let pk = Ed.toPublic sk
+              sig = Ed.sign sk pk msg
+           in Right (convert sig)
 sign (PrivateKey RSA skRaw) msg = RSA.sign skRaw msg
 sign (PrivateKey Secp256k1 _) _ =
   Left "sign: secp256k1 signing runs in IO (LibP2P.Crypto.Secp256k1.signIO)"
@@ -81,6 +86,48 @@ verify (PublicKey Ed25519 pkRaw) msg sigRaw =
 verify (PublicKey RSA pkRaw) msg sigRaw = RSA.verify pkRaw msg sigRaw
 verify (PublicKey Secp256k1 pkRaw) msg sigRaw = Secp256k1.verify pkRaw msg sigRaw
 verify (PublicKey ECDSA pkRaw) msg sigRaw = ECDSA.verify pkRaw msg sigRaw
+
+-- | Reconstruct a full key pair from a private key in libp2p wire format,
+-- deriving the public key. This is the import path for keys produced by
+-- other implementations (the peer-ids spec requires that implementations
+-- can produce the public key from the private key).
+keyPairFromPrivateKey :: PrivateKey -> Either String KeyPair
+keyPairFromPrivateKey (PrivateKey Ed25519 raw) = do
+  privBytes <- normalizeEd25519Private raw
+  let (seed, embeddedPk) = BS.splitAt 32 privBytes
+  case CE.eitherCryptoError (Ed.secretKey seed) of
+    Left err -> Left $ "keyPairFromPrivateKey: " <> show err
+    Right sk
+      | pkRaw /= embeddedPk ->
+          Left "keyPairFromPrivateKey: Ed25519 public key does not match the seed"
+      | otherwise ->
+          Right (KeyPair (PublicKey Ed25519 pkRaw) (PrivateKey Ed25519 privBytes))
+      where
+        pkRaw = convert (Ed.toPublic sk)
+keyPairFromPrivateKey (PrivateKey RSA raw) =
+  (\pub -> KeyPair (PublicKey RSA pub) (PrivateKey RSA raw)) <$> RSA.derivePublicKey raw
+keyPairFromPrivateKey (PrivateKey Secp256k1 raw) =
+  (\pub -> KeyPair (PublicKey Secp256k1 pub) (PrivateKey Secp256k1 raw))
+    <$> Secp256k1.derivePublicKey raw
+keyPairFromPrivateKey (PrivateKey ECDSA raw) =
+  (\pub -> KeyPair (PublicKey ECDSA pub) (PrivateKey ECDSA raw)) <$> ECDSA.derivePublicKey raw
+
+-- | Normalize Ed25519 private key bytes to the preferred 64-byte form
+-- (seed || public key). The legacy 96-byte form (seed || pub || pub) is
+-- accepted after verifying that both embedded public keys are identical,
+-- per the peer-ids spec.
+normalizeEd25519Private :: ByteString -> Either String ByteString
+normalizeEd25519Private raw
+  | BS.length raw == 64 = Right raw
+  | BS.length raw == 96 =
+      let (privBytes, redundantPk) = BS.splitAt 64 raw
+       in if BS.drop 32 privBytes == redundantPk
+            then Right privBytes
+            else Left "normalizeEd25519Private: legacy 96-byte key has mismatched public keys"
+  | otherwise =
+      Left $
+        "normalizeEd25519Private: private key must be 64 or 96 bytes, got "
+          <> show (BS.length raw)
 
 -- | Generate a new RSA key pair (2048-bit) with libp2p wire-format key bytes.
 generateRSAKeyPair :: IO KeyPair

--- a/src/LibP2P/Crypto/Protobuf.hs
+++ b/src/LibP2P/Crypto/Protobuf.hs
@@ -4,9 +4,16 @@
 -- - Minimal varint encoding
 -- - Fields in field number order (Type=1, Data=2)
 -- - All fields present, no extras
+--
+-- Both messages share the same wire layout (per the peer-ids spec):
+--
+-- > message PublicKey  { required KeyType Type = 1; required bytes Data = 2; }
+-- > message PrivateKey { required KeyType Type = 1; required bytes Data = 2; }
 module LibP2P.Crypto.Protobuf
   ( encodePublicKey
   , decodePublicKey
+  , encodePrivateKey
+  , decodePrivateKey
   ) where
 
 import Data.ByteString (ByteString)
@@ -14,7 +21,7 @@ import qualified Data.ByteString as BS
 import Data.Word (Word64, Word8)
 import Numeric (showHex)
 import LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
-import LibP2P.Crypto.Key (KeyType (..), PublicKey (..))
+import LibP2P.Crypto.Key (KeyType (..), PrivateKey (..), PublicKey (..))
 
 -- | Protobuf KeyType enum values (per libp2p peer-ids spec: RSA=0, Ed25519=1,
 -- Secp256k1=2, ECDSA=3).
@@ -32,12 +39,33 @@ keyTypeFromProto 3 = Right ECDSA
 keyTypeFromProto n = Left $ "unknown KeyType: " <> show n
 
 -- | Deterministic protobuf encoding of a PublicKey message.
+encodePublicKey :: PublicKey -> ByteString
+encodePublicKey (PublicKey kt rawKey) = encodeKeyMessage kt rawKey
+
+-- | Decode a protobuf-encoded PublicKey message.
+decodePublicKey :: ByteString -> Either String PublicKey
+decodePublicKey bs = uncurry PublicKey <$> decodeKeyMessage "decodePublicKey" bs
+
+-- | Deterministic protobuf encoding of a PrivateKey message. Note that
+-- PrivateKey messages are never sent over the wire; this is the on-disk
+-- format shared by libp2p implementations.
+encodePrivateKey :: PrivateKey -> ByteString
+encodePrivateKey (PrivateKey kt rawKey) = encodeKeyMessage kt rawKey
+
+-- | Decode a protobuf-encoded PrivateKey message, e.g. a key file written
+-- by another implementation. The Data field is returned as-is; use
+-- 'LibP2P.Crypto.Key.keyPairFromPrivateKey' to validate it and derive the
+-- public key.
+decodePrivateKey :: ByteString -> Either String PrivateKey
+decodePrivateKey bs = uncurry PrivateKey <$> decodeKeyMessage "decodePrivateKey" bs
+
+-- | Shared deterministic encoding of the key messages.
 --
 -- Layout:
 --   Field 1 (Type): tag=0x08 (field 1, wire type 0=varint), value=keytype
 --   Field 2 (Data): tag=0x12 (field 2, wire type 2=length-delimited), length, bytes
-encodePublicKey :: PublicKey -> ByteString
-encodePublicKey (PublicKey kt rawKey) =
+encodeKeyMessage :: KeyType -> ByteString -> ByteString
+encodeKeyMessage kt rawKey =
   -- Field 1: tag 0x08 + varint value
   BS.singleton 0x08 <> encodeUvarint (keyTypeToProto kt)
     -- Field 2: tag 0x12 + varint length + raw bytes
@@ -45,9 +73,9 @@ encodePublicKey (PublicKey kt rawKey) =
     <> encodeUvarint (fromIntegral (BS.length rawKey))
     <> rawKey
 
--- | Decode a protobuf-encoded PublicKey message.
-decodePublicKey :: ByteString -> Either String PublicKey
-decodePublicKey bs = do
+-- | Shared decoding of the key messages; @ctx@ names the caller in errors.
+decodeKeyMessage :: String -> ByteString -> Either String (KeyType, ByteString)
+decodeKeyMessage ctx bs = do
   -- Field 1: expect tag 0x08
   (tag1, rest1) <- takeExpectedByte 0x08 bs "expected tag 0x08 for field 1"
   _ <- pure tag1
@@ -58,14 +86,14 @@ decodePublicKey bs = do
   (dataLen, rest4) <- decodeUvarint rest3
   let len = fromIntegral dataLen :: Int
   if BS.length rest4 < len
-    then Left "decodePublicKey: not enough bytes for key data"
+    then Left $ ctx <> ": not enough bytes for key data"
     else
       let keyData = BS.take len rest4
-       in Right (PublicKey kt keyData)
+       in Right (kt, keyData)
   where
     takeExpectedByte :: Word8 -> ByteString -> String -> Either String (Word8, ByteString)
     takeExpectedByte expected input msg
-      | BS.null input = Left $ "decodePublicKey: " <> msg <> " (empty input)"
+      | BS.null input = Left $ ctx <> ": " <> msg <> " (empty input)"
       | BS.head input /= expected =
-          Left $ "decodePublicKey: " <> msg <> " (got 0x" <> showHex (BS.head input) ")"
+          Left $ ctx <> ": " <> msg <> " (got 0x" <> showHex (BS.head input) ")"
       | otherwise = Right (expected, BS.tail input)

--- a/src/LibP2P/Crypto/RSA.hs
+++ b/src/LibP2P/Crypto/RSA.hs
@@ -11,9 +11,11 @@ module LibP2P.Crypto.RSA
   ( generate
   , sign
   , verify
+  , derivePublicKey
   ) where
 
 import Crypto.Hash.Algorithms (SHA256 (..))
+import Crypto.Number.Basic (numBytes)
 import qualified Crypto.PubKey.RSA as RSA
 import qualified Crypto.PubKey.RSA.PKCS15 as PKCS15
 import Data.ASN1.BinaryEncoding (DER (..))
@@ -26,7 +28,8 @@ import Data.X509 (PubKey (PubKeyRSA))
 publicExponent :: Integer
 publicExponent = 0x10001
 
--- | Default modulus size in bytes (2048-bit).
+-- | Modulus size in bytes for locally generated keys (2048-bit).
+-- Imported keys may use any modulus size; see 'decodePrivateKey'.
 keySizeBytes :: Int
 keySizeBytes = 256
 
@@ -51,6 +54,10 @@ verify pubDer msg sig =
   case decodePublicKey pubDer of
     Left _ -> False
     Right pub -> PKCS15.verify (Just SHA256) pub msg sig
+
+-- | Derive the SPKI-DER public key from a PKCS#1-DER private key.
+derivePublicKey :: ByteString -> Either String ByteString
+derivePublicKey privDer = encodePublicKey . RSA.private_pub <$> decodePrivateKey privDer
 
 -- | Encode an RSA public key as DER SubjectPublicKeyInfo.
 encodePublicKey :: RSA.PublicKey -> ByteString
@@ -105,7 +112,9 @@ decodePrivateKey bs =
         Right
           RSA.PrivateKey
             { RSA.private_pub =
-                RSA.PublicKey {RSA.public_size = keySizeBytes, RSA.public_n = n, RSA.public_e = e}
+                -- The modulus size must be derived from n itself: keys from
+                -- other implementations are not necessarily 2048-bit.
+                RSA.PublicKey {RSA.public_size = numBytes n, RSA.public_n = n, RSA.public_e = e}
             , RSA.private_d = d
             , RSA.private_p = p
             , RSA.private_q = q

--- a/src/LibP2P/Crypto/Secp256k1.hs
+++ b/src/LibP2P/Crypto/Secp256k1.hs
@@ -11,6 +11,7 @@ module LibP2P.Crypto.Secp256k1
   ( generate
   , signIO
   , verify
+  , derivePublicKey
   ) where
 
 import Crypto.Hash.Algorithms (SHA256 (..))
@@ -72,6 +73,12 @@ signIO privRaw msg
       let priv = ECDSA.PrivateKey curve (os2ip privRaw)
       sig <- ECDSA.sign priv SHA256 msg
       pure (Right (encodeSignature sig))
+
+-- | Derive the 33-byte compressed public key from a 32-byte private scalar.
+derivePublicKey :: ByteString -> Either String ByteString
+derivePublicKey privRaw
+  | BS.length privRaw /= 32 = Left "Secp256k1.derivePublicKey: private key must be 32 bytes"
+  | otherwise = Right (encodePoint (generateQ curve (os2ip privRaw)))
 
 -- | Verify a DER signature against a 33-byte compressed public key (ECDSA/SHA-256).
 verify :: ByteString -> ByteString -> ByteString -> Bool

--- a/test/LibP2P/Crypto/KeyImportSpec.hs
+++ b/test/LibP2P/Crypto/KeyImportSpec.hs
@@ -1,0 +1,273 @@
+-- | Cross-implementation private key import tests.
+--
+-- All fixtures are the official test vectors from the libp2p peer-ids spec
+-- (specs/peer-ids/peer-ids.md, "Test vectors"): hex-encoded protobuf
+-- PrivateKey/PublicKey messages produced by go-libp2p. The spec requires
+-- that implementations can produce the provided public key from the
+-- private key.
+module LibP2P.Crypto.KeyImportSpec (spec) where
+
+import Data.ByteArray.Encoding (Base (Base16), convertFromBase)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as C8
+import Data.Char (toLower)
+import qualified LibP2P.Crypto.ECDSA as ECDSA
+import LibP2P.Crypto.Key
+import LibP2P.Crypto.Protobuf
+import qualified LibP2P.Crypto.Secp256k1 as Secp256k1
+import Test.Hspec
+
+spec :: Spec
+spec = describe "private key import (peer-ids spec test vectors)" $ do
+  describe "Ed25519" $ do
+    it "derives the spec public key from the spec private key" $
+      withImported ed25519PrivHex $ \kp ->
+        encodePublicKey (kpPublic kp) `shouldBe` unhex ed25519PubHex
+
+    it "normalizes the private key to the 64-byte (seed || public key) form" $
+      withImported ed25519PrivHex $ \kp ->
+        skBytes (kpPrivate kp) `shouldBe` unhex ed25519RawPrivHex
+
+    it "signs with the imported private key; the spec public key verifies" $
+      withImported ed25519PrivHex $ \kp -> do
+        let msg = "cross-implementation ed25519" :: ByteString
+        case sign (kpPrivate kp) msg of
+          Left err -> expectationFailure err
+          Right sig -> verifyWithSpecPub ed25519PubHex msg sig
+
+    it "accepts the legacy 96-byte form when both public keys match" $ do
+      let raw96 = unhex ed25519RawPrivHex <> unhex ed25519RawPubHex
+      case keyPairFromPrivateKey (PrivateKey Ed25519 raw96) of
+        Left err -> expectationFailure err
+        Right kp -> do
+          skBytes (kpPrivate kp) `shouldBe` unhex ed25519RawPrivHex
+          pkBytes (kpPublic kp) `shouldBe` unhex ed25519RawPubHex
+
+    it "rejects the legacy 96-byte form when the public keys differ" $ do
+      let raw96 = unhex ed25519RawPrivHex <> BS.replicate 32 0x00
+      shouldFailImport (PrivateKey Ed25519 raw96)
+
+    it "rejects a bare 32-byte seed (invalid per the spec)" $ do
+      let seed = BS.take 32 (unhex ed25519RawPrivHex)
+      shouldFailImport (PrivateKey Ed25519 seed)
+
+  describe "ECDSA (P-256)" $ do
+    it "derives the spec public key from the spec DER private key" $
+      withImported ecdsaPrivHex $ \kp ->
+        encodePublicKey (kpPublic kp) `shouldBe` unhex ecdsaPubHex
+
+    it "signs with the imported DER private key; the spec public key verifies" $
+      withImported ecdsaPrivHex $ \kp -> do
+        let msg = "cross-implementation ecdsa" :: ByteString
+        signed <- ECDSA.signIO (skBytes (kpPrivate kp)) msg
+        case signed of
+          Left err -> expectationFailure err
+          Right sig -> verifyWithSpecPub ecdsaPubHex msg sig
+
+    it "round-trips locally generated key pairs through the import path" $ do
+      kp <- generateECDSAKeyPair
+      case keyPairFromPrivateKey (kpPrivate kp) of
+        Left err -> expectationFailure err
+        Right kp' -> pkBytes (kpPublic kp') `shouldBe` pkBytes (kpPublic kp)
+
+  describe "RSA (4096-bit spec vector)" $ do
+    it "signs with the imported private key (no hardcoded modulus size)" $
+      withImported rsaPrivHex $ \kp -> do
+        let msg = "cross-implementation rsa" :: ByteString
+        case sign (kpPrivate kp) msg of
+          Left err -> expectationFailure err
+          Right sig -> verifyWithSpecPub rsaPubHex msg sig
+
+    it "derives the spec public key from the spec private key" $
+      withImported rsaPrivHex $ \kp ->
+        encodePublicKey (kpPublic kp) `shouldBe` unhex rsaPubHex
+
+  describe "secp256k1" $ do
+    it "derives the spec public key from the spec private key" $
+      withImported secp256k1PrivHex $ \kp ->
+        encodePublicKey (kpPublic kp) `shouldBe` unhex secp256k1PubHex
+
+    it "signs with the imported private key; the spec public key verifies" $
+      withImported secp256k1PrivHex $ \kp -> do
+        let msg = "cross-implementation secp256k1" :: ByteString
+        signed <- Secp256k1.signIO (skBytes (kpPrivate kp)) msg
+        case signed of
+          Left err -> expectationFailure err
+          Right sig -> verifyWithSpecPub secp256k1PubHex msg sig
+
+  describe "PrivateKey protobuf" $ do
+    it "re-encodes every decoded spec vector byte-identically" $
+      mapM_ reencodesIdentically
+        [ed25519PrivHex, ecdsaPrivHex, rsaPrivHex, secp256k1PrivHex]
+
+    it "fails gracefully on an unknown key type" $ do
+      let bs = BS.pack [0x08, 0x63, 0x12, 0x00]
+      case decodePrivateKey bs of
+        Left _ -> pure ()
+        Right _ -> expectationFailure "expected decode to fail for unknown type"
+
+-- | Decode a protobuf PrivateKey vector, derive the key pair, and run a check.
+withImported :: String -> (KeyPair -> Expectation) -> Expectation
+withImported privHex check =
+  case decodePrivateKey (unhex privHex) >>= keyPairFromPrivateKey of
+    Left err -> expectationFailure err
+    Right kp -> check kp
+
+-- | Verify a signature against a spec PublicKey protobuf vector.
+verifyWithSpecPub :: String -> ByteString -> ByteString -> Expectation
+verifyWithSpecPub pubHex msg sig =
+  case decodePublicKey (unhex pubHex) of
+    Left err -> expectationFailure err
+    Right pub -> verify pub msg sig `shouldBe` True
+
+-- | decode >>> encode must reproduce the exact vector bytes.
+reencodesIdentically :: String -> Expectation
+reencodesIdentically privHex =
+  case decodePrivateKey (unhex privHex) of
+    Left err -> expectationFailure err
+    Right sk -> encodePrivateKey sk `shouldBe` unhex privHex
+
+-- | Importing this private key must be rejected.
+shouldFailImport :: PrivateKey -> Expectation
+shouldFailImport sk =
+  case keyPairFromPrivateKey sk of
+    Left _ -> pure ()
+    Right _ -> expectationFailure "expected key import to fail"
+
+unhex :: String -> ByteString
+unhex s = case convertFromBase Base16 (C8.pack (map toLower s)) of
+  Left err -> error ("invalid hex fixture: " <> err)
+  Right bs -> bs
+
+-- Ed25519: protobuf Data is seed (32) || public key (32).
+ed25519PrivHex :: String
+ed25519PrivHex =
+  "080112407e0830617c4a7de83925dfb2694556b12936c477a0e1feb2e148ec9da60fee7d"
+    <> "1ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e"
+
+ed25519PubHex :: String
+ed25519PubHex =
+  "080112201ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e"
+
+-- Raw (non-protobuf) forms of the Ed25519 vector, for legacy-format tests.
+ed25519RawPrivHex :: String
+ed25519RawPrivHex =
+  "7e0830617c4a7de83925dfb2694556b12936c477a0e1feb2e148ec9da60fee7d"
+    <> "1ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e"
+
+ed25519RawPubHex :: String
+ed25519RawPubHex =
+  "1ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e"
+
+-- ECDSA: protobuf Data is an RFC 5915 ECPrivateKey DER (prime256v1).
+ecdsaPrivHex :: String
+ecdsaPrivHex =
+  "08031279307702010104203E5B1FE9712E6C314942A750BD67485DE3C1EFE85B1BFB520A"
+    <> "E8F9AE3DFA4A4CA00A06082A8648CE3D030107A14403420004DE3D300FA36AE0E8F5D5"
+    <> "30899D83ABAB44ABF3161F162A4BC901D8E6ECDA020E8B6D5F8DA30525E71D6851510C"
+    <> "098E5C47C646A597FB4DCEC034E9F77C409E62"
+
+ecdsaPubHex :: String
+ecdsaPubHex =
+  "0803125b3059301306072a8648ce3d020106082a8648ce3d03010703420004de3d300fa3"
+    <> "6ae0e8f5d530899d83abab44abf3161f162a4bc901d8e6ecda020e8b6d5f8da30525e7"
+    <> "1d6851510c098e5c47c646a597fb4dcec034e9f77c409e62"
+
+secp256k1PrivHex :: String
+secp256k1PrivHex =
+  "0802122053DADF1D5A164D6B4ACDB15E24AA4C5B1D3461BDBD42ABEDB0A4404D56CED8FB"
+
+secp256k1PubHex :: String
+secp256k1PubHex =
+  "08021221037777e994e452c21604f91de093ce415f5432f701dd8cd1a7a6fea0e630bfca99"
+
+-- RSA: protobuf Data is a PKCS#1 RSAPrivateKey DER (4096-bit modulus).
+rsaPrivHex :: String
+rsaPrivHex =
+  "080012ae123082092a0201000282020100e1beab071d08200bde24eef00d049449b07770"
+    <> "ff9910257b2d7d5dda242ce8f0e2f12e1af4b32d9efd2c090f66b0f29986dbb645dae988"
+    <> "0089704a94e5066d594162ae6ee8892e6ec70701db0a6c445c04778eb3de1293aa1a23c3"
+    <> "825b85c6620a2bc3f82f9b0c309bc0ab3aeb1873282bebd3da03c33e76c21e9beb172fd4"
+    <> "4c9e43be32e2c99827033cf8d0f0c606f4579326c930eb4e854395ad941256542c793902"
+    <> "185153c474bed109d6ff5141ebf9cd256cf58893a37f83729f97e7cb435ec679d2e33901"
+    <> "d27bb35aa0d7e20561da08885ef0abbf8e2fb48d6a5487047a9ecb1ad41fa7ed84f6e3e8"
+    <> "ecd5d98b3982d2a901b4454991766da295ab78822add5612a2df83bcee814cf50973e80d"
+    <> "7ef38111b1bd87da2ae92438a2c8cbcc70b31ee319939a3b9c761dbc13b5c086d6b64bf7"
+    <> "ae7dacc14622375d92a8ff9af7eb962162bbddebf90acb32adb5e4e4029f1c96019949ec"
+    <> "fbfeffd7ac1e3fbcc6b6168c34be3d5a2e5999fcbb39bba7adbca78eab09b9bc39f7fa4b"
+    <> "93411f4cc175e70c0a083e96bfaefb04a9580b4753c1738a6a760ae1afd851a1a4bdad23"
+    <> "1cf56e9284d832483df215a46c1c21bdf0c6cfe951c18f1ee4078c79c13d63edb6e14fea"
+    <> "effabc90ad317e4875fe648101b0864097e998f0ca3025ef9638cd2b0caecd3770ab54a1"
+    <> "d9c6ca959b0f5dcbc90caeefc4135baca6fd475224269bbe1b02030100010282020100a4"
+    <> "72ffa858efd8588ce59ee264b957452f3673acdf5631d7bfd5ba0ef59779c231b0bc838a"
+    <> "8b14cae367b6d9ef572c03c7883b0a3c652f5c24c316b1ccfd979f13d0cd7da20c7d34d9"
+    <> "ec32dfdc81ee7292167e706d705efde5b8f3edfcba41409e642f8897357df5d320d21c43"
+    <> "b33600a7ae4e505db957c1afbc189d73f0b5d972d9aaaeeb232ca20eebd5de6fe7f29d01"
+    <> "470354413cc9a0af1154b7af7c1029adcd67c74b4798afeb69e09f2cb387305e73a1b5f4"
+    <> "50202d54f0ef096fe1bde340219a1194d1ac9026e90b366cce0c59b239d10e4888f52ca1"
+    <> "780824d39ae01a6b9f4dd6059191a7f12b2a3d8db3c2868cd4e5a5862b8b625a4197d52c"
+    <> "6ac77710116ebd3ced81c4d91ad5fdfbed68312ebce7eea45c1833ca3acf7da2052820ea"
+    <> "cf5c6b07d086dabeb893391c71417fd8a4b1829ae2cf60d1749d0e25da19530d889461c2"
+    <> "1da3492a8dc6ccac7de83ac1c2185262c7473c8cc42f547cc9864b02a8073b6aa54a037d"
+    <> "8c0de3914784e6205e83d97918b944f11b877b12084c0dd1d36592f8a4f8b8da5bb404c3"
+    <> "d2c079b22b6ceabfbcb637c0dbe0201f0909d533f8bf308ada47aee641a012a494d31b54"
+    <> "c974e58b87f140258258bb82f31692659db7aa07e17a5b2a0832c24e122d3a8babcc9ee7"
+    <> "4cbb07d3058bb85b15f6f6b2674aba9fd34367be9782d444335fbed31e3c4086c652597c"
+    <> "27104938b47fa10282010100e9fdf843c1550070ca711cb8ff28411466198f0e212511c3"
+    <> "186623890c0071bf6561219682fe7dbdfd81176eba7c4faba21614a20721e0fcd63768e6"
+    <> "d925688ecc90992059ac89256e0524de90bf3d8a052ce6a9f6adafa712f3107a016e20c8"
+    <> "0255c9e37d8206d1bc327e06e66eb24288da866b55904fd8b59e6b2ab31bc5eab47e5970"
+    <> "93c63fab7872102d57b4c589c66077f534a61f5f65127459a33c91f6db61fc431b1ae90b"
+    <> "e92b4149a3255291baf94304e3efb77b1107b5a3bda911359c40a53c347ff9100baf8f36"
+    <> "dc5cd991066b5bdc28b39ed644f404afe9213f4d31c9d4e40f3a5f5e3c39bebeb244e841"
+    <> "37544e1a1839c1c8aaebf0c78a7fad590282010100f6fa1f1e6b803742d5490b7441152f"
+    <> "500970f46feb0b73a6e4baba2aaf3c0e245ed852fc31d86a8e46eb48e90fac409989dfee"
+    <> "45238f97e8f1f8e83a136488c1b04b8a7fb695f37b8616307ff8a8d63e8cfa0b4fb9b916"
+    <> "7ffaebabf111aa5a4344afbabd002ae8961c38c02da76a9149abdde93eb389eb32595c29"
+    <> "ba30d8283a7885218a5a9d33f7f01dbdf85f3aad016c071395491338ec318d39220e1c7b"
+    <> "d69d3d6b520a13a30d745c102b827ad9984b0dd6aed73916ffa82a06c1c111e7047dcd26"
+    <> "68f988a0570a71474992eecf416e068f029ec323d5d635fd24694fc9bf96973c255d26c7"
+    <> "72a95bf8b7f876547a5beabf86f06cd21b67994f944e7a5493028201010095b02fd30069"
+    <> "e547426a8bea58e8a2816f33688dac6c6f6974415af8402244a22133baedf34ce499d703"
+    <> "6f3f19b38eb00897c18949b0c5a25953c71aeeccfc8f6594173157cc854bd98f16dffe8f"
+    <> "28ca13b77eb43a2730585c49fc3f608cd811bb54b03b84bddaa8ef910988567f78301226"
+    <> "6199667a546a18fd88271fbf63a45ae4fd4884706da8befb9117c0a4d73de5172f8640b1"
+    <> "091ed8a4aea3ed4641463f5ff6a5e3401ad7d0c92811f87956d1fd5f9a1d15c7f3839a08"
+    <> "698d9f35f9d966e5000f7cb2655d7b6c4adcd8a9d950ea5f61bb7c9a33c17508f9baa313"
+    <> "eecfee4ae493249ebe05a5d7770bbd3551b2eeb752e3649e0636de08e3d672e66cb90282"
+    <> "010100ad93e4c31072b063fc5ab5fe22afacece775c795d0efdf7c704cfc027bde0d626a"
+    <> "7646fc905bb5a80117e3ca49059af14e0160089f9190065be9bfecf12c3b2145b211c8e8"
+    <> "9e42dd91c38e9aa23ca73697063564f6f6aa6590088a738722df056004d18d7bccac62b3"
+    <> "bafef6172fc2a4b071ea37f31eff7a076bcab7dd144e51a9da8754219352aef2c7347897"
+    <> "1539fa41de4759285ea626fa3c72e7085be47d554d915bbb5149cb6ef835351f23104304"
+    <> "9cd941506a034bf2f8767f3e1e42ead92f91cb3d75549b57ef7d56ac39c2d80d67f6a2b4"
+    <> "ca192974bfc5060e2dd171217971002193dba12e7e4133ab201f07500a90495a38610279"
+    <> "b13a48d54f0c99028201003e3a1ac0c2b67d54ed5c4bbe04a7db99103659d33a4f9d3580"
+    <> "9e1f60c282e5988dddc964527f3b05e6cc890eab3dcb571d66debf3a5527704c87264b39"
+    <> "54d7265f4e8d2c637dd89b491b9cf23f264801f804b90454d65af0c4c830d1aef76f597e"
+    <> "f61b26ca857ecce9cb78d4f6c2218c00d2975d46c2b013fbf59b750c3b92d8d3ed9e6d1f"
+    <> "d0ef1ec091a5c286a3fe2dead292f40f380065731e2079ebb9f2a7ef2c415ecbb488da98"
+    <> "f3a12609ca1b6ec8c734032c8bd513292ff842c375d4acd1b02dfb206b24cd815f8e2f9d"
+    <> "4af8e7dea0370b19c1b23cc531d78b40e06e1119ee2e08f6f31c6e2e8444c568d13c5d45"
+    <> "1a291ae0c9f1d4f27d23b3a00d60ad"
+
+-- RSA public key: protobuf Data is a PKIX SubjectPublicKeyInfo DER.
+rsaPubHex :: String
+rsaPubHex =
+  "080012a60430820222300d06092a864886f70d01010105000382020f003082020a028202"
+    <> "0100e1beab071d08200bde24eef00d049449b07770ff9910257b2d7d5dda242ce8f0e2f1"
+    <> "2e1af4b32d9efd2c090f66b0f29986dbb645dae9880089704a94e5066d594162ae6ee889"
+    <> "2e6ec70701db0a6c445c04778eb3de1293aa1a23c3825b85c6620a2bc3f82f9b0c309bc0"
+    <> "ab3aeb1873282bebd3da03c33e76c21e9beb172fd44c9e43be32e2c99827033cf8d0f0c6"
+    <> "06f4579326c930eb4e854395ad941256542c793902185153c474bed109d6ff5141ebf9cd"
+    <> "256cf58893a37f83729f97e7cb435ec679d2e33901d27bb35aa0d7e20561da08885ef0ab"
+    <> "bf8e2fb48d6a5487047a9ecb1ad41fa7ed84f6e3e8ecd5d98b3982d2a901b4454991766d"
+    <> "a295ab78822add5612a2df83bcee814cf50973e80d7ef38111b1bd87da2ae92438a2c8cb"
+    <> "cc70b31ee319939a3b9c761dbc13b5c086d6b64bf7ae7dacc14622375d92a8ff9af7eb96"
+    <> "2162bbddebf90acb32adb5e4e4029f1c96019949ecfbfeffd7ac1e3fbcc6b6168c34be3d"
+    <> "5a2e5999fcbb39bba7adbca78eab09b9bc39f7fa4b93411f4cc175e70c0a083e96bfaefb"
+    <> "04a9580b4753c1738a6a760ae1afd851a1a4bdad231cf56e9284d832483df215a46c1c21"
+    <> "bdf0c6cfe951c18f1ee4078c79c13d63edb6e14feaeffabc90ad317e4875fe648101b086"
+    <> "4097e998f0ca3025ef9638cd2b0caecd3770ab54a1d9c6ca959b0f5dcbc90caeefc4135b"
+    <> "aca6fd475224269bbe1b0203010001"


### PR DESCRIPTION
## Root cause

Private key files from other implementations (including the peer-ids spec's own test vectors) could not be loaded:

1. **RSA** — `decodePrivateKey` hardcoded `public_size = 256`, so the spec's 4096-bit vector made crypton's `i2ospOf_` throw a pure `error` from `sign`, escaping the `Either` contract. Fixed by deriving the size from the modulus (`numBytes n`).
2. **ECDSA** — the private key was a bare 32-byte scalar; the spec and go-libp2p use an RFC 5915 `ECPrivateKey` DER. `generate`/`signIO` now encode/decode that DER (named-curve parameters + public key, matching Go's `x509.MarshalECPrivateKey`).
3. **Ed25519** — only a 32-byte seed was accepted; the spec requires the 64-byte `seed || pub` form, plus the legacy 96-byte `seed || pub || pub` form (accepted only when the redundant public key matches).
4. **Protobuf** — no `PrivateKey` message codec existed; added `encodePrivateKey`/`decodePrivateKey` sharing the deterministic `PublicKey` wire layout.

## Fix

- `Key.keyPairFromPrivateKey` derives the public key from an imported private key for all four key types (peer-ids spec: "Implementations SHOULD check that they can produce the provided public key from the private key").
- New `KeyImportSpec` exercises every peer-ids spec test vector end to end: protobuf decode, public key derivation (byte-identical to the spec's public vectors), sign/verify, legacy/invalid Ed25519 forms, and byte-identical re-encoding.

644 tests pass (629 existing + 15 new) with GHC 9.10.1.

Closes #161