### PR TITLE
test: retire gossipsub tests that asserted #154/#157 defects as correct

### DIFF
--- a/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
@@ -328,18 +328,20 @@ spec = do
                 Nothing -> False) sent
         length pruneMsgs `shouldBe` 0
 
-      it "rejects graft when not subscribed (sends PRUNE)" $ do
-        (router, logRef) <- mkTestRouter localPid
+      it "does not add the sender to the mesh for an unsubscribed topic" $ do
+        (router, _) <- mkTestRouter localPid
         let sender = mkPeerId 1
         addPeer router sender GossipSubPeer False fixedTime
-        -- No mesh entry = not subscribed
         handleGraft router sender [Graft "unknown-topic"]
-        sent <- readIORef logRef
-        let pruneMsgs = filter (\(pid, rpc) ->
-              pid == sender && case rpcControl rpc of
-                Just ctrl -> any (\p -> pruneTopic p == "unknown-topic") (ctrlPrune ctrl)
-                Nothing -> False) sent
-        length pruneMsgs `shouldBe` 1
+        -- The sender must never enter a mesh for a topic we are not
+        -- subscribed to. Note: the reply behaviour is deliberately NOT
+        -- asserted here. The router currently answers with PRUNE, but
+        -- gossipsub-v1.1.md requires ignoring a GRAFT for an unknown topic
+        -- entirely (the PRUNE reply is a spam amplification vector). The
+        -- previous version of this test asserted the PRUNE reply as correct;
+        -- the reply fix is tracked in #157.
+        mesh <- readTVarIO (gsMesh router)
+        Map.findWithDefault Set.empty "unknown-topic" mesh `shouldBe` Set.empty
 
       it "rejects graft during backoff (sends PRUNE with backoff)" $ do
         (router, logRef, timeRef) <- mkTestRouterWithTime localPid fixedTime
@@ -457,12 +459,42 @@ spec = do
         sent `shouldBe` []
 
     describe "handleIWant" $ do
-      it "is a stub in Phase 9a (does nothing)" $ do
+      -- gossipsub-v1.0.md: IWANT requests are answered from the mcache.
+      -- These replace the retired "stub does nothing" test, which passed
+      -- only because the cache happened to be empty (#175).
+      it "answers IWANT for our own published message from the mcache" $ do
+        (router, logRef) <- mkTestRouter localPid
+        addSubscribedPeer router (mkPeerId 1) "blocks"
+        kp <- newKeyPair
+        publish router "blocks" (BS.pack [1, 2, 3]) (Just kp)
+        published <- concatMap (rpcPublish . snd) <$> readIORef logRef
+        case published of
+          [msg] -> do
+            writeIORef logRef []
+            let requester = mkPeerId 2
+            handleIWant router requester [IWant [defaultMessageId msg]]
+            sent <- readIORef logRef
+            map fst sent `shouldBe` [requester]
+            concatMap (rpcPublish . snd) sent `shouldBe` [msg]
+          _ -> expectationFailure "expected exactly one published message"
+
+      it "answers IWANT for a message received from another peer" $ do
         (router, logRef) <- mkTestRouter localPid
         let sender = mkPeerId 1
-        handleIWant router sender [IWant [BS.pack [1]]]
+            requester = mkPeerId 2
+        addPeer router sender GossipSubPeer False fixedTime
+        kp <- newKeyPair
+        let msg = signedMessage kp "t" (BS.pack [5])
+        handleRPC router sender emptyRPC { rpcPublish = [msg] }
+        writeIORef logRef []
+        handleIWant router requester [IWant [defaultMessageId msg]]
         sent <- readIORef logRef
-        sent `shouldBe` []
+        concatMap (rpcPublish . snd) sent `shouldBe` [msg]
+
+      it "sends nothing for message ids not in the cache" $ do
+        (router, logRef) <- mkTestRouter localPid
+        handleIWant router (mkPeerId 1) [IWant [BS.pack [9, 9]]]
+        readIORef logRef `shouldReturn` []
 
     describe "publish" $ do
       it "flood publishes to all topic peers" $ do
@@ -652,6 +684,44 @@ spec = do
             msg = (signedMessage kp "t" (BS.pack [1])) { msgFrom = Just spoofed }
         handleRPC router sender emptyRPC { rpcPublish = [msg] }
         readIORef deliveredRef `shouldReturn` 0
+
+      it "rejects an unsigned message under StrictSign" $ do
+        -- pubsub/README.md StrictSign: "Enforce the fields to be present,
+        -- reject otherwise." The pre-#154 suite asserted the opposite:
+        -- that an unsigned message is delivered (#175).
+        (router, logRef) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            meshPeer = mkPeerId 2
+        addPeer router sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.fromList [sender, meshPeer])
+        deliveredRef <- newIORef (0 :: Int)
+        atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
+          modifyIORef' deliveredRef (+ 1)
+        let unsigned = PubSubMessage Nothing (BS.pack [1]) Nothing "t" Nothing Nothing
+        handleRPC router sender emptyRPC { rpcPublish = [unsigned] }
+        readIORef deliveredRef `shouldReturn` 0
+        readIORef logRef `shouldReturn` []
+        invalidCount router sender "t" `shouldReturn` 1
+
+      it "still delivers the genuine message after rejecting a forgery with the same id" $ do
+        -- pubsub/README.md:236-238 — a rejected message must not poison the
+        -- seen cache: validation runs before dedup, so the genuine message
+        -- (same from and seqno, hence the same message id) still goes through.
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        deliveredRef <- newIORef (0 :: Int)
+        atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
+          modifyIORef' deliveredRef (+ 1)
+        kp <- newKeyPair
+        let genuine = signedMessage kp "t" (BS.pack [1])
+            forged  = genuine { msgData = BS.pack [99] }
+        defaultMessageId forged `shouldBe` defaultMessageId genuine
+        handleRPC router sender emptyRPC { rpcPublish = [forged] }
+        readIORef deliveredRef `shouldReturn` 0
+        handleRPC router sender emptyRPC { rpcPublish = [genuine] }
+        readIORef deliveredRef `shouldReturn` 1
 
       it "charges the sender a P4 invalid delivery for a rejected message" $ do
         (router, _) <- mkTestRouter localPid


### PR DESCRIPTION
## Summary

Issue #175 named three tests that asserted the #154/#157 defects as correct behaviour. Verified against current main:

| Test | Status |
|---|---|
| Unsigned-message dedup test (old `RouterSpec.hs:472-479`) | Already rewritten by the #154 fix (now uses a properly signed message) — no action needed |
| GRAFT for unknown topic gets a PRUNE (`RouterSpec.hs:331-342`) | **Rewritten here** |
| `handleIWant` "is a stub in Phase 9a (does nothing)" (`RouterSpec.hs:459-465`) | **Replaced here** |

## Changes

- **`handleIWant` stub test replaced** with three behavioural tests: IWANT is answered from the mcache for our own published messages (publish → cachePut → serve round-trip), for messages received from other peers, and unknown ids get no response. The old test passed only because the cache happened to be empty; `handleIWant` has served from the mcache since PR #191.
- **GRAFT-for-unsubscribed-topic test rewritten** to assert only the correct adjacent behaviour: the sender never enters the mesh. The old assertion required a PRUNE reply, which gossipsub-v1.1 identifies as a spam amplification vector — the correct behaviour is to ignore the GRAFT entirely. Since that fix belongs to #157 (open, being fixed separately), the reply is deliberately not asserted in either direction; a comment in the test references #157.
- **Added** `rejects an unsigned message under StrictSign` at router level (no delivery, no forwarding, P4 charged) — the pre-#154 suite asserted the opposite, and no router-level test covered this exact case.
- **Added** `still delivers the genuine message after rejecting a forgery with the same id` — guards the validation-before-dedup ordering (pubsub/README.md: a rejected message must not poison the seen cache).

## TDD sanity check

Temporarily disabled the `handleIWant` mcache response: both new IWANT round-trip tests fail with `expected [msg] but got []`. Reverted; full suite: **720 examples, 0 failures** (GHC 9.10.3).

## Remaining from #175 (blocked or out of scope for this PR)

- **#157 hardening tests** (ignore GRAFT for unknown topic, IWANT/IHAVE caps, PX emission and thresholds, v1.0/floodsub negotiation): blocked on #157, which is open and being fixed separately.
- **#156 scoring-wiring tests** (P1/P2/P3 counters written by the router, threshold enforcement, populated topic params): blocked on #156, which is still open — these tests would fail today by design of the defect.
- **Extended topic validators** (Accept/Reject/Ignore trichotomy): needs a new API; the current `TopicValidator = ... -> IO Bool` cannot express Ignore-without-penalty. Basic reject/accept validator tests already exist.
- **`assigns distinct message ids to successive unsigned publishes`**: still a real defect — `mkUnsignedMessage` sets no seqno, so `defaultMessageId` yields the empty id for every StrictNoSign publish. Not covered by any open issue as far as I can tell; deserves its own issue rather than a failing test.
- **Multi-node (N≥3) in-process mesh harness** and cross-implementation signing tests: substantial new infrastructure; most of the mesh-level assertions additionally depend on #156/#157 behaviour.

Refs #175
