### PR TITLE
fix(nat): register AutoNAT, Circuit Relay v2 and DCUtR handlers on the Switch

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -76,6 +76,7 @@ library
     LibP2P.NAT.Relay.Client
     LibP2P.NAT.DCUtR.Message
     LibP2P.NAT.DCUtR
+    LibP2P.NAT
     LibP2P.Noise.Framing
     LibP2P.Noise.Handshake
     LibP2P.Noise.Session
@@ -168,6 +169,7 @@ test-suite libp2p-hs-test
     LibP2P.NAT.Relay.ClientSpec
     LibP2P.NAT.DCUtR.MessageSpec
     LibP2P.NAT.DCUtR.DCUtRSpec
+    LibP2P.NAT.RegistrationSpec
     LibP2P.Protocol.GossipSub.TypesSpec
     LibP2P.Protocol.GossipSub.MessageSpec
     LibP2P.Protocol.GossipSub.RouterSpec

--- a/src/LibP2P.hs
+++ b/src/LibP2P.hs
@@ -14,6 +14,7 @@
 --   addTransport sw tcp
 --   registerIdentifyHandlers sw
 --   registerPingHandler sw
+--   _relayState <- registerNATHandlers sw defaultNATConfig
 --   addrs <- switchListen sw defaultConnectionGater [fromText "/ip4/127.0.0.1/tcp/0"]
 --   print addrs
 --   -- ... dial other peers, etc.
@@ -74,6 +75,19 @@ module LibP2P
   , PingResult (..)
   , PingError (..)
 
+    -- * NAT traversal (AutoNAT, Circuit Relay v2, DCUtR)
+  , NATConfig (..)
+  , defaultNATConfig
+  , registerNATHandlers
+  , registerAutoNATHandler
+  , registerRelayHopHandler
+  , registerRelayStopHandler
+  , registerDCUtRHandler
+  , RelayState
+  , RelayConfig (..)
+  , defaultRelayConfig
+  , newRelayState
+
     -- * GossipSub
   , GossipSubNode (..)
   , GossipSubParams (..)
@@ -92,6 +106,16 @@ import LibP2P.Crypto.PeerId (PeerId, fromPublicKey, peerIdBytes, toBase58, parse
 import LibP2P.Multiaddr (Multiaddr (..), fromText, splitP2P, toText)
 import LibP2P.Multiaddr.Protocol (Protocol (..))
 import LibP2P.MultistreamSelect.Negotiation (ProtocolId, StreamIO (..))
+import LibP2P.NAT
+  ( NATConfig (..)
+  , defaultNATConfig
+  , registerAutoNATHandler
+  , registerDCUtRHandler
+  , registerNATHandlers
+  , registerRelayHopHandler
+  , registerRelayStopHandler
+  )
+import LibP2P.NAT.Relay (RelayConfig (..), RelayState, defaultRelayConfig, newRelayState)
 import LibP2P.Protocol.GossipSub.Handler
   ( GossipSubNode (..)
   , gossipJoin

--- a/src/LibP2P/NAT.hs
+++ b/src/LibP2P/NAT.hs
@@ -1,0 +1,220 @@
+-- | NAT traversal handler registration (specs/autonat, specs/relay, specs/relay/DCUtR).
+--
+-- Wires the AutoNAT, Circuit Relay v2, and DCUtR module implementations
+-- into the Switch protocol registry, in the style of
+-- 'LibP2P.Protocol.Identify.registerIdentifyHandlers':
+--
+--   /libp2p/autonat/1.0.0            — AutoNAT dial-back server
+--   /libp2p/circuit/relay/0.2.0/hop  — Circuit Relay v2 relay server
+--   /libp2p/circuit/relay/0.2.0/stop — Circuit Relay v2 target (inbound relayed streams)
+--   /libp2p/dcutr                    — DCUtR hole-punch coordination (handler side)
+module LibP2P.NAT
+  ( -- * Configuration
+    NATConfig (..)
+  , defaultNATConfig
+    -- * Registration
+  , registerNATHandlers
+  , registerAutoNATHandler
+  , registerRelayHopHandler
+  , registerRelayStopHandler
+  , registerDCUtRHandler
+  ) where
+
+import Control.Concurrent.STM (atomically)
+import Control.Exception (SomeException, catch, try)
+import LibP2P.Crypto.PeerId (PeerId)
+import LibP2P.Multiaddr (Multiaddr)
+import LibP2P.MultistreamSelect.Negotiation
+  ( NegotiationResult (..)
+  , StreamIO (..)
+  , negotiateInitiator
+  )
+import LibP2P.NAT.AutoNAT (AutoNATConfig (..), handleAutoNAT)
+import LibP2P.NAT.AutoNAT.Message (autoNATProtocolId)
+import LibP2P.NAT.DCUtR (DCUtRConfig (..), handleDCUtR)
+import LibP2P.NAT.DCUtR.Message (dcutrProtocolId)
+import LibP2P.NAT.Relay
+  ( RelayConfig
+  , RelayState
+  , defaultRelayConfig
+  , handleConnect
+  , handleReserve
+  , newRelayState
+  )
+import LibP2P.NAT.Relay.Client (handleStop)
+import LibP2P.NAT.Relay.Message
+  ( HopMessage (..)
+  , HopMessageType (..)
+  , RelayLimit
+  , RelayStatus (..)
+  , hopProtocolId
+  , maxRelayMessageSize
+  , readHopMessage
+  , stopProtocolId
+  , writeHopMessage
+  )
+import LibP2P.Switch (selectTransport, setStreamHandler)
+import LibP2P.Switch.ConnPool (lookupConn)
+import LibP2P.Switch.Connection (newStream)
+import LibP2P.Switch.Dial (dial)
+import LibP2P.Switch.Listen (switchListenAddrs)
+import LibP2P.Switch.Types
+  ( Connection (..)
+  , MuxerSession (..)
+  , Switch (..)
+  )
+import LibP2P.Switch.Upgrade (upgradeOutbound)
+import LibP2P.Transport (Transport (..))
+
+-- | Configuration for the NAT traversal handlers.
+data NATConfig = NATConfig
+  { ncRelayConfig     :: !RelayConfig
+    -- ^ Resource limits for the Circuit Relay v2 server side
+  , ncOnRelayedStream :: !(PeerId -> Maybe RelayLimit -> StreamIO -> IO ())
+    -- ^ Invoked when a relay delivers an inbound relayed stream (stop
+    -- protocol) after the CONNECT/OK exchange: source peer, limit
+    -- advertised by the relay, and the relayed stream. The application
+    -- owns the stream from this point (e.g. to run DCUtR over it).
+  }
+
+-- | Default NAT configuration: default relay limits, and inbound relayed
+-- streams are left to the remote end (no local consumer).
+defaultNATConfig :: NATConfig
+defaultNATConfig = NATConfig
+  { ncRelayConfig     = defaultRelayConfig
+  , ncOnRelayedStream = \_ _ _ -> pure ()
+  }
+
+-- | Register all four NAT protocol handlers on the Switch.
+--
+-- Creates the relay server state from 'ncRelayConfig' and returns it so
+-- callers can inspect reservations/circuits.
+registerNATHandlers :: Switch -> NATConfig -> IO RelayState
+registerNATHandlers sw config = do
+  relayState <- newRelayState (ncRelayConfig config)
+  registerAutoNATHandler sw
+  registerRelayHopHandler sw relayState
+  registerRelayStopHandler sw (ncOnRelayedStream config)
+  registerDCUtRHandler sw
+  pure relayState
+
+-- | Register the AutoNAT server handler (/libp2p/autonat/1.0.0).
+--
+-- The dial-back deliberately bypasses the connection pool: reusing the
+-- requester's existing connection would always report success. Instead a
+-- fresh transport dial + upgrade verifies both reachability and identity,
+-- and the probe connection is closed immediately (go-libp2p uses a
+-- separate dialer host for the same reason).
+registerAutoNATHandler :: Switch -> IO ()
+registerAutoNATHandler sw =
+  setStreamHandler sw autoNATProtocolId $ \conn stream ->
+    let config = AutoNATConfig
+          { natThreshold = 3
+          , natDialBack  = freshDialBack sw
+          }
+    in handleAutoNAT config stream (connPeerId conn) (connRemoteAddr conn)
+
+-- | Dial back a peer on a fresh connection, verify its identity, and close.
+freshDialBack :: Switch -> PeerId -> [Multiaddr] -> IO (Either String ())
+freshDialBack _ _ [] = pure (Left "dial-back: no addresses")
+freshDialBack sw pid (addr : rest) = do
+  result <- try (probeAddr sw pid addr)
+  case result of
+    Right (Right ()) -> pure (Right ())
+    Right (Left err)
+      | null rest -> pure (Left err)
+      | otherwise -> freshDialBack sw pid rest
+    Left (e :: SomeException)
+      | null rest -> pure (Left (show e))
+      | otherwise -> freshDialBack sw pid rest
+
+-- | Probe a single address: transport dial, upgrade, check peer identity.
+probeAddr :: Switch -> PeerId -> Multiaddr -> IO (Either String ())
+probeAddr sw pid addr = do
+  mTransport <- selectTransport sw addr
+  case mTransport of
+    Nothing -> pure (Left ("dial-back: no transport for " ++ show addr))
+    Just transport -> do
+      rawConn <- transportDial transport addr
+      conn <- upgradeOutbound (swIdentityKey sw) rawConn
+      let matches = connPeerId conn == pid
+      muxClose (connSession conn) `catch` \(_ :: SomeException) -> pure ()
+      pure $ if matches
+        then Right ()
+        else Left "dial-back: peer identity mismatch"
+
+-- | Register the Circuit Relay v2 hop handler
+-- (/libp2p/circuit/relay/0.2.0/hop): serve RESERVE and CONNECT requests.
+registerRelayHopHandler :: Switch -> RelayState -> IO ()
+registerRelayHopHandler sw relayState =
+  setStreamHandler sw hopProtocolId $ \conn stream -> do
+    result <- readHopMessage stream maxRelayMessageSize
+    case result of
+      Left _ -> pure ()
+      Right msg -> case hopType msg of
+        Just HopReserve ->
+          handleReserve relayState stream (connPeerId conn)
+        Just HopConnect ->
+          handleConnect relayState stream (connPeerId conn) msg (openStopStream sw)
+        _ -> writeHopMessage stream HopMessage
+          { hopType = Just HopStatus
+          , hopPeer = Nothing
+          , hopReservation = Nothing
+          , hopLimit = Nothing
+          , hopStatus = Just UnexpectedMessage
+          }
+
+-- | Open a stop-protocol stream to the circuit target over an existing
+-- connection. Returns Nothing when the target is not connected or the
+-- stop protocol cannot be negotiated.
+openStopStream :: Switch -> PeerId -> IO (Maybe StreamIO)
+openStopStream sw targetId = do
+  result <- try $ do
+    mConn <- atomically $ lookupConn (swConnPool sw) targetId
+    case mConn of
+      Nothing -> pure Nothing
+      Just conn -> do
+        streamOrErr <- newStream sw conn
+        case streamOrErr of
+          Left _ -> pure Nothing
+          Right stream -> do
+            negotiated <- negotiateInitiator stream [stopProtocolId]
+            case negotiated of
+              Accepted _ -> pure (Just stream)
+              NoProtocol -> do
+                streamClose stream `catch` \(_ :: SomeException) -> pure ()
+                pure Nothing
+  case result of
+    Left (_ :: SomeException) -> pure Nothing
+    Right mStream -> pure mStream
+
+-- | Register the Circuit Relay v2 stop handler
+-- (/libp2p/circuit/relay/0.2.0/stop): accept inbound relayed streams and
+-- hand them to the application callback.
+registerRelayStopHandler
+  :: Switch
+  -> (PeerId -> Maybe RelayLimit -> StreamIO -> IO ())
+  -> IO ()
+registerRelayStopHandler sw onRelayedStream =
+  setStreamHandler sw stopProtocolId $ \_conn stream -> do
+    result <- handleStop stream
+    case result of
+      Left _ -> pure ()
+      Right (sourcePeer, mLimit) -> onRelayedStream sourcePeer mLimit stream
+
+-- | Register the DCUtR handler (/libp2p/dcutr).
+--
+-- Answers the CONNECT/SYNC exchange with our listen addresses and dials
+-- the initiator's addresses through the Switch for the hole punch.
+registerDCUtRHandler :: Switch -> IO ()
+registerDCUtRHandler sw =
+  setStreamHandler sw dcutrProtocolId $ \conn stream -> do
+    addrs <- switchListenAddrs sw
+    let config = DCUtRConfig
+          { dcMaxAttempts = 3
+          , dcDialer = \addr -> do
+              dialed <- dial sw (connPeerId conn) [addr]
+              pure $ either (Left . show) (const (Right ())) dialed
+          }
+    _ <- handleDCUtR config stream addrs
+    pure ()

--- a/test/LibP2P/NAT/RegistrationSpec.hs
+++ b/test/LibP2P/NAT/RegistrationSpec.hs
@@ -1,0 +1,201 @@
+-- | Tests for NAT protocol handler registration on the Switch (issue #152).
+--
+-- Verifies that registerNATHandlers registers the AutoNAT, Circuit Relay v2
+-- hop/stop, and DCUtR protocol handlers, and that an inbound stream for each
+-- protocol is dispatched to the right handler over a real TCP connection.
+module LibP2P.NAT.RegistrationSpec (spec) where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Data.Maybe (isJust)
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair, publicKey)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey, peerIdBytes)
+import LibP2P.Multiaddr (Multiaddr (..), toBytes)
+import LibP2P.Multiaddr.Protocol (Protocol (..))
+import LibP2P.MultistreamSelect.Negotiation
+  ( NegotiationResult (..)
+  , ProtocolId
+  , StreamIO (..)
+  , negotiateInitiator
+  )
+import LibP2P.NAT
+  ( NATConfig (..)
+  , defaultNATConfig
+  , registerNATHandlers
+  )
+import LibP2P.NAT.AutoNAT (requestAutoNAT)
+import LibP2P.NAT.AutoNAT.Message
+  ( ResponseStatus (..)
+  , anRespStatus
+  , autoNATProtocolId
+  )
+import LibP2P.NAT.DCUtR.Message
+  ( HolePunchMessage (..)
+  , HolePunchType (..)
+  , dcutrProtocolId
+  , maxDCUtRMessageSize
+  , readHolePunchMessage
+  , writeHolePunchMessage
+  )
+import LibP2P.NAT.Relay.Client (makeReservation)
+import LibP2P.NAT.Relay.Message
+  ( HopMessage (..)
+  , RelayPeer (..)
+  , RelayStatus (..)
+  , StopMessage (..)
+  , StopMessageType (..)
+  , hopProtocolId
+  , maxRelayMessageSize
+  , readStopMessage
+  , stopProtocolId
+  , writeStopMessage
+  )
+import LibP2P.Protocol.Identify (buildLocalIdentify)
+import LibP2P.Protocol.Identify.Message (IdentifyInfo (..))
+import LibP2P.Switch (addTransport, lookupStreamHandler, newSwitch, switchClose)
+import LibP2P.Switch.Connection (newStream)
+import LibP2P.Switch.Dial (dial)
+import LibP2P.Switch.Listen (defaultConnectionGater, switchListen)
+import LibP2P.Switch.Types (Connection (..), Switch)
+import LibP2P.Transport.TCP (newTCPTransport)
+import System.Timeout (timeout)
+import Test.Hspec
+
+-- | Generate a test identity (PeerId, KeyPair).
+mkTestIdentity :: IO (PeerId, KeyPair)
+mkTestIdentity = do
+  Right kp <- generateKeyPair
+  let pid = fromPublicKey (publicKey kp)
+  pure (pid, kp)
+
+-- | Loopback address with port 0 (OS assigns ephemeral port).
+loopbackAddr :: Multiaddr
+loopbackAddr = Multiaddr [IP4 0x7f000001, TCP 0]
+
+-- | Server B registers NAT handlers and listens; client A (also listening,
+-- so AutoNAT dial-back can succeed) dials B. The action receives A's switch,
+-- peer id and listen addrs, B's switch and peer id, and A's connection to B.
+withNATPair
+  :: NATConfig
+  -> ((Switch, PeerId, [Multiaddr]) -> (Switch, PeerId) -> Connection -> IO a)
+  -> IO a
+withNATPair config action = do
+  -- Node B: NAT server
+  (pidB, kpB) <- mkTestIdentity
+  swB <- newSwitch pidB kpB
+  addTransport swB =<< newTCPTransport
+  _relayState <- registerNATHandlers swB config
+  addrsB <- switchListen swB defaultConnectionGater [loopbackAddr]
+  -- Node A: client, listening so B can dial back
+  (pidA, kpA) <- mkTestIdentity
+  swA <- newSwitch pidA kpA
+  addTransport swA =<< newTCPTransport
+  addrsA <- switchListen swA defaultConnectionGater [loopbackAddr]
+  dialResult <- dial swA pidB [head addrsB]
+  case dialResult of
+    Left err -> do
+      switchClose swA
+      switchClose swB
+      fail $ "withNATPair: dial failed: " ++ show err
+    Right conn -> do
+      threadDelay 300000
+      result <- action (swA, pidA, addrsA) (swB, pidB) conn
+      switchClose swA
+      switchClose swB
+      pure result
+
+-- | Open a stream on the connection and negotiate the given protocol.
+openProtoStream :: Switch -> Connection -> ProtocolId -> IO StreamIO
+openProtoStream sw conn proto = do
+  streamOrErr <- newStream sw conn
+  case streamOrErr of
+    Left err -> fail $ "newStream failed: " ++ show err
+    Right stream -> do
+      result <- negotiateInitiator stream [proto]
+      case result of
+        Accepted _ -> pure stream
+        NoProtocol -> fail $ "protocol not supported by remote: " ++ show proto
+
+spec :: Spec
+spec = do
+  describe "registerNATHandlers" $ do
+    it "registers AutoNAT, relay hop/stop and DCUtR protocol handlers" $ do
+      (pid, kp) <- mkTestIdentity
+      sw <- newSwitch pid kp
+      _state <- registerNATHandlers sw defaultNATConfig
+      mapM_
+        (\proto -> do
+          mHandler <- lookupStreamHandler sw proto
+          (proto, isJust mHandler) `shouldBe` (proto, True))
+        [autoNATProtocolId, hopProtocolId, stopProtocolId, dcutrProtocolId]
+
+    it "registered NAT protocols appear in the local identify protocol list" $ do
+      (pid, kp) <- mkTestIdentity
+      sw <- newSwitch pid kp
+      _state <- registerNATHandlers sw defaultNATConfig
+      info <- buildLocalIdentify sw Nothing
+      mapM_ (\proto -> idProtocols info `shouldContain` [proto])
+        [autoNATProtocolId, hopProtocolId, stopProtocolId, dcutrProtocolId]
+
+  describe "inbound stream dispatch" $ do
+    it "dispatches /libp2p/autonat/1.0.0 to the AutoNAT handler (dial-back OK)" $ do
+      withNATPair defaultNATConfig $ \(swA, pidA, addrsA) _nodeB conn -> do
+        result <- timeout 10000000 $ do
+          stream <- openProtoStream swA conn autoNATProtocolId
+          requestAutoNAT stream pidA addrsA
+        case result of
+          Nothing -> expectationFailure "autonat request timed out"
+          Just (Left err) -> expectationFailure $ "autonat request failed: " ++ err
+          Just (Right resp) -> anRespStatus resp `shouldBe` Just StatusOK
+
+    it "dispatches /libp2p/circuit/relay/0.2.0/hop to the relay hop handler" $ do
+      withNATPair defaultNATConfig $ \(swA, _pidA, _addrsA) _nodeB conn -> do
+        result <- timeout 10000000 $ do
+          stream <- openProtoStream swA conn hopProtocolId
+          makeReservation stream
+        case result of
+          Nothing -> expectationFailure "hop reserve timed out"
+          Just (Left err) -> expectationFailure $ "hop reserve failed: " ++ err
+          Just (Right resp) -> hopStatus resp `shouldBe` Just RelayOK
+
+    it "dispatches /libp2p/circuit/relay/0.2.0/stop to the relay stop handler" $ do
+      relayedMVar <- newEmptyMVar
+      let config = defaultNATConfig
+            { ncOnRelayedStream = \src mLimit _stream -> putMVar relayedMVar (src, mLimit) }
+      withNATPair config $ \(swA, pidA, _addrsA) _nodeB conn -> do
+        result <- timeout 10000000 $ do
+          stream <- openProtoStream swA conn stopProtocolId
+          writeStopMessage stream StopMessage
+            { stopType = Just StopConnect
+            , stopPeer = Just RelayPeer { rpId = peerIdBytes pidA, rpAddrs = [] }
+            , stopLimit = Nothing
+            , stopStatus = Nothing
+            }
+          readStopMessage stream maxRelayMessageSize
+        case result of
+          Nothing -> expectationFailure "stop connect timed out"
+          Just (Left err) -> expectationFailure $ "stop connect failed: " ++ err
+          Just (Right resp) -> do
+            stopStatus resp `shouldBe` Just RelayOK
+            callback <- timeout 5000000 $ takeMVar relayedMVar
+            case callback of
+              Nothing -> expectationFailure "relayed-stream callback not invoked"
+              Just (src, _mLimit) -> src `shouldBe` pidA
+
+    it "dispatches /libp2p/dcutr to the DCUtR handler" $ do
+      withNATPair defaultNATConfig $ \(swA, _pidA, addrsA) _nodeB conn -> do
+        result <- timeout 10000000 $ do
+          stream <- openProtoStream swA conn dcutrProtocolId
+          writeHolePunchMessage stream HolePunchMessage
+            { hpType = HPConnect
+            , hpObsAddrs = map toBytes addrsA
+            }
+          readHolePunchMessage stream maxDCUtRMessageSize
+        case result of
+          Nothing -> expectationFailure "dcutr exchange timed out"
+          Just (Left err) -> expectationFailure $ "dcutr exchange failed: " ++ err
+          Just (Right resp) -> do
+            hpType resp `shouldBe` HPConnect
+            -- The handler advertises B's listen addresses
+            hpObsAddrs resp `shouldSatisfy` (not . null)


### PR DESCRIPTION
## Summary

None of the NAT-traversal modules were reachable from a running host (`grep -rn "LibP2P.NAT" src/` outside `src/LibP2P/NAT/` returned nothing), so `/libp2p/autonat/1.0.0`, `/libp2p/circuit/relay/0.2.0/hop`, `/libp2p/circuit/relay/0.2.0/stop`, and `/libp2p/dcutr` were never advertised and inbound negotiation got `NoProtocol`.

This adds `LibP2P.NAT` with registration functions in the style of `registerIdentifyHandlers`, wired to the existing module implementations and using the `Connection` now carried by `StreamHandler` (#195):

- **AutoNAT** — serves dial-back requests with the connection's authenticated peer id and remote (observed) address. The dial-back uses a fresh transport dial + upgrade and verifies peer identity, deliberately bypassing the pool (reusing the requester's existing connection would always report success; go-libp2p uses a separate dialer host for the same reason).
- **Relay hop** — dispatches RESERVE/CONNECT to `handleReserve`/`handleConnect`, opening stop streams to circuit targets over pooled connections via `newStream` (#196).
- **Relay stop** — accepts inbound relayed streams via `handleStop` and hands them to an application callback (`NATConfig.ncOnRelayedStream`).
- **DCUtR** — answers the CONNECT/SYNC exchange with our listen addresses and hole-punch dials through the Switch.

`registerNATHandlers` registers all four and returns the `RelayState`; per-role register functions are also exported and re-exported from the `LibP2P` facade. Protocol ID strings match specs/autonat, specs/relay/circuit-v2.md, and specs/relay/DCUtR.md.

## Tests

New `test/LibP2P/NAT/RegistrationSpec.hs` (TDD, failing first):
- all four protocol IDs registered and visible in the local Identify protocol list
- end-to-end dispatch over real TCP for each protocol: AutoNAT dial-back returns `OK`, hop RESERVE returns `OK`, stop CONNECT returns `OK` and invokes the callback, DCUtR responds with CONNECT.

722 examples, 0 failures (GHC 9.10).

Closes #152