### PR TITLE
fix(dht): multi-request streams, peer multiaddrs, and outbound RPC wiring

### DIFF
--- a/src/LibP2P/DHT.hs
+++ b/src/LibP2P/DHT.hs
@@ -2,10 +2,10 @@
 --
 -- The DHTNode is the top-level coordinator for Kademlia DHT operations.
 -- It owns the routing table, record store, provider store, and handles
--- both inbound (as handler) and outbound (sendDHTRequest) RPC.
+-- both inbound (as handler) and outbound (dhtSendRequest) RPC.
 --
--- For testability, sendDHTRequest is a field of DHTNode, allowing mock
--- injection in tests without real network connections.
+-- The outbound sender is wired to the Switch by 'newDHTNode'; it remains
+-- a record field so tests can inject mocks without a real network.
 module LibP2P.DHT
   ( -- * Types
     DHTNode (..)
@@ -23,11 +23,14 @@ module LibP2P.DHT
   , lookupRecord
   , addProvider
   , getProviders
+    -- * Wire helpers
+  , decodePeerAddrs
     -- * Constants
   , dhtProtocolId
   ) where
 
 import Control.Concurrent.STM
+import Control.Exception (SomeException, try)
 import Data.ByteString (ByteString)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -38,10 +41,15 @@ import LibP2P.DHT.Distance (keyToDHTKey, peerIdToKey)
 import LibP2P.DHT.Message
 import LibP2P.DHT.RoutingTable (RoutingTable, closestPeers, newRoutingTable)
 import LibP2P.DHT.Types
-import LibP2P.Multiaddr (Multiaddr)
-import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.Multiaddr (Multiaddr, fromBytes, toBytes)
+import LibP2P.MultistreamSelect.Negotiation
+  ( NegotiationResult (..)
+  , StreamIO (..)
+  , negotiateInitiator
+  )
 import LibP2P.Switch (setStreamHandler)
-import LibP2P.Switch.Types (Switch (..))
+import LibP2P.Switch.ConnPool (lookupConn)
+import LibP2P.Switch.Types (Connection (..), MuxerSession (..), Switch (..))
 
 -- | DHT protocol identifier for multistream-select.
 dhtProtocolId :: Text
@@ -73,17 +81,22 @@ data DHTNode = DHTNode
   , dhtLocalKey      :: !DHTKey
   , dhtLocalPeerId   :: !PeerId
   , dhtMode          :: !DHTMode
+  , dhtStreams       :: !(TVar (Map PeerId StreamIO))
+    -- ^ Cached outbound @/ipfs/kad/1.0.0@ streams, one per peer
+    -- (go-libp2p reuses a single long-lived stream per peer)
   , dhtSendRequest   :: !(PeerId -> DHTMessage -> IO (Either String DHTMessage))
-    -- ^ Injectable RPC sender for testability
+    -- ^ Outbound RPC sender. Wired to the Switch by 'newDHTNode';
+    -- kept as a field so tests can inject mocks.
   }
 
--- | Create a new DHT node.
+-- | Create a new DHT node with the outbound sender wired to the Switch.
 newDHTNode :: Switch -> DHTMode -> IO DHTNode
 newDHTNode sw mode = do
   let localPid = swLocalPeerId sw
   rt <- newTVarIO (newRoutingTable localPid)
   records <- newTVarIO Map.empty
   providers <- newTVarIO Map.empty
+  streams <- newTVarIO Map.empty
   pure DHTNode
     { dhtSwitch        = sw
     , dhtRoutingTable  = rt
@@ -92,7 +105,8 @@ newDHTNode sw mode = do
     , dhtLocalKey      = peerIdToKey localPid
     , dhtLocalPeerId   = localPid
     , dhtMode          = mode
-    , dhtSendRequest   = \_ _ -> pure (Left "sendDHTRequest not configured")
+    , dhtStreams       = streams
+    , dhtSendRequest   = sendRequestViaSwitch sw streams
     }
 
 -- | Register the DHT handler on the Switch (server mode only).
@@ -100,15 +114,28 @@ registerDHTHandler :: DHTNode -> IO ()
 registerDHTHandler node =
   setStreamHandler (dhtSwitch node) dhtProtocolId (\stream pid -> handleDHTRequest node stream pid)
 
--- | Handle an inbound DHT RPC request.
+-- | Handle an inbound DHT stream.
+--
+-- Per specs/kad-dht, implementations must handle additional RPC request
+-- messages on the same incoming stream: go-libp2p keeps one long-lived
+-- stream per peer and pipelines requests over it. Loop until the stream
+-- errors, is reset, or reaches EOF.
 handleDHTRequest :: DHTNode -> StreamIO -> PeerId -> IO ()
-handleDHTRequest node stream _remotePeerId = do
-  result <- readFramedMessage stream maxDHTMessageSize
-  case result of
-    Left _err -> pure ()  -- Stream error, just return
-    Right msg -> do
-      response <- processRequest node msg _remotePeerId
-      writeFramedMessage stream response
+handleDHTRequest node stream remotePeerId = loop
+  where
+    loop = do
+      result <- try $ do
+        readResult <- readFramedMessage stream maxDHTMessageSize
+        case readResult of
+          Left err -> pure (Left err)
+          Right msg -> do
+            response <- processRequest node msg remotePeerId
+            writeFramedMessage stream response
+            pure (Right ())
+      case result of
+        Left (_ :: SomeException) -> pure ()  -- Stream closed or reset
+        Right (Left _err) -> pure ()          -- Framing/decode error: stop serving
+        Right (Right ()) -> loop
 
 -- | Process a single DHT request and produce a response.
 processRequest :: DHTNode -> DHTMessage -> PeerId -> IO DHTMessage
@@ -192,6 +219,73 @@ handleGetProviders node msg = do
     , msgProviderPeers = providerPeers
     }
 
+-- Outbound RPC
+
+-- | Send a DHT request to a peer over the Switch.
+--
+-- Reuses a cached @/ipfs/kad/1.0.0@ stream per peer when one exists
+-- (go-libp2p pipelines all requests to a peer over one stream); otherwise
+-- opens a new muxer stream on an existing connection and negotiates the
+-- protocol. A failed exchange on a cached stream evicts it and retries
+-- once on a fresh stream.
+sendRequestViaSwitch
+  :: Switch
+  -> TVar (Map PeerId StreamIO)
+  -> PeerId
+  -> DHTMessage
+  -> IO (Either String DHTMessage)
+sendRequestViaSwitch sw streamsVar pid request = do
+  mCached <- Map.lookup pid <$> readTVarIO streamsVar
+  case mCached of
+    Nothing -> openAndExchange
+    Just stream -> do
+      result <- exchangeFramed stream request
+      case result of
+        Right resp -> pure (Right resp)
+        Left _ -> do
+          -- Cached stream is dead: evict it and retry on a fresh one.
+          atomically $ modifyTVar' streamsVar (Map.delete pid)
+          openAndExchange
+  where
+    openAndExchange = do
+      opened <- openDHTStream sw pid
+      case opened of
+        Left err -> pure (Left err)
+        Right stream -> do
+          atomically $ modifyTVar' streamsVar (Map.insert pid stream)
+          result <- exchangeFramed stream request
+          case result of
+            Left err -> do
+              atomically $ modifyTVar' streamsVar (Map.delete pid)
+              pure (Left err)
+            ok -> pure ok
+
+-- | Write a framed request and read the framed response, capturing IO errors.
+exchangeFramed :: StreamIO -> DHTMessage -> IO (Either String DHTMessage)
+exchangeFramed stream request = do
+  result <- try $ do
+    writeFramedMessage stream request
+    readFramedMessage stream maxDHTMessageSize
+  pure $ case result of
+    Left (e :: SomeException) -> Left ("DHT stream I/O failed: " ++ show e)
+    Right r -> r
+
+-- | Open a new muxer stream to the peer and negotiate @/ipfs/kad/1.0.0@.
+openDHTStream :: Switch -> PeerId -> IO (Either String StreamIO)
+openDHTStream sw pid = do
+  mConn <- atomically $ lookupConn (swConnPool sw) pid
+  case mConn of
+    Nothing -> pure (Left "no open connection to peer")
+    Just conn -> do
+      result <- try $ do
+        stream <- muxOpenStream (connSession conn)
+        negotiated <- negotiateInitiator stream [dhtProtocolId]
+        pure (stream, negotiated)
+      pure $ case result of
+        Left (e :: SomeException) -> Left ("failed to open DHT stream: " ++ show e)
+        Right (stream, Accepted _) -> Right stream
+        Right (_, NoProtocol) -> Left "peer does not support /ipfs/kad/1.0.0"
+
 -- Store operations
 
 -- | Store a record in the local datastore.
@@ -217,10 +311,12 @@ getProviders node key =
 -- Helpers
 
 -- | Convert a BucketEntry to a DHTPeer protobuf message.
+-- Per specs/kad-dht, Peer records carry the peer's known multiaddrs so
+-- the requester can dial them (go-libp2p filters address-less peers).
 entryToDHTPeer :: BucketEntry -> DHTPeer
 entryToDHTPeer entry = DHTPeer
   { dhtPeerId = peerIdBytes (entryPeerId entry)
-  , dhtPeerAddrs = []  -- addresses would be encoded multiaddrs
+  , dhtPeerAddrs = map toBytes (entryAddrs entry)
   , dhtPeerConnType = entryConnType entry
   }
 
@@ -228,7 +324,7 @@ entryToDHTPeer entry = DHTPeer
 dhtPeerToProvider :: DHTPeer -> UTCTime -> ProviderEntry
 dhtPeerToProvider peer now = ProviderEntry
   { peProvider  = PeerId (dhtPeerId peer)
-  , peAddrs     = []  -- raw bytes in dhtPeerAddrs; address decoding is not yet wired
+  , peAddrs     = decodePeerAddrs (dhtPeerAddrs peer)
   , peTimestamp = now
   }
 
@@ -236,6 +332,12 @@ dhtPeerToProvider peer now = ProviderEntry
 providerToDHTPeer :: ProviderEntry -> DHTPeer
 providerToDHTPeer pe = DHTPeer
   { dhtPeerId = peerIdBytes (peProvider pe)
-  , dhtPeerAddrs = []  -- addresses would be encoded multiaddrs
+  , dhtPeerAddrs = map toBytes (peAddrs pe)
   , dhtPeerConnType = Connected
   }
+
+-- | Decode raw wire multiaddrs from a Peer record, dropping any that fail
+-- to parse: a malformed address from a remote peer must not poison the
+-- rest of the record.
+decodePeerAddrs :: [ByteString] -> [Multiaddr]
+decodePeerAddrs raw = [addr | Right addr <- map fromBytes raw]

--- a/src/LibP2P/DHT/Lookup.hs
+++ b/src/LibP2P/DHT/Lookup.hs
@@ -27,7 +27,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Time (UTCTime, getCurrentTime)
 import LibP2P.Crypto.PeerId (PeerId (..), peerIdBytes)
-import LibP2P.DHT (DHTNode (..), ProviderEntry (..), Validator (..))
+import LibP2P.DHT (DHTNode (..), ProviderEntry (..), Validator (..), decodePeerAddrs)
 import LibP2P.DHT.Distance (keyToDHTKey, peerIdToKey, sortByDistance)
 import LibP2P.DHT.Message
 import LibP2P.DHT.RoutingTable (closestPeers, insertPeer, allPeers)
@@ -391,11 +391,13 @@ bootstrap node seeds = do
 -- Helpers
 
 -- | Convert a DHTPeer to a BucketEntry (with current time).
+-- Per specs/kad-dht, multiaddrs carried by Peer records are decoded and
+-- kept so the learned peers can be dialled in follow-up queries.
 dhtPeerToEntry :: a -> DHTPeer -> BucketEntry
 dhtPeerToEntry _ peer = BucketEntry
   { entryPeerId   = PeerId (dhtPeerId peer)
   , entryKey      = peerIdToKey (PeerId (dhtPeerId peer))
-  , entryAddrs    = []  -- would need multiaddr decoding
+  , entryAddrs    = decodePeerAddrs (dhtPeerAddrs peer)
   , entryLastSeen = epochTime
   , entryConnType = dhtPeerConnType peer
   }
@@ -404,7 +406,7 @@ dhtPeerToEntry _ peer = BucketEntry
 dhtPeerToProvider :: DHTPeer -> ProviderEntry
 dhtPeerToProvider peer = ProviderEntry
   { peProvider  = PeerId (dhtPeerId peer)
-  , peAddrs     = []
+  , peAddrs     = decodePeerAddrs (dhtPeerAddrs peer)
   , peTimestamp = epochTime
   }
 

--- a/test/LibP2P/DHT/DHTSpec.hs
+++ b/test/LibP2P/DHT/DHTSpec.hs
@@ -7,6 +7,7 @@ module LibP2P.DHT.DHTSpec
 
 import Test.Hspec
 
+import Control.Concurrent.Async (async, wait)
 import Control.Concurrent.STM
 import Crypto.Hash (Digest, SHA256, hash)
 import Data.ByteArray (convert)
@@ -21,9 +22,18 @@ import LibP2P.DHT.Distance (peerIdToKey, sortByDistance)
 import LibP2P.DHT.Message
 import LibP2P.DHT.RoutingTable (insertPeer)
 import LibP2P.DHT.Types
-import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
-import LibP2P.Switch.Types (Switch (..))
+import LibP2P.Multiaddr (Multiaddr, fromText, toBytes)
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), negotiateResponder)
+import LibP2P.Switch.ConnPool (addConn)
+import LibP2P.Switch.Types
+  ( ConnState (..)
+  , Connection (..)
+  , Direction (..)
+  , MuxerSession (..)
+  , Switch (..)
+  )
 import LibP2P.Switch.ResourceManager (ResourceManager, newResourceManager, DefaultLimits (..), noLimits)
+import System.Timeout (timeout)
 
 -- | Helper: create a PeerId from raw bytes.
 mkPeerId :: BS.ByteString -> PeerId
@@ -87,22 +97,70 @@ dummyKeyPair = KeyPair
   (PublicKey Ed25519 (BS.replicate 32 0))
   (PrivateKey Ed25519 (BS.replicate 64 0))
 
--- | Create a stream pair for testing.
+-- | A test multiaddr for address propagation assertions.
+testAddr :: Multiaddr
+testAddr = either error id (fromText "/ip4/127.0.0.1/tcp/4001")
+
+-- | Create a stream pair for testing, with close/EOF support.
+-- Closing one end makes reads on the other end fail once the in-flight
+-- bytes are drained, mimicking a real muxer stream reaching EOF.
 mkStreamPair :: IO (StreamIO, StreamIO)
 mkStreamPair = do
-  q1 <- newTQueueIO :: IO (TQueue Word8)
-  q2 <- newTQueueIO :: IO (TQueue Word8)
-  let streamA = StreamIO
-        { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q1 b)) (BS.unpack bs)
-        , streamReadByte = atomically (readTQueue q2)
-        , streamClose = pure ()
+  q1 <- newTQueueIO :: IO (TQueue Word8)  -- A -> B
+  q2 <- newTQueueIO :: IO (TQueue Word8)  -- B -> A
+  closedAtoB <- newTVarIO False
+  closedBtoA <- newTVarIO False
+  let writeAll q bs = mapM_ (\b -> atomically (writeTQueue q b)) (BS.unpack bs)
+      readOrEOF q closedVar = atomically $ do
+        mb <- tryReadTQueue q
+        case mb of
+          Just b -> pure b
+          Nothing -> do
+            closed <- readTVar closedVar
+            if closed then throwSTM (userError "stream closed") else retry
+      streamA = StreamIO
+        { streamWrite = writeAll q1
+        , streamReadByte = readOrEOF q2 closedBtoA
+        , streamClose = atomically (writeTVar closedAtoB True)
         }
       streamB = StreamIO
-        { streamWrite = \bs -> mapM_ (\b -> atomically (writeTQueue q2 b)) (BS.unpack bs)
-        , streamReadByte = atomically (readTQueue q1)
-        , streamClose = pure ()
+        { streamWrite = writeAll q2
+        , streamReadByte = readOrEOF q1 closedAtoB
+        , streamClose = atomically (writeTVar closedBtoA True)
         }
   pure (streamA, streamB)
+
+-- | A mock Connection that hands out the given stream on the first
+-- muxOpenStream call and counts opens; later opens fail so tests can
+-- assert that the sender reuses one stream per peer.
+mkMockConnection :: PeerId -> StreamIO -> TVar Int -> IO Connection
+mkMockConnection pid stream openCountVar = do
+  stateVar <- newTVarIO ConnOpen
+  handedOut <- newTVarIO False
+  let openOnce = do
+        first <- atomically $ do
+          done <- readTVar handedOut
+          if done
+            then pure False
+            else do
+              writeTVar handedOut True
+              modifyTVar' openCountVar (+ 1)
+              pure True
+        if first then pure stream else fail "mock: stream already opened"
+  pure Connection
+    { connPeerId     = pid
+    , connDirection  = Outbound
+    , connLocalAddr  = testAddr
+    , connRemoteAddr = testAddr
+    , connSecurity   = "/noise"
+    , connMuxer      = "/yamux/1.0.0"
+    , connSession    = MuxerSession
+        { muxOpenStream   = openOnce
+        , muxAcceptStream = fail "mock: no inbound streams"
+        , muxClose        = pure ()
+        }
+    , connState      = stateVar
+    }
 
 spec :: Spec
 spec = do
@@ -121,6 +179,7 @@ spec = do
             , msgKey = BS.pack [42, 42, 42]
             }
       writeFramedMessage clientStream request
+      streamClose clientStream
       handleDHTRequest node serverStream remotePid
 
       result <- readFramedMessage clientStream maxDHTMessageSize
@@ -144,6 +203,7 @@ spec = do
             , msgKey = BS.pack [0xFF, 0xFF]
             }
       writeFramedMessage clientStream request
+      streamClose clientStream
       handleDHTRequest node serverStream remotePid
 
       result <- readFramedMessage clientStream maxDHTMessageSize
@@ -172,6 +232,7 @@ spec = do
       (clientStream, serverStream) <- mkStreamPair
       let request = emptyDHTMessage { msgType = FindNode, msgKey = wireKey }
       writeFramedMessage clientStream request
+      streamClose clientStream
       handleDHTRequest node serverStream remotePid
 
       result <- readFramedMessage clientStream maxDHTMessageSize
@@ -194,6 +255,7 @@ spec = do
       (clientStream, serverStream) <- mkStreamPair
       let request = emptyDHTMessage { msgType = GetValue, msgKey = wireKey }
       writeFramedMessage clientStream request
+      streamClose clientStream
       handleDHTRequest node serverStream remotePid
 
       result <- readFramedMessage clientStream maxDHTMessageSize
@@ -216,6 +278,7 @@ spec = do
       (clientStream, serverStream) <- mkStreamPair
       let request = emptyDHTMessage { msgType = GetProviders, msgKey = wireKey }
       writeFramedMessage clientStream request
+      streamClose clientStream
       handleDHTRequest node serverStream remotePid
 
       result <- readFramedMessage clientStream maxDHTMessageSize
@@ -232,6 +295,7 @@ spec = do
       (clientStream, serverStream) <- mkStreamPair
       let request = emptyDHTMessage { msgType = GetValue, msgKey = key }
       writeFramedMessage clientStream request
+      streamClose clientStream
       handleDHTRequest node serverStream remotePid
 
       result <- readFramedMessage clientStream maxDHTMessageSize
@@ -244,6 +308,7 @@ spec = do
       (clientStream, serverStream) <- mkStreamPair
       let request = emptyDHTMessage { msgType = GetValue, msgKey = BS.pack [1, 2, 3] }
       writeFramedMessage clientStream request
+      streamClose clientStream
       handleDHTRequest node serverStream remotePid
 
       result <- readFramedMessage clientStream maxDHTMessageSize
@@ -265,6 +330,7 @@ spec = do
             , msgRecord = Just rec
             }
       writeFramedMessage clientStream request
+      streamClose clientStream
       handleDHTRequest node serverStream remotePid
       _ <- readFramedMessage clientStream maxDHTMessageSize
 
@@ -283,6 +349,7 @@ spec = do
             , msgProviderPeers = [fakePeer]
             }
       writeFramedMessage clientStream request
+      streamClose clientStream
       handleDHTRequest node serverStream remotePid
 
       result <- readFramedMessage clientStream maxDHTMessageSize
@@ -307,6 +374,7 @@ spec = do
             , msgProviderPeers = [validPeer]
             }
       writeFramedMessage clientStream request
+      streamClose clientStream
       handleDHTRequest node serverStream remotePid
 
       result <- readFramedMessage clientStream maxDHTMessageSize
@@ -332,6 +400,7 @@ spec = do
             , msgProviderPeers = [validPeer]
             }
       writeFramedMessage clientStream1 addReq
+      streamClose clientStream1
       handleDHTRequest node serverStream1 remotePid
       _ <- readFramedMessage clientStream1 maxDHTMessageSize
 
@@ -342,6 +411,7 @@ spec = do
             , msgKey = key
             }
       writeFramedMessage clientStream2 getReq
+      streamClose clientStream2
       handleDHTRequest node serverStream2 remotePid
 
       result <- readFramedMessage clientStream2 maxDHTMessageSize
@@ -352,11 +422,149 @@ spec = do
           dhtPeerId (head (msgProviderPeers resp)) `shouldBe` peerIdBytes remotePid
         Left err -> expectationFailure $ "Failed: " ++ err
 
+    -- Issue #147: specs/kad-dht requires handling additional RPC request
+    -- messages on the same inbound stream — go-libp2p keeps one long-lived
+    -- stream per peer and pipelines requests over it.
+    it "serves multiple consecutive requests on a single stream" $ do
+      node <- mkTestNode localPid
+      let key = BS.pack [0xCA, 0xFE]
+          rec = DHTRecord key (BS.pack [0xDE, 0xAD]) "2024-01-01T00:00:00Z"
+      storeRecord node rec
+
+      (clientStream, serverStream) <- mkStreamPair
+      handler <- async (handleDHTRequest node serverStream remotePid)
+
+      writeFramedMessage clientStream
+        (emptyDHTMessage { msgType = FindNode, msgKey = BS.pack [1] })
+      r1 <- timeout 2000000 (readFramedMessage clientStream maxDHTMessageSize)
+      case r1 of
+        Just (Right resp) -> msgType resp `shouldBe` FindNode
+        _ -> expectationFailure "no response to first request"
+
+      writeFramedMessage clientStream
+        (emptyDHTMessage { msgType = GetValue, msgKey = key })
+      r2 <- timeout 2000000 (readFramedMessage clientStream maxDHTMessageSize)
+      case r2 of
+        Just (Right resp) -> msgRecord resp `shouldBe` Just rec
+        _ -> expectationFailure
+               "handler did not serve a second request on the same stream"
+
+      streamClose clientStream
+      wait handler
+
+    -- Issue #147: Peer records must carry the peer's known multiaddrs so
+    -- the requester can dial them (go-libp2p filters address-less peers).
+    it "FIND_NODE returns closerPeers with their known multiaddrs" $ do
+      node <- mkTestNode localPid
+      now <- getCurrentTime
+      let pid2 = mkPeerId (BS.pack [2])
+          entry = BucketEntry pid2 (peerIdToKey pid2) [testAddr] now Connected
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        fst (insertPeer entry rt)
+
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage { msgType = FindNode, msgKey = BS.pack [42] }
+      writeFramedMessage clientStream request
+      streamClose clientStream
+      handleDHTRequest node serverStream remotePid
+
+      result <- readFramedMessage clientStream maxDHTMessageSize
+      case result of
+        Right resp -> map dhtPeerAddrs (msgCloserPeers resp)
+                        `shouldBe` [[toBytes testAddr]]
+        Left err -> expectationFailure $ "Failed: " ++ err
+
+    it "GET_PROVIDERS returns provider peers with their multiaddrs" $ do
+      node <- mkTestNode localPid
+      now <- getCurrentTime
+      let key = BS.pack [0xAB]
+      addProvider node key (ProviderEntry (mkPeerId (BS.pack [7])) [testAddr] now)
+
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage { msgType = GetProviders, msgKey = key }
+      writeFramedMessage clientStream request
+      streamClose clientStream
+      handleDHTRequest node serverStream remotePid
+
+      result <- readFramedMessage clientStream maxDHTMessageSize
+      case result of
+        Right resp -> map dhtPeerAddrs (msgProviderPeers resp)
+                        `shouldBe` [[toBytes testAddr]]
+        Left err -> expectationFailure $ "Failed: " ++ err
+
+    it "ADD_PROVIDER decodes provider multiaddrs into the provider store" $ do
+      node <- mkTestNode localPid
+      let key = BS.pack [0xAA, 0xCC]
+          validPeer = DHTPeer (peerIdBytes remotePid) [toBytes testAddr] Connected
+
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage
+            { msgType = AddProvider
+            , msgKey = key
+            , msgProviderPeers = [validPeer]
+            }
+      writeFramedMessage clientStream request
+      streamClose clientStream
+      handleDHTRequest node serverStream remotePid
+
+      stored <- getProviders node key
+      map peAddrs stored `shouldBe` [[testAddr]]
+
     it "registerDHTHandler registers protocol on Switch" $ do
       node <- mkTestNode localPid
       registerDHTHandler node
       protos <- readTVarIO (swProtocols (dhtSwitch node))
       Map.member dhtProtocolId protos `shouldBe` True
+
+  -- Issue #168: newDHTNode must wire an outbound sender that opens a
+  -- /ipfs/kad/1.0.0 stream via the Switch. Previously the default sender
+  -- was a permanent failure and only a test mock ever assigned the field.
+  describe "dhtSendRequest (production wiring)" $ do
+    it "opens a stream via the Switch, negotiates the protocol, and exchanges framed messages, reusing the stream" $ do
+      clientNode <- mkTestNode localPid
+      serverNode <- mkTestNode remotePid
+      (clientEnd, serverEnd) <- mkStreamPair
+      openCountVar <- newTVarIO (0 :: Int)
+      conn <- mkMockConnection remotePid clientEnd openCountVar
+      atomically $ addConn (swConnPool (dhtSwitch clientNode)) conn
+
+      -- Remote side: multistream-select responder, then the DHT handler.
+      server <- async $ do
+        _ <- negotiateResponder serverEnd [dhtProtocolId]
+        handleDHTRequest serverNode serverEnd localPid
+
+      let req1 = emptyDHTMessage { msgType = FindNode, msgKey = BS.pack [42] }
+      r1 <- timeout 2000000 (dhtSendRequest clientNode remotePid req1)
+      case r1 of
+        Just (Right resp) -> msgType resp `shouldBe` FindNode
+        Just (Left err) -> expectationFailure $ "send failed: " ++ err
+        Nothing -> expectationFailure "send timed out"
+
+      -- A second request must reuse the cached stream: the mock connection
+      -- only allows a single muxOpenStream call.
+      let key = BS.pack [0xCA]
+          rec = DHTRecord key (BS.pack [1]) "2024-01-01T00:00:00Z"
+      storeRecord serverNode rec
+      let req2 = emptyDHTMessage { msgType = GetValue, msgKey = key }
+      r2 <- timeout 2000000 (dhtSendRequest clientNode remotePid req2)
+      case r2 of
+        Just (Right resp) -> msgRecord resp `shouldBe` Just rec
+        Just (Left err) -> expectationFailure $ "second send failed: " ++ err
+        Nothing -> expectationFailure "second send timed out"
+
+      opens <- readTVarIO openCountVar
+      opens `shouldBe` 1
+
+      streamClose clientEnd
+      wait server
+
+    it "fails with Left when there is no connection to the peer" $ do
+      node <- mkTestNode localPid
+      let request = emptyDHTMessage { msgType = FindNode, msgKey = BS.pack [1] }
+      result <- dhtSendRequest node (mkPeerId (BS.pack [9])) request
+      case result of
+        Left _ -> pure ()
+        Right _ -> expectationFailure "expected failure without a connection"
 
   describe "Store operations" $ do
     it "storeRecord + lookupRecord round-trip" $ do

--- a/test/LibP2P/DHT/LookupSpec.hs
+++ b/test/LibP2P/DHT/LookupSpec.hs
@@ -15,6 +15,7 @@ import LibP2P.DHT.Lookup
 import LibP2P.DHT.Message
 import LibP2P.DHT.RoutingTable (insertPeer, allPeers)
 import LibP2P.DHT.Types
+import LibP2P.Multiaddr (fromText, toBytes)
 
 -- Reuse mock Switch helpers from DHTSpec
 import LibP2P.DHT.DHTSpec (mkTestNode, mkPeerId, localPid)
@@ -30,11 +31,17 @@ mkNodeWithMock pid mockSend = do
 type MockNetwork = Map.Map PeerId (DHTMessage -> DHTMessage)
 
 -- | Build a mock sendRequest from a MockNetwork.
+--
+-- Issue #173: mock senders must read the request rather than return a
+-- canned constant. A query without a wire key would be a client-side bug
+-- that a constant mock silently masks, so reject it like a real peer.
 mockSendFromNetwork :: MockNetwork -> PeerId -> DHTMessage -> IO (Either String DHTMessage)
-mockSendFromNetwork network pid msg =
-  case Map.lookup pid network of
-    Nothing -> pure (Left "peer not found in mock network")
-    Just handler -> pure (Right (handler msg))
+mockSendFromNetwork network pid msg
+  | BS.null (msgKey msg) = pure (Left "mock: request carries no wire key")
+  | otherwise =
+      case Map.lookup pid network of
+        Nothing -> pure (Left "peer not found in mock network")
+        Just handler -> pure (Right (handler msg))
 
 spec :: Spec
 spec = do
@@ -204,6 +211,33 @@ spec = do
       result <- iterativeFindNode node targetPid
       -- Results should be sorted by XOR distance to the target
       map entryPeerId result `shouldBe` expectedOrder
+
+    -- Issue #147 (receive side): multiaddrs carried by closerPeers must be
+    -- decoded into the resulting entries instead of being dropped —
+    -- otherwise the peers we learn about cannot be dialled.
+    it "decodes closerPeers' multiaddrs into lookup results" $ do
+      now <- getCurrentTime
+      let pidA = mkPeerId (BS.pack [10])
+          pidB = mkPeerId (BS.pack [20])
+          addrB = either error id (fromText "/ip4/192.0.2.1/tcp/4001")
+          targetPid = mkPeerId (BS.pack [42])
+          network = Map.fromList
+            [ (pidA, \_ -> emptyDHTMessage
+                { msgType = FindNode
+                , msgCloserPeers =
+                    [DHTPeer (peerIdBytes pidB) [toBytes addrB] NotConnected]
+                })
+            , (pidB, \_ -> emptyDHTMessage
+                { msgType = FindNode, msgCloserPeers = [] })
+            ]
+      node <- mkNodeWithMock localPid (mockSendFromNetwork network)
+      let entryA = BucketEntry pidA (peerIdToKey pidA) [] now NotConnected
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        fst (insertPeer entryA rt)
+
+      result <- iterativeFindNode node targetPid
+      let entriesB = filter ((== pidB) . entryPeerId) result
+      map entryAddrs entriesB `shouldBe` [[addrB]]
 
   describe "iterativeGetValue" $ do
     it "sends the raw record key as the wire key" $ do
@@ -379,6 +413,29 @@ spec = do
       result <- iterativeGetProviders node key
       -- Should have collected providers from both hops
       length result `shouldSatisfy` (>= 2)
+
+    -- Issue #147 (receive side): provider records carry multiaddrs that
+    -- must be decoded so the provider can be dialled.
+    it "decodes provider multiaddrs into provider entries" $ do
+      now <- getCurrentTime
+      let pidA = mkPeerId (BS.pack [10])
+          key = BS.pack [0xD1]
+          providerAddr = either error id (fromText "/ip4/192.0.2.7/tcp/4001")
+          providerPeer = DHTPeer (BS.pack [50]) [toBytes providerAddr] Connected
+          network = Map.fromList
+            [ (pidA, \_ -> emptyDHTMessage
+                { msgType = GetProviders
+                , msgCloserPeers = []
+                , msgProviderPeers = [providerPeer]
+                })
+            ]
+      node <- mkNodeWithMock localPid (mockSendFromNetwork network)
+      let entryA = BucketEntry pidA (peerIdToKey pidA) [] now NotConnected
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        fst (insertPeer entryA rt)
+
+      result <- iterativeGetProviders node key
+      map peAddrs result `shouldBe` [[providerAddr]]
 
   describe "bootstrap" $ do
     it "self-lookup sends raw peer IDs as wire keys" $ do


### PR DESCRIPTION
Fixes two High DHT bugs that each block real-network participation.

## Handler: one request per stream (#147, defect 1)

specs/kad-dht requires handling additional RPC request messages on the same incoming stream; go-libp2p keeps one long-lived stream per peer and pipelines requests over it. `handleDHTRequest` now loops (read framed request -> process -> write framed response) until the stream errors, is reset, or reaches EOF.

## Peer records: empty addrs (#147, defect 2)

All three outbound conversion helpers hardcoded `addrs = []`, and the receive side discarded inbound addrs. Now:

- `closerPeers` / `providerPeers` carry the entry's multiaddrs (`entryAddrs` / `peAddrs`) as encoded bytes,
- inbound addrs are decoded into `BucketEntry.entryAddrs` and `ProviderEntry.peAddrs` via a shared `decodePeerAddrs`, dropping individually malformed addresses.

## Outbound RPC: never wired (#168)

`dhtSendRequest` defaulted to a permanent `Left` and was only assigned in a test mock. `newDHTNode` now wires a production sender that:

- looks up an open connection in the Switch pool, opens a muxer stream, negotiates `/ipfs/kad/1.0.0`,
- writes the uvarint-framed request and reads the framed response,
- caches one stream per peer (matching go-libp2p's stream reuse and the new multi-request handler), evicting and retrying once on a dead cached stream.

The field remains injectable for tests.

## Tests

TDD: 7 new tests (multi-request stream, addr propagation out/in for closer peers and providers, production sender against a mock switch incl. stream-reuse assertion, no-connection failure). The in-memory test stream pair now models close/EOF. Constant mock senders in LookupSpec now read the request (re #173). 677 examples, 0 failures on GHC 9.10.1.

Closes #147
Closes #168