### PR TITLE
fix: pass Connection to StreamHandler so identify sends observedAddr

### DIFF
--- a/src/LibP2P/DHT.hs
+++ b/src/LibP2P/DHT.hs
@@ -41,7 +41,7 @@ import LibP2P.DHT.Types
 import LibP2P.Multiaddr (Multiaddr)
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
 import LibP2P.Switch (setStreamHandler)
-import LibP2P.Switch.Types (Switch (..))
+import LibP2P.Switch.Types (Connection (..), Switch (..))
 
 -- | DHT protocol identifier for multistream-select.
 dhtProtocolId :: Text
@@ -98,7 +98,8 @@ newDHTNode sw mode = do
 -- | Register the DHT handler on the Switch (server mode only).
 registerDHTHandler :: DHTNode -> IO ()
 registerDHTHandler node =
-  setStreamHandler (dhtSwitch node) dhtProtocolId (\stream pid -> handleDHTRequest node stream pid)
+  setStreamHandler (dhtSwitch node) dhtProtocolId
+    (\conn stream -> handleDHTRequest node stream (connPeerId conn))
 
 -- | Handle an inbound DHT RPC request.
 handleDHTRequest :: DHTNode -> StreamIO -> PeerId -> IO ()

--- a/src/LibP2P/Protocol/GossipSub/Handler.hs
+++ b/src/LibP2P/Protocol/GossipSub/Handler.hs
@@ -190,7 +190,7 @@ startGossipSub :: GossipSubNode -> IO ()
 startGossipSub node = do
   -- Register inbound stream handler on Switch
   setStreamHandler (gsnSwitch node) gossipSubProtocolId
-    (handleGossipSubStream node)
+    (\conn stream -> handleGossipSubStream node stream (connPeerId conn))
   -- Register connection notifier to auto-open GossipSub streams to new peers
   atomically $ modifyTVar' (swNotifiers (gsnSwitch node))
     (onNewConnection node :)

--- a/src/LibP2P/Protocol/Identify.hs
+++ b/src/LibP2P/Protocol/Identify.hs
@@ -33,7 +33,6 @@ import Control.Exception (SomeException, catch)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
-import LibP2P.Crypto.PeerId (PeerId)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Crypto.Key (kpPublic)
 import LibP2P.Multiaddr.Codec (encodeProtocols)
@@ -69,9 +68,10 @@ identifyPushProtocolId = "/ipfs/id/push/1.0.0"
 --
 -- Sends our local IdentifyInfo as a varint-length-prefixed protobuf,
 -- then closes the stream (per specs/identify: respond and close).
-handleIdentify :: Switch -> StreamIO -> PeerId -> IO ()
-handleIdentify sw stream _remotePeerId = do
-  info <- buildLocalIdentify sw Nothing
+-- The connection provides the remote address used for observedAddr.
+handleIdentify :: Switch -> Connection -> StreamIO -> IO ()
+handleIdentify sw conn stream = do
+  info <- buildLocalIdentify sw (Just conn)
   streamWrite stream (encodeFramedIdentify info)
   streamClose stream
 
@@ -92,14 +92,14 @@ requestIdentify conn = do
 -- Reads the pushed varint-length-prefixed IdentifyInfo from the remote
 -- peer. The length prefix is the message boundary — identify push has
 -- no stream-close boundary to fall back on.
-handleIdentifyPush :: Switch -> StreamIO -> PeerId -> IO ()
-handleIdentifyPush sw stream remotePeerId = do
+handleIdentifyPush :: Switch -> Connection -> StreamIO -> IO ()
+handleIdentifyPush sw conn stream = do
   infoOrErr <- readFramedIdentify stream maxIdentifySize
   case infoOrErr of
     Left _ -> pure ()
     Right info -> atomically $ do
       store <- readTVar (swPeerStore sw)
-      writeTVar (swPeerStore sw) (Map.insert remotePeerId info store)
+      writeTVar (swPeerStore sw) (Map.insert (connPeerId conn) info store)
 
 -- | Build our local IdentifyInfo from Switch state.
 buildLocalIdentify :: Switch -> Maybe Connection -> IO IdentifyInfo

--- a/src/LibP2P/Protocol/Ping.hs
+++ b/src/LibP2P/Protocol/Ping.hs
@@ -104,7 +104,8 @@ sendPing conn = do
 registerPingHandler :: Switch -> IO ()
 registerPingHandler sw = atomically $ do
   protos <- readTVar (swProtocols sw)
-  writeTVar (swProtocols sw) (Map.insert pingProtocolId handlePing protos)
+  let handler conn stream = handlePing stream (connPeerId conn)
+  writeTVar (swProtocols sw) (Map.insert pingProtocolId handler protos)
 
 -- | Read exactly n bytes from a StreamIO.
 readExact :: StreamIO -> Int -> IO ByteString

--- a/src/LibP2P/Switch/Listen.hs
+++ b/src/LibP2P/Switch/Listen.hs
@@ -126,7 +126,7 @@ dispatchStream sw conn stream = do
       -- Look up the handler for the negotiated protocol
       mHandler <- lookupHandler proto
       case mHandler of
-        Just handler -> handler stream (connPeerId conn)
+        Just handler -> handler conn stream
         Nothing -> pure ()  -- Should not happen: proto was in supported list
     NoProtocol -> pure ()  -- No common protocol, stream will be closed
   where

--- a/src/LibP2P/Switch/Types.hs
+++ b/src/LibP2P/Switch/Types.hs
@@ -63,8 +63,11 @@ data Connection = Connection
 
 -- | A protocol stream handler.
 --
--- Receives the stream I/O and the remote peer's identity.
-type StreamHandler = StreamIO -> PeerId -> IO ()
+-- Receives the connection the stream runs over and the stream I/O.
+-- The connection exposes the remote peer identity ('connPeerId') and
+-- addresses ('connRemoteAddr', 'connLocalAddr'), which protocols like
+-- Identify (observedAddr) and the NAT stack need.
+type StreamHandler = Connection -> StreamIO -> IO ()
 
 -- | Events emitted by the Switch for observability.
 data SwitchEvent

--- a/test/LibP2P/Protocol/Identify/IdentifySpec.hs
+++ b/test/LibP2P/Protocol/Identify/IdentifySpec.hs
@@ -7,6 +7,7 @@ import Control.Concurrent.STM
   , atomically
   , newEmptyTMVarIO
   , newTQueueIO
+  , newTVarIO
   , putTMVar
   , readTQueue
   , readTVar
@@ -22,11 +23,20 @@ import LibP2P.Crypto.Key (kpPublic)
 import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
+import LibP2P.Multiaddr (Multiaddr (..))
+import LibP2P.Multiaddr.Codec (encodeProtocols)
+import LibP2P.Multiaddr.Protocol (Protocol (..))
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
 import LibP2P.Protocol.Identify
 import LibP2P.Protocol.Identify.Message (IdentifyInfo (..), decodeIdentify, encodeIdentify, maxIdentifySize)
 import LibP2P.Switch (newSwitch, setStreamHandler)
-import LibP2P.Switch.Types (Switch (..))
+import LibP2P.Switch.Types
+  ( ConnState (..)
+  , Connection (..)
+  , Direction (..)
+  , MuxerSession (..)
+  , Switch (..)
+  )
 import Data.Word (Word8)
 import System.IO.Error (mkIOError, eofErrorType)
 import Test.Hspec
@@ -40,6 +50,25 @@ mkTestSwitch = do
   setStreamHandler sw "/test/1.0.0" (\_ _ -> pure ())
   setStreamHandler sw "/test/2.0.0" (\_ _ -> pure ())
   pure sw
+
+-- | Create a dummy upgraded Connection with a known remote multiaddr.
+mkTestConnection :: PeerId -> Multiaddr -> IO Connection
+mkTestConnection pid remoteAddr = do
+  stateVar <- newTVarIO ConnOpen
+  pure Connection
+    { connPeerId     = pid
+    , connDirection  = Inbound
+    , connLocalAddr  = Multiaddr [IP4 0x7f000001, TCP 0]
+    , connRemoteAddr = remoteAddr
+    , connSecurity   = "/noise"
+    , connMuxer      = "/yamux/1.0.0"
+    , connSession    = MuxerSession
+        { muxOpenStream   = fail "test connection: no muxer"
+        , muxAcceptStream = fail "test connection: no muxer"
+        , muxClose        = pure ()
+        }
+    , connState      = stateVar
+    }
 
 -- | Create a stream pair where the writer can signal EOF via streamClose.
 -- After close is called, reads on the other side throw an IOError.
@@ -114,8 +143,9 @@ spec = do
     it "handleIdentify writes a varint-length-prefixed protobuf" $ do
       sw <- mkTestSwitch
       (streamA, streamB) <- mkClosableStreamPair
+      conn <- mkTestConnection (PeerId "remote") (Multiaddr [IP4 0x7f000001, TCP 4001])
       -- handleIdentify writes the framed protobuf to streamA and closes it (EOF)
-      writer <- async $ handleIdentify sw streamA (PeerId "remote")
+      writer <- async $ handleIdentify sw conn streamA
       -- Read all raw bytes from streamB until EOF
       bytesOrErr <- readAllBytes streamB
       wait writer
@@ -131,6 +161,24 @@ spec = do
               Right info -> do
                 idProtocolVersion info `shouldBe` Just "ipfs/0.1.0"
                 idAgentVersion info `shouldBe` Just "libp2p-hs/0.1.0"
+
+    it "handleIdentify populates observedAddr with the connection's remote address" $ do
+      sw <- mkTestSwitch
+      (streamA, streamB) <- mkClosableStreamPair
+      -- The address of the remote peer as seen by us (specs/identify: observedAddr)
+      let observedProtos = [IP4 0x7f000001, TCP 45678]
+      conn <- mkTestConnection (PeerId "remote") (Multiaddr observedProtos)
+      writer <- async $ handleIdentify sw conn streamA
+      bytesOrErr <- readAllBytes streamB
+      wait writer
+      case bytesOrErr of
+        Left err -> expectationFailure $ "reading stream failed: " ++ err
+        Right bs -> case decodeUvarint bs of
+          Left err -> expectationFailure $ "no varint length prefix: " ++ err
+          Right (_len, payload) -> case decodeIdentify payload of
+            Left parseErr -> expectationFailure $ "Decode failed: " ++ show parseErr
+            Right info ->
+              idObservedAddr info `shouldBe` Just (encodeProtocols observedProtos)
 
     it "handleIdentify closes stream after writing (signals EOF)" $ do
       sw <- mkTestSwitch
@@ -163,7 +211,8 @@ spec = do
             , streamClose    = pure ()
             }
       -- handleIdentify should write + close the stream
-      writer <- async $ handleIdentify sw testStream (PeerId "remote")
+      conn <- mkTestConnection (PeerId "remote") (Multiaddr [IP4 0x7f000001, TCP 4001])
+      writer <- async $ handleIdentify sw conn testStream
       bytesOrErr <- readAllBytes readerStream
       wait writer
       -- Stream close should have been called by handleIdentify
@@ -191,7 +240,8 @@ spec = do
       streamWrite streamA (frame encoded)
       streamClose streamA
       -- handleIdentifyPush reads from streamB
-      handleIdentifyPush sw streamB remotePeerId
+      conn <- mkTestConnection remotePeerId (Multiaddr [IP4 0x7f000001, TCP 4001])
+      handleIdentifyPush sw conn streamB
       -- Check peer store
       store <- atomically $ readTVar (swPeerStore sw)
       case Map.lookup remotePeerId store of

--- a/test/LibP2P/Switch/ListenSpec.hs
+++ b/test/LibP2P/Switch/ListenSpec.hs
@@ -137,8 +137,8 @@ spec = do
       sw <- newSwitch pidB kpB
       -- Register a handler that signals when called via MVar
       handlerDone <- newEmptyMVar
-      setStreamHandler sw "/test/1.0.0" $ \_stream peerId ->
-        putMVar handlerDone peerId
+      setStreamHandler sw "/test/1.0.0" $ \conn _stream ->
+        putMVar handlerDone (connPeerId conn)
       -- Set up upgraded connections (dialer=outbound, listener=inbound)
       (streamA, streamB) <- mkMemoryStreamPair
       let rawConnA = mkMockRawConn streamA localAddr remoteAddr
@@ -158,6 +158,34 @@ spec = do
       case result of
         Nothing -> expectationFailure "timeout: stream not dispatched to handler"
         Just receivedPeerId -> receivedPeerId `shouldBe` pidA
+      muxClose (connSession connDialer)
+      muxClose (connSession connListener)
+
+    it "passes the Connection so the handler can see the remote address" $ do
+      (_pidA, kpA) <- mkTestIdentity
+      (pidB, kpB) <- mkTestIdentity
+      sw <- newSwitch pidB kpB
+      -- Register a handler that reports the connection's remote multiaddr
+      handlerDone <- newEmptyMVar
+      setStreamHandler sw "/test/1.0.0" $ \conn _stream ->
+        putMVar handlerDone (connRemoteAddr conn)
+      -- Set up upgraded connections (dialer=outbound, listener=inbound)
+      (streamA, streamB) <- mkMemoryStreamPair
+      let rawConnA = mkMockRawConn streamA localAddr remoteAddr
+          rawConnB = mkMockRawConn streamB remoteAddr localAddr
+      (connDialer, connListener) <- concurrently
+        (upgradeOutbound kpA rawConnA)
+        (upgradeInbound kpB rawConnB)
+      _loopThread <- async $ streamAcceptLoop sw connListener
+      result <- timeout 5000000 $ do
+        dialerStream <- muxOpenStream (connSession connDialer)
+        negResult <- negotiateInitiator dialerStream ["/test/1.0.0"]
+        case negResult of
+          Accepted _ -> takeMVar handlerDone
+          _          -> fail "protocol negotiation failed"
+      case result of
+        Nothing -> expectationFailure "timeout: stream not dispatched to handler"
+        Just seenAddr -> seenAddr `shouldBe` connRemoteAddr connListener
       muxClose (connSession connDialer)
       muxClose (connSession connListener)
 


### PR DESCRIPTION
## Summary

`StreamHandler` only carried the stream and the remote peer id, so no protocol handler could see the connection it was running over. This made identify's `observedAddr` (spec field 4) structurally impossible to send, and blocked every NAT-side connection check (AutoNAT amplification guard, relay/DCUtR relayed-connection checks).

## Changes

- Widen `StreamHandler` to `Connection -> StreamIO -> IO ()` (`Switch/Types.hs`); dispatch passes the full `Connection` (`Switch/Listen.hs`). `connPeerId` makes the old peer-id argument redundant.
- `handleIdentify` builds its response with the connection, so `observedAddr` now carries the remote peer's address as observed locally, per [specs/identify](https://github.com/libp2p/specs/tree/master/identify).
- `handleIdentifyPush` derives the remote peer id from the connection.
- Ping, DHT, and GossipSub registrations adapt with `connPeerId`; their protocol-logic function signatures are untouched to keep the diff minimal.

## Tests

- New: identify response over a connection with a known remote multiaddr carries that address in `observedAddr` (varint-framed protobuf).
- New: a dispatched stream handler can read `connRemoteAddr` of the connection it runs over.
- Full suite: 701 examples, 0 failures (GHC 9.10.1).

Closes #167
Closes #145