### PR TITLE
fix(switch): tear down connections when sessions die, close, or shut down

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -53,6 +53,7 @@ library
     LibP2P.Transport.TCP
     LibP2P.Switch.Types
     LibP2P.Switch.ConnPool
+    LibP2P.Switch.Connection
     LibP2P.Switch
     LibP2P.Switch.Dial
     LibP2P.Switch.Listen
@@ -143,6 +144,7 @@ test-suite libp2p-hs-test
     LibP2P.Yamux.SessionSpec
     LibP2P.Transport.TCPSpec
     LibP2P.Switch.ConnPoolSpec
+    LibP2P.Switch.ConnectionLifecycleSpec
     LibP2P.Switch.SwitchSpec
     LibP2P.Switch.DialSpec
     LibP2P.Switch.ListenSpec

--- a/src/LibP2P.hs
+++ b/src/LibP2P.hs
@@ -45,7 +45,10 @@ module LibP2P
   , switchListenAddrs
   , switchClose
   , dial
+  , closeConnection
+  , newStream
   , DialError (..)
+  , ResourceError (..)
   , setStreamHandler
   , removeStreamHandler
   , StreamIO (..)
@@ -101,9 +104,10 @@ import LibP2P.Protocol.GossipSub.Handler
 import LibP2P.Protocol.GossipSub.Types (GossipSubParams (..), defaultGossipSubParams)
 import LibP2P.Protocol.Identify (registerIdentifyHandlers, requestIdentify)
 import LibP2P.Protocol.Ping (PingError (..), PingResult (..), registerPingHandler, sendPing)
+import LibP2P.Switch.Connection (closeConnection, newStream)
 import LibP2P.Switch.Dial (dial)
 import LibP2P.Switch.Listen (ConnectionGater (..), defaultConnectionGater, switchListen, switchListenAddrs)
 import LibP2P.Switch (addTransport, newSwitch, removeStreamHandler, setStreamHandler, switchClose)
-import LibP2P.Switch.Types (Connection (..), DialError (..), StreamHandler, Switch)
+import LibP2P.Switch.Types (Connection (..), DialError (..), ResourceError (..), StreamHandler, Switch)
 import LibP2P.Transport.TCP (newTCPTransport)
 import LibP2P.Transport (Transport (..))

--- a/src/LibP2P/Switch.hs
+++ b/src/LibP2P/Switch.hs
@@ -22,6 +22,7 @@ import LibP2P.Crypto.Key (KeyPair)
 import LibP2P.Crypto.PeerId (PeerId)
 import LibP2P.Multiaddr (Multiaddr)
 import LibP2P.MultistreamSelect.Negotiation (ProtocolId)
+import LibP2P.Switch.Connection (closeAllConnections)
 import LibP2P.Switch.ResourceManager (DefaultLimits (..), defaultPeerLimits, defaultSystemLimits, newResourceManager)
 import LibP2P.Switch.Types (ActiveListener (..), StreamHandler, Switch (..))
 import LibP2P.Transport (Listener (..), Transport (..))
@@ -93,7 +94,8 @@ lookupStreamHandler sw proto = atomically $ do
   pure $ Map.lookup proto protos
 
 -- | Shut down the switch.
--- Cancels all accept loop threads, closes all listeners, then sets the closed flag.
+-- Cancels all accept loop threads, closes all listeners, tears down all
+-- pooled connections, then sets the closed flag.
 switchClose :: Switch -> IO ()
 switchClose sw = do
   -- Read and clear listeners atomically
@@ -104,6 +106,9 @@ switchClose sw = do
     pure ls
   -- Cancel accept loops and close listeners outside STM
   mapM_ closeListener listeners
+  -- Tear down every pooled connection (pool removal, resource release,
+  -- muxer close, transport close)
+  closeAllConnections sw
   where
     closeListener al = do
       cancel (alAcceptLoop al) `catch` (\(_ :: SomeException) -> pure ())

--- a/src/LibP2P/Switch/Connection.hs
+++ b/src/LibP2P/Switch/Connection.hs
@@ -1,0 +1,80 @@
+-- | Connection lifecycle for the Switch.
+--
+-- Provides the single teardown path for upgraded connections and a
+-- resource-accounted outbound stream opener. Teardown fires from the
+-- stream accept loop exit (remote disconnect or session death), from
+-- explicit 'closeConnection' calls, and from 'switchClose' via
+-- 'closeAllConnections'.
+module LibP2P.Switch.Connection
+  ( closeConnection
+  , closeAllConnections
+  , newStream
+  ) where
+
+import Control.Concurrent.STM (atomically, readTVar, writeTChan, writeTVar)
+import Control.Exception (SomeException, catch, finally, onException)
+import Control.Monad (unless, when)
+import Data.IORef (atomicModifyIORef', newIORef)
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.Switch.ConnPool (allConns, removeConn)
+import LibP2P.Switch.ResourceManager
+  ( Direction (..)
+  , ResourceError
+  , releaseConnection
+  , releasePeerStream
+  , reservePeerStream
+  )
+import LibP2P.Switch.Types
+  ( ConnState (..)
+  , Connection (..)
+  , MuxerSession (..)
+  , Switch (..)
+  , SwitchEvent (..)
+  )
+
+-- | Tear down a connection: remove it from the pool, release its
+-- resource reservation, publish a Disconnected event, and close the
+-- muxer session together with the underlying transport.
+--
+-- Idempotent: the state transition to ConnClosed is atomic, so
+-- concurrent calls (accept loop exit, explicit close, switchClose)
+-- perform the teardown exactly once.
+closeConnection :: Switch -> Connection -> IO ()
+closeConnection sw conn = do
+  shouldClose <- atomically $ do
+    st <- readTVar (connState conn)
+    if st == ConnClosed
+      then pure False
+      else do
+        writeTVar (connState conn) ConnClosed
+        removeConn (swConnPool sw) conn
+        releaseConnection (swResourceMgr sw) (connPeerId conn) (connDirection conn)
+        writeTChan (swEvents sw)
+          (Disconnected (connPeerId conn) (connDirection conn) (connRemoteAddr conn))
+        pure True
+  when shouldClose $
+    muxClose (connSession conn) `catch` \(_ :: SomeException) -> pure ()
+
+-- | Tear down every pooled connection (used by switchClose).
+closeAllConnections :: Switch -> IO ()
+closeAllConnections sw = do
+  conns <- atomically $ allConns (swConnPool sw)
+  mapM_ (closeConnection sw) conns
+
+-- | Open an outbound stream on a connection, reserving a stream slot
+-- against the peer's resource scope. The slot is released when the
+-- returned stream is closed (exactly once, even on double close).
+newStream :: Switch -> Connection -> IO (Either ResourceError StreamIO)
+newStream sw conn = do
+  let pid = connPeerId conn
+      release = atomically $ releasePeerStream (swResourceMgr sw) pid Outbound
+  reserved <- atomically $ reservePeerStream (swResourceMgr sw) pid Outbound
+  case reserved of
+    Left err -> pure (Left err)
+    Right () -> do
+      stream <- muxOpenStream (connSession conn) `onException` release
+      releasedRef <- newIORef False
+      let releaseOnce = do
+            already <- atomicModifyIORef' releasedRef (\r -> (True, r))
+            unless already release
+      pure (Right stream { streamClose = streamClose stream `finally` releaseOnce })

--- a/src/LibP2P/Switch/Dial.hs
+++ b/src/LibP2P/Switch/Dial.hs
@@ -34,9 +34,11 @@ import Control.Concurrent.STM
   , putTMVar
   , readTMVar
   , readTVar
+  , tryPutTMVar
+  , writeTChan
   , writeTVar
   )
-import Control.Exception (SomeException)
+import Control.Exception (SomeException, finally, onException)
 import Control.Monad (forM, when)
 import Data.List (find)
 import qualified Data.Map.Strict as Map
@@ -44,6 +46,7 @@ import Data.Time.Clock (NominalDiffTime, addUTCTime, getCurrentTime)
 import LibP2P.Crypto.PeerId (PeerId)
 import LibP2P.Multiaddr (Multiaddr)
 import LibP2P.Switch.ConnPool (addConn, lookupConn)
+import LibP2P.Switch.Connection (closeConnection)
 import LibP2P.Switch.Listen (streamAcceptLoop)
 import LibP2P.Switch.ResourceManager (Direction (..), releaseConnection, reserveConnection)
 import LibP2P.Switch.Types
@@ -52,6 +55,7 @@ import LibP2P.Switch.Types
   , DialError (..)
   , MuxerSession (..)
   , Switch (..)
+  , SwitchEvent (..)
   )
 import LibP2P.Switch.Upgrade (upgradeOutbound)
 import LibP2P.Transport (Transport (..))
@@ -149,8 +153,21 @@ dial sw remotePeerId addrs = do
                   -- Another thread is already dialing; wait for its result
                   atomically $ readTMVar tmvar
                 StartNew tmvar ->
-                  -- We own this dial; execute and broadcast result
+                  -- We own this dial; execute and broadcast result.
+                  -- If the dial throws, fill the TMVar and drop the
+                  -- pending entry so waiters and future dials never
+                  -- wedge on a stale pending dial.
                   dialNewAndBroadcast sw remotePeerId addrs tmvar
+                    `onException` abortPendingDial sw remotePeerId tmvar
+
+-- | Clean up a pending dial whose worker threw an exception.
+-- Fills the TMVar (if still empty) so joined waiters are released,
+-- and removes the pending map entry so future dials can proceed.
+abortPendingDial :: Switch -> PeerId -> TMVar (Either DialError Connection) -> IO ()
+abortPendingDial sw pid tmvar = atomically $ do
+  _ <- tryPutTMVar tmvar (Left (DialAllFailed ["dial aborted by exception"]))
+  pending <- readTVar (swPendingDials sw)
+  writeTVar (swPendingDials sw) (Map.delete pid pending)
 
 -- | Atomically check for an existing pending dial or create one.
 checkPendingDial :: Switch -> PeerId -> STM PendingCheck
@@ -197,9 +214,14 @@ dialNewAndBroadcast sw remotePeerId addrs tmvar = do
       case verified of
         Right conn -> do
           clearBackoff (swDialBackoffs sw) remotePeerId
-          atomically $ addConn (swConnPool sw) conn
-          -- Start accepting inbound streams on the dialer side
-          _ <- async $ streamAcceptLoop sw conn
+          atomically $ do
+            addConn (swConnPool sw) conn
+            writeTChan (swEvents sw)
+              (Connected (connPeerId conn) Outbound (connRemoteAddr conn))
+          -- Start accepting inbound streams on the dialer side; tear the
+          -- connection down when the session dies (pool removal,
+          -- resource release, muxer + transport close).
+          _ <- async $ streamAcceptLoop sw conn `finally` closeConnection sw conn
           -- Notify connection listeners (e.g. GossipSub auto-stream open)
           notifiers <- atomically $ readTVar (swNotifiers sw)
           mapM_ (\f -> async $ f conn) notifiers

--- a/src/LibP2P/Switch/Listen.hs
+++ b/src/LibP2P/Switch/Listen.hs
@@ -19,24 +19,31 @@ module LibP2P.Switch.Listen
   ) where
 
 import Control.Concurrent.Async (async)
-import Control.Concurrent.STM (atomically, readTVar, writeTVar)
-import Control.Exception (SomeException, catch)
+import Control.Concurrent.STM (atomically, readTVar, writeTChan, writeTVar)
+import Control.Exception (SomeException, catch, finally)
 import Data.List (find)
 import qualified Data.Map.Strict as Map
 import LibP2P.Crypto.PeerId (PeerId)
 import LibP2P.Multiaddr (Multiaddr)
 import LibP2P.MultistreamSelect.Negotiation
   ( NegotiationResult (..)
-  , StreamIO
+  , StreamIO (..)
   , negotiateResponder
   )
 import LibP2P.Switch.ConnPool (addConn)
-import LibP2P.Switch.ResourceManager (Direction (..), reserveConnection)
+import LibP2P.Switch.Connection (closeConnection)
+import LibP2P.Switch.ResourceManager
+  ( Direction (..)
+  , releasePeerStream
+  , reserveConnection
+  , reservePeerStream
+  )
 import LibP2P.Switch.Types
   ( ActiveListener (..)
   , Connection (..)
   , MuxerSession (..)
   , Switch (..)
+  , SwitchEvent (..)
   )
 import LibP2P.Switch.Upgrade (upgradeInbound)
 import LibP2P.Transport (Listener (..), RawConnection (..), Transport (..))
@@ -80,13 +87,17 @@ handleInbound sw gater rawConn = do
           case resCheck of
             Left _ -> muxClose (connSession conn)
             Right () -> do
-              -- Add to connection pool
-              atomically $ addConn (swConnPool sw) conn
+              -- Add to connection pool and publish Connected event
+              atomically $ do
+                addConn (swConnPool sw) conn
+                writeTChan (swEvents sw)
+                  (Connected (connPeerId conn) Inbound (connRemoteAddr conn))
               -- Notify connection listeners (e.g. GossipSub auto-stream open)
               notifiers <- atomically $ readTVar (swNotifiers sw)
               mapM_ (\f -> async $ f conn) notifiers
-              -- Block on stream accept loop until connection closes
-              streamAcceptLoop sw conn
+              -- Block on stream accept loop until the session dies, then
+              -- tear down: pool removal, resource release, muxer close.
+              streamAcceptLoop sw conn `finally` closeConnection sw conn
 
 -- | Accept inbound streams and dispatch to registered protocol handlers.
 --
@@ -116,20 +127,31 @@ streamAcceptLoop sw conn = loop
 -- the remote peer wants, then looks up and invokes the registered handler.
 dispatchStream :: Switch -> Connection -> StreamIO -> IO ()
 dispatchStream sw conn stream = do
-  -- Get the list of supported protocols from the Switch
-  supportedProtos <- atomically $
-    Map.keys <$> readProtos
-  -- Run multistream-select responder
-  result <- negotiateResponder stream supportedProtos
-  case result of
-    Accepted proto -> do
-      -- Look up the handler for the negotiated protocol
-      mHandler <- lookupHandler proto
-      case mHandler of
-        Just handler -> handler stream (connPeerId conn)
-        Nothing -> pure ()  -- Should not happen: proto was in supported list
-    NoProtocol -> pure ()  -- No common protocol, stream will be closed
+  -- Reserve an inbound stream slot against the peer's resource scope
+  reserved <- atomically $
+    reservePeerStream (swResourceMgr sw) (connPeerId conn) Inbound
+  case reserved of
+    Left _ ->
+      -- Over the stream limit: refuse the stream without negotiating
+      streamClose stream `catch` \(_ :: SomeException) -> pure ()
+    Right () -> negotiateAndDispatch `finally` release
   where
+    release = atomically $
+      releasePeerStream (swResourceMgr sw) (connPeerId conn) Inbound
+    negotiateAndDispatch = do
+      -- Get the list of supported protocols from the Switch
+      supportedProtos <- atomically $
+        Map.keys <$> readProtos
+      -- Run multistream-select responder
+      result <- negotiateResponder stream supportedProtos
+      case result of
+        Accepted proto -> do
+          -- Look up the handler for the negotiated protocol
+          mHandler <- lookupHandler proto
+          case mHandler of
+            Just handler -> handler stream (connPeerId conn)
+            Nothing -> pure ()  -- Should not happen: proto was in supported list
+        NoProtocol -> pure ()  -- No common protocol, stream will be closed
     readProtos = readTVar (swProtocols sw)
     lookupHandler proto = atomically $
       Map.lookup proto <$> readTVar (swProtocols sw)

--- a/src/LibP2P/Switch/ResourceManager.hs
+++ b/src/LibP2P/Switch/ResourceManager.hs
@@ -30,6 +30,8 @@ module LibP2P.Switch.ResourceManager
   , releaseConnection
   , reserveStream
   , releaseStream
+  , reservePeerStream
+  , releasePeerStream
     -- * Bracket patterns
   , withConnection
   , withStream
@@ -190,6 +192,20 @@ reserveStream scope dir = reserveStreamInScope scope dir
 -- | Release a stream in the given scope (walks up to parent).
 releaseStream :: ResourceScope -> Direction -> STM ()
 releaseStream scope dir = releaseStreamInScope scope dir
+
+-- | Reserve a stream against a peer's scope (peer scope → system scope).
+reservePeerStream :: ResourceManager -> PeerId -> Direction -> STM (Either ResourceError ())
+reservePeerStream rm pid dir = do
+  peerScope <- getOrCreatePeerScope rm pid
+  reserveStream peerScope dir
+
+-- | Release a stream against a peer's scope (peer scope → system scope).
+releasePeerStream :: ResourceManager -> PeerId -> Direction -> STM ()
+releasePeerStream rm pid dir = do
+  peers <- readTVar (rmPeerScopes rm)
+  case Map.lookup pid peers of
+    Nothing -> pure ()
+    Just peerScope -> releaseStream peerScope dir
 
 -- | Bracket: reserve connection, run action, release on exit (even on exception).
 withConnection :: ResourceManager -> PeerId -> Direction -> IO a -> IO a

--- a/src/LibP2P/Switch/Upgrade.hs
+++ b/src/LibP2P/Switch/Upgrade.hs
@@ -24,9 +24,10 @@ module LibP2P.Switch.Upgrade
   , writeFramedMessage
   ) where
 
-import Control.Concurrent.Async (async)
-import Control.Concurrent.STM (newTVarIO)
-import Control.Monad (replicateM)
+import Control.Concurrent.Async (async, cancel, race, waitCatch)
+import Control.Concurrent.STM (atomically, isEmptyTQueue, newTVarIO, retry)
+import Control.Exception (SomeException, catch)
+import Control.Monad (replicateM, unless)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -39,7 +40,7 @@ import LibP2P.Yamux.Session (closeSession, newSession, recvLoop, sendLoop)
 import qualified LibP2P.Yamux.Session as Yamux
 import LibP2P.Yamux.Stream (streamRead)
 import qualified LibP2P.Yamux.Stream as YS
-import LibP2P.Yamux.Types (SessionRole (..), YamuxSession, YamuxStream)
+import LibP2P.Yamux.Types (SessionRole (..), YamuxSession (ysessSendCh), YamuxStream)
 import LibP2P.MultistreamSelect.Negotiation
   ( NegotiationResult (..)
   , StreamIO (..)
@@ -72,6 +73,7 @@ import LibP2P.Switch.Types
   , MuxerSession (..)
   )
 import LibP2P.Transport (RawConnection (..))
+import System.Timeout (timeout)
 import qualified LibP2P.Crypto.Protobuf as Proto
 import qualified LibP2P.Noise.Handshake as HS
 
@@ -260,15 +262,24 @@ decryptAndReadByte recvRef bufRef rawIO = do
       writeIORef bufRef (BS.tail buf)
       pure (BS.head buf)
 
+-- | Bounded window given to the send loop to flush the GoAway frame
+-- before the transport is closed underneath it.
+goAwayFlushTimeoutUs :: Int
+goAwayFlushTimeoutUs = 200000
+
 -- | Wrap a YamuxSession as a MuxerSession.
 -- Starts sendLoop and recvLoop as background threads.
 -- The MuxerSession provides open/accept stream operations that
 -- produce StreamIO-compatible streams.
-yamuxToMuxerSession :: YamuxSession -> IO MuxerSession
-yamuxToMuxerSession yamuxSess = do
+--
+-- The supplied close action closes the underlying transport; muxClose
+-- runs it after sending GoAway and stopping the session loops, so
+-- closing a connection actually releases the socket.
+yamuxToMuxerSession :: YamuxSession -> IO () -> IO MuxerSession
+yamuxToMuxerSession yamuxSess closeTransport = do
   -- Start background loops
-  _ <- async (sendLoop yamuxSess)
-  _ <- async (recvLoop yamuxSess)
+  sendLoopA <- async (sendLoop yamuxSess)
+  recvLoopA <- async (recvLoop yamuxSess)
   pure MuxerSession
     { muxOpenStream = do
         result <- Yamux.openStream yamuxSess
@@ -276,11 +287,25 @@ yamuxToMuxerSession yamuxSess = do
           Right stream -> yamuxStreamToStreamIO stream
           Left err -> fail $ "muxOpenStream: " <> show err
     , muxAcceptStream = do
-        result <- Yamux.acceptStream yamuxSess
+        -- Fail the accept as soon as the receive loop dies (remote
+        -- GoAway followed by EOF, transport error, or local close), so
+        -- the Switch's stream accept loop exits and tears down the
+        -- connection instead of blocking forever.
+        result <- race (waitCatch recvLoopA) (Yamux.acceptStream yamuxSess)
         case result of
-          Right stream -> yamuxStreamToStreamIO stream
-          Left err -> fail $ "muxAcceptStream: " <> show err
-    , muxClose = closeSession yamuxSess
+          Left _ -> fail "muxAcceptStream: session terminated"
+          Right (Right stream) -> yamuxStreamToStreamIO stream
+          Right (Left err) -> fail $ "muxAcceptStream: " <> show err
+    , muxClose = do
+        -- Queue GoAway, give the send loop a bounded window to flush
+        -- it, then stop the loops and close the underlying transport.
+        closeSession yamuxSess
+        _ <- timeout goAwayFlushTimeoutUs $ atomically $ do
+          empty <- isEmptyTQueue (ysessSendCh yamuxSess)
+          unless empty retry
+        cancel sendLoopA
+        cancel recvLoopA
+        closeTransport `catch` \(_ :: SomeException) -> pure ()
     }
 
 -- | Convert a YamuxStream to StreamIO with a read buffer.
@@ -348,7 +373,7 @@ upgradeOutbound identityKP rawConn = do
   let yamuxWrite = streamWrite encryptedIO
       yamuxRead  = \n -> readExact encryptedIO n
   yamuxSess <- newSession RoleClient yamuxWrite yamuxRead
-  muxer <- yamuxToMuxerSession yamuxSess
+  muxer <- yamuxToMuxerSession yamuxSess (rcClose rawConn)
 
   -- Build Connection
   stateVar <- newTVarIO ConnOpen
@@ -395,7 +420,7 @@ upgradeInbound identityKP rawConn = do
   let yamuxWrite = streamWrite encryptedIO
       yamuxRead  = \n -> readExact encryptedIO n
   yamuxSess <- newSession RoleServer yamuxWrite yamuxRead
-  muxer <- yamuxToMuxerSession yamuxSess
+  muxer <- yamuxToMuxerSession yamuxSess (rcClose rawConn)
 
   -- Build Connection
   stateVar <- newTVarIO ConnOpen

--- a/test/LibP2P/Switch/ConnectionLifecycleSpec.hs
+++ b/test/LibP2P/Switch/ConnectionLifecycleSpec.hs
@@ -1,0 +1,298 @@
+-- | Connection lifecycle tests (issue #179).
+--
+-- Verifies that connections are actually torn down: pool removal on
+-- remote disconnect, explicit closeConnection, switchClose teardown,
+-- resource release, stream slot accounting, and dial dedup cleanup.
+module LibP2P.Switch.ConnectionLifecycleSpec (spec) where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (async)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent.STM (atomically, newTVarIO, readTVar)
+import Control.Exception (SomeException, try)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Maybe (isJust, isNothing)
+import qualified Data.Map.Strict as Map
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair, publicKey)
+import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.Multiaddr (Multiaddr (..))
+import LibP2P.Multiaddr.Protocol (Protocol (..))
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), mkMemoryStreamPair, negotiateInitiator)
+import LibP2P.Switch (addTransport, newSwitch, setStreamHandler, switchClose)
+import LibP2P.Switch.ConnPool (addConn, lookupConn)
+import LibP2P.Switch.Connection (closeConnection, newStream)
+import LibP2P.Switch.Dial (dial)
+import LibP2P.Switch.Listen (defaultConnectionGater, dispatchStream, switchListen)
+import LibP2P.Switch.ResourceManager
+  ( ResourceManager (..)
+  , ResourceScope (..)
+  , ResourceUsage (..)
+  )
+import LibP2P.Switch.Types
+  ( ConnState (..)
+  , Connection (..)
+  , DialError (..)
+  , Direction (..)
+  , MuxerSession (..)
+  , Switch (..)
+  )
+import LibP2P.Switch.Upgrade (upgradeInbound)
+import LibP2P.Transport (RawConnection (..), Transport (..))
+import LibP2P.Transport.TCP (newTCPTransport)
+import System.Timeout (timeout)
+import Test.Hspec
+
+-- | Generate a test identity (PeerId, KeyPair).
+mkTestIdentity :: IO (PeerId, KeyPair)
+mkTestIdentity = do
+  Right kp <- generateKeyPair
+  let pid = fromPublicKey (publicKey kp)
+  pure (pid, kp)
+
+-- | A test multiaddr: /ip4/127.0.0.1/tcp/4001
+testAddr :: Multiaddr
+testAddr = Multiaddr [IP4 0x7f000001, TCP 4001]
+
+-- | Loopback address with port 0 (OS assigns ephemeral port).
+loopbackAddr :: Multiaddr
+loopbackAddr = Multiaddr [IP4 0x7f000001, TCP 0]
+
+-- | Poll a condition every 100ms, up to n attempts.
+waitUntil :: Int -> IO Bool -> IO Bool
+waitUntil 0 _ = pure False
+waitUntil n check = do
+  ok <- check
+  if ok
+    then pure True
+    else threadDelay 100000 >> waitUntil (n - 1) check
+
+-- | Read the peer scope usage for a peer, if the scope exists.
+peerUsage :: Switch -> PeerId -> IO (Maybe ResourceUsage)
+peerUsage sw pid = atomically $ do
+  peers <- readTVar (rmPeerScopes (swResourceMgr sw))
+  case Map.lookup pid peers of
+    Nothing -> pure Nothing
+    Just scope -> Just <$> readTVar (rsUsage scope)
+
+-- | A dummy connection whose muxer serves in-memory streams.
+mkDummyConnection :: PeerId -> IO StreamIO -> IO Connection
+mkDummyConnection pid openAction = do
+  stateVar <- newTVarIO ConnOpen
+  pure Connection
+    { connPeerId     = pid
+    , connDirection  = Outbound
+    , connLocalAddr  = Multiaddr [IP4 0x7f000001, TCP 0]
+    , connRemoteAddr = testAddr
+    , connSecurity   = "/noise"
+    , connMuxer      = "/yamux/1.0.0"
+    , connSession    = MuxerSession
+        { muxOpenStream   = openAction
+        , muxAcceptStream = fail "dummy: no inbound streams"
+        , muxClose        = pure ()
+        }
+    , connState      = stateVar
+    }
+
+-- | Mock transport whose dialed connection records rcClose calls in an IORef.
+mkClosableMockTransport :: KeyPair -> IORef Bool -> IO Transport
+mkClosableMockTransport responderKP closedRef = pure Transport
+  { transportDial = \addr -> do
+      (streamA, streamB) <- mkMemoryStreamPair
+      let rawConnB = RawConnection
+            { rcStreamIO   = streamB
+            , rcLocalAddr  = addr
+            , rcRemoteAddr = Multiaddr [IP4 0x7f000001, TCP 0]
+            , rcClose      = pure ()
+            }
+      _ <- async $ do
+        _ <- upgradeInbound responderKP rawConnB
+        pure ()
+      pure RawConnection
+        { rcStreamIO   = streamA
+        , rcLocalAddr  = Multiaddr [IP4 0x7f000001, TCP 0]
+        , rcRemoteAddr = addr
+        , rcClose      = writeIORef closedRef True
+        }
+  , transportListen = \_ -> error "mock: listen not supported"
+  , transportCanDial = \(Multiaddr ps) -> case ps of
+      (IP4 _ : TCP _ : _) -> True
+      _ -> False
+  }
+
+-- | Build a TCP node with Switch.
+mkTCPNode :: IO (Switch, PeerId)
+mkTCPNode = do
+  (pid, kp) <- mkTestIdentity
+  sw <- newSwitch pid kp
+  tcp <- newTCPTransport
+  addTransport sw tcp
+  pure (sw, pid)
+
+spec :: Spec
+spec = do
+  describe "closeConnection" $ do
+    it "removes the connection from the pool, closes the transport, and releases the reservation" $ do
+      (localPid, localKP) <- mkTestIdentity
+      (_remotePid, remoteKP) <- mkTestIdentity
+      sw <- newSwitch localPid localKP
+      closedRef <- newIORef False
+      transport <- mkClosableMockTransport remoteKP closedRef
+      addTransport sw transport
+      result <- dial sw _remotePid [testAddr]
+      case result of
+        Left err -> expectationFailure $ "dial failed: " <> show err
+        Right conn -> do
+          -- Reservation is held while the connection lives
+          usageBefore <- peerUsage sw (connPeerId conn)
+          fmap ruConnsOutbound usageBefore `shouldBe` Just 1
+          closeConnection sw conn
+          -- Pool no longer contains the connection
+          poolConn <- atomically $ lookupConn (swConnPool sw) (connPeerId conn)
+          isNothing poolConn `shouldBe` True
+          -- Connection state is ConnClosed
+          st <- atomically $ readTVar (connState conn)
+          st `shouldBe` ConnClosed
+          -- Underlying transport was closed
+          closedOk <- waitUntil 20 (readIORef closedRef)
+          closedOk `shouldBe` True
+          -- Connection reservation was released
+          usageAfter <- peerUsage sw (connPeerId conn)
+          fmap ruConnsOutbound usageAfter `shouldBe` Just 0
+
+    it "is idempotent (double close does not underflow the reservation)" $ do
+      (localPid, localKP) <- mkTestIdentity
+      (_remotePid, remoteKP) <- mkTestIdentity
+      sw <- newSwitch localPid localKP
+      closedRef <- newIORef False
+      transport <- mkClosableMockTransport remoteKP closedRef
+      addTransport sw transport
+      Right conn <- dial sw _remotePid [testAddr]
+      closeConnection sw conn
+      closeConnection sw conn
+      usage <- peerUsage sw (connPeerId conn)
+      fmap ruConnsOutbound usage `shouldBe` Just 0
+
+  describe "remote disconnect" $ do
+    it "removes the connection from the pool when the remote closes; a fresh dial succeeds" $ do
+      (swB, pidB) <- mkTCPNode
+      addrs <- switchListen swB defaultConnectionGater [loopbackAddr]
+      let listenAddr = head addrs
+      (swA, pidA) <- mkTCPNode
+      Right conn <- dial swA pidB [listenAddr]
+      -- Wait for B to pool the inbound connection
+      pooledOk <- waitUntil 30 $ do
+        c <- atomically $ lookupConn (swConnPool swB) pidA
+        pure (isJust c)
+      pooledOk `shouldBe` True
+      -- B closes its side of the connection
+      Just connB <- atomically $ lookupConn (swConnPool swB) pidA
+      closeConnection swB connB
+      -- A must notice the dead session and drop the connection from its pool
+      droppedOk <- waitUntil 50 $ do
+        c <- atomically $ lookupConn (swConnPool swA) pidB
+        pure (isNothing c)
+      droppedOk `shouldBe` True
+      -- A's connection reservation must be released
+      usageA <- peerUsage swA pidB
+      fmap ruConnsOutbound usageA `shouldBe` Just 0
+      -- A subsequent dial creates a fresh connection
+      redialResult <- timeout 5000000 $ dial swA pidB [listenAddr]
+      case redialResult of
+        Nothing -> expectationFailure "redial timed out"
+        Just (Left err) -> expectationFailure $ "redial failed: " <> show err
+        Just (Right conn2) ->
+          -- Fresh connection: distinct state TVar
+          (connState conn2 == connState conn) `shouldBe` False
+      switchClose swA
+      switchClose swB
+
+  describe "switchClose" $ do
+    it "closes pooled connections on both sides" $ do
+      (swB, pidB) <- mkTCPNode
+      addrs <- switchListen swB defaultConnectionGater [loopbackAddr]
+      let listenAddr = head addrs
+      (swA, pidA) <- mkTCPNode
+      Right conn <- dial swA pidB [listenAddr]
+      pooledOk <- waitUntil 30 $ do
+        c <- atomically $ lookupConn (swConnPool swB) pidA
+        pure (isJust c)
+      pooledOk `shouldBe` True
+      switchClose swA
+      -- A's pool is emptied and the connection is closed
+      poolA <- atomically $ lookupConn (swConnPool swA) pidB
+      isNothing poolA `shouldBe` True
+      st <- atomically $ readTVar (connState conn)
+      st `shouldBe` ConnClosed
+      -- B notices the remote disconnect and drops A from its pool
+      droppedOk <- waitUntil 50 $ do
+        c <- atomically $ lookupConn (swConnPool swB) pidA
+        pure (isNothing c)
+      droppedOk `shouldBe` True
+      switchClose swB
+
+  describe "stream resource accounting" $ do
+    it "newStream reserves an outbound stream slot and releases it on close" $ do
+      (localPid, localKP) <- mkTestIdentity
+      (remotePid, _remoteKP) <- mkTestIdentity
+      sw <- newSwitch localPid localKP
+      (sIO, _peerIO) <- mkMemoryStreamPair
+      conn <- mkDummyConnection remotePid (pure sIO)
+      atomically $ addConn (swConnPool sw) conn
+      result <- newStream sw conn
+      case result of
+        Left err -> expectationFailure $ "newStream failed: " <> show err
+        Right stream -> do
+          usageOpen <- peerUsage sw remotePid
+          fmap ruStreamsOutbound usageOpen `shouldBe` Just 1
+          streamClose stream
+          usageClosed <- peerUsage sw remotePid
+          fmap ruStreamsOutbound usageClosed `shouldBe` Just 0
+          -- Double close releases only once
+          streamClose stream
+          usageDouble <- peerUsage sw remotePid
+          fmap ruStreamsOutbound usageDouble `shouldBe` Just 0
+
+    it "dispatchStream counts an inbound stream against the peer limit and releases it" $ do
+      (localPid, localKP) <- mkTestIdentity
+      (remotePid, _remoteKP) <- mkTestIdentity
+      sw <- newSwitch localPid localKP
+      usageMVar <- newEmptyMVar
+      setStreamHandler sw "/test/1.0.0" $ \_stream _pid -> do
+        usage <- peerUsage sw remotePid
+        putMVar usageMVar (fmap ruStreamsInbound usage)
+      conn <- mkDummyConnection remotePid (fail "no outbound")
+      (clientIO, serverIO) <- mkMemoryStreamPair
+      _ <- async $ negotiateInitiator clientIO ["/test/1.0.0"]
+      dispatchResult <- timeout 5000000 $ dispatchStream sw conn serverIO
+      dispatchResult `shouldBe` Just ()
+      -- During the handler, the inbound stream slot was held
+      heldUsage <- takeMVar usageMVar
+      heldUsage `shouldBe` Just 1
+      -- After dispatch completes, the slot is released
+      usageAfter <- peerUsage sw remotePid
+      fmap ruStreamsInbound usageAfter `shouldBe` Just 0
+
+  describe "dial dedup" $ do
+    it "removes the pending entry when the dial throws" $ do
+      (localPid, localKP) <- mkTestIdentity
+      (remotePid, _remoteKP) <- mkTestIdentity
+      sw <- newSwitch localPid localKP
+      -- A transport whose canDial check blows up mid-dial
+      addTransport sw Transport
+        { transportDial = \_ -> fail "unreachable"
+        , transportListen = \_ -> error "mock: listen not supported"
+        , transportCanDial = \_ -> error "boom: canDial exploded"
+        }
+      firstResult <- try (dial sw remotePid [testAddr]) :: IO (Either SomeException (Either DialError Connection))
+      case firstResult of
+        Left _ -> pure ()  -- Expected: the dial threw
+        Right _ -> expectationFailure "expected the dial to throw"
+      -- The pending dial entry must have been cleaned up
+      pendingMap <- atomically $ readTVar (swPendingDials sw)
+      Map.member remotePid pendingMap `shouldBe` False
+      -- A subsequent dial must not wedge on the stale entry
+      secondResult <- timeout 2000000 (try (dial sw remotePid [testAddr]) :: IO (Either SomeException (Either DialError Connection)))
+      case secondResult of
+        Nothing -> expectationFailure "second dial wedged on a stale pending entry"
+        Just _ -> pure ()


### PR DESCRIPTION
## Summary

Fixes the switch's missing connection teardown (#179): `removeConn`, `releaseConnection` and `reserveStream` had zero production callers, so dead connections stayed in the pool forever, per-peer connection reservations accumulated until dialing a peer became permanently impossible, and stream limits were declared but unenforced.

Follows go-libp2p's swarm lifecycle model: when a muxed session ends, the Switch removes the connection from its pool, releases its resource reservation, closes the muxer and the underlying socket, and publishes a `Disconnected` event.

## Changes

- **New `LibP2P.Switch.Connection`**: idempotent `closeConnection` (pool removal, resource release, `Disconnected` event, muxer + transport close, `ConnClosed` state), `closeAllConnections`, and a resource-accounted `newStream` for outbound streams.
- **Teardown fires from every session-death path**: stream accept loop exit on both listener and dialer sides (`finally`), and `switchClose`, which previously never touched `swConnPool`.
- **Session death is observable**: `muxAcceptStream` now races the yamux receive loop, so remote GoAway/EOF/transport errors end the accept loop instead of blocking forever; `muxClose` sends GoAway with a bounded flush window, cancels the session loops, and closes the raw transport socket.
- **Stream limits enforced**: `dispatchStream` reserves an inbound stream slot per peer (refusing streams over the limit) and releases it when dispatch completes; `newStream` reserves an outbound slot released exactly once on stream close.
- **`swEvents` is live**: `Connected` published on dial success and inbound pool insertion, `Disconnected` on teardown.
- **Dial dedup can no longer wedge**: an exception between `checkPendingDial` and `putTMVar` now fills the TMVar and removes the pending entry (`onException`).

## Tests

New `ConnectionLifecycleSpec` (7 tests): pool removal + resource release + transport close on `closeConnection`, idempotency, pool removal on remote disconnect over real TCP followed by a successful fresh dial, `switchClose` closing pooled connections on both sides, outbound/inbound stream slot accounting, and dial-dedup cleanup on exception.

Full suite: 706 examples, 0 failures (GHC 9.10.1).

Closes #179