### PR TITLE
test: foreign-peer handshake harness and noise/mss boundary coverage (#172)

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -155,6 +155,7 @@ test-suite libp2p-hs-test
     LibP2P.Protocol.Identify.IdentifySpec
     LibP2P.Protocol.Ping.PingSpec
     LibP2P.Noise.HandshakeSpec
+    LibP2P.Noise.ForeignPeerSpec
     LibP2P.DHT.DistanceSpec
     LibP2P.DHT.RoutingTableSpec
     LibP2P.DHT.MessageSpec

--- a/test/LibP2P/MultistreamSelect/NegotiationSpec.hs
+++ b/test/LibP2P/MultistreamSelect/NegotiationSpec.hs
@@ -1,21 +1,36 @@
 module LibP2P.MultistreamSelect.NegotiationSpec (spec) where
 
-import Control.Concurrent.Async (concurrently, race, withAsync)
+import Control.Concurrent.Async (concurrently, withAsync)
+import Control.Monad (replicateM)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import LibP2P.MultistreamSelect.Negotiation
 import LibP2P.MultistreamSelect.Wire
 import System.Timeout (timeout)
 import Test.Hspec
 
+-- | Read exactly n raw bytes from a StreamIO (test-side helper for
+-- inspecting the wire without going through the message decoder).
+readRawBytes :: StreamIO -> Int -> IO ByteString
+readRawBytes s n = BS.pack <$> replicateM n (streamReadByte s)
+
+-- | The exact wire encoding of the "/multistream/1.0.0" header:
+-- varint(19), the 18 ASCII bytes of the protocol id, trailing newline.
+-- Transcribed from the multistream-select spec, not computed — a typo in
+-- the header constant must not be able to satisfy this test.
+multistreamHeaderBytes :: ByteString
+multistreamHeaderBytes = BS.pack
+  [ 0x13
+  , 0x2f, 0x6d, 0x75, 0x6c, 0x74, 0x69, 0x73, 0x74, 0x72, 0x65
+  , 0x61, 0x6d, 0x2f, 0x31, 0x2e, 0x30, 0x2e, 0x30
+  , 0x0a
+  ]
+
 spec :: Spec
 spec = do
   describe "Wire encoding" $ do
-    it "encodes /multistream/1.0.0 correctly" $ do
-      -- "/multistream/1.0.0" = 18 chars + '\n' = 19 bytes payload
-      let encoded = encodeMessage "/multistream/1.0.0"
-      BS.head encoded `shouldBe` 0x13 -- varint(19)
-      BS.last encoded `shouldBe` 0x0a
-      BS.length encoded `shouldBe` 20 -- 1 (varint) + 18 (text) + 1 (\n)
+    it "encodes /multistream/1.0.0 to the exact spec bytes" $
+      encodeMessage "/multistream/1.0.0" `shouldBe` multistreamHeaderBytes
 
     it "encodes /noise correctly" $ do
       let encoded = encodeMessage "/noise"
@@ -73,6 +88,30 @@ spec = do
       withAsync (negotiateResponder streamB ["/bar"]) $ \_ -> do
         initResult <- negotiateInitiator streamA ["/foo"]
         initResult `shouldBe` NoProtocol
+
+  describe "Negotiation - differing protocol tables" $ do
+    it "negotiates the only shared protocol after multiple na rounds" $ do
+      (streamA, streamB) <- mkMemoryStreamPair
+      (initResult, respResult) <-
+        concurrently
+          (negotiateInitiator streamA ["/tls/1.0.0", "/mplex/6.7.0", "/noise"])
+          (negotiateResponder streamB ["/yamux/1.0.0", "/noise"])
+      initResult `shouldBe` Accepted "/noise"
+      respResult `shouldBe` Accepted "/noise"
+
+    it "responder answers an unsupported proposal with the exact na bytes" $ do
+      (streamA, streamB) <- mkMemoryStreamPair
+      -- Hand-rolled initiator: instead of pairing the responder with our
+      -- own initiator (which by construction agrees on every byte), speak
+      -- the protocol manually and compare the responder's raw wire output
+      -- against the bytes the spec mandates.
+      withAsync (negotiateResponder streamB ["/bar"]) $ \_ -> do
+        streamWrite streamA (encodeMessage multistreamHeader)
+        headerEcho <- readRawBytes streamA 20
+        headerEcho `shouldBe` multistreamHeaderBytes
+        streamWrite streamA (encodeMessage "/foo")
+        naBytes <- readRawBytes streamA 4
+        naBytes `shouldBe` BS.pack [0x03, 0x6e, 0x61, 0x0a]
 
   describe "Negotiation - yamux" $ do
     it "negotiates muxer protocol" $ do

--- a/test/LibP2P/Noise/ForeignPeerSpec.hs
+++ b/test/LibP2P/Noise/ForeignPeerSpec.hs
@@ -1,0 +1,181 @@
+-- | Foreign-peer tests for the production Noise XX handshake path.
+--
+-- Every other Noise test in this repository pairs two instances of the
+-- production code with each other, which can only validate internal
+-- consistency: both ends build their messages from the same functions, so
+-- they can never disagree. These tests drive one endpoint BY HAND from the
+-- low-level handshake primitives, so the remote side can deviate from
+-- anything our own production path would send — in particular an
+-- identity_sig computed over the wrong Noise static key (a replayed or
+-- forged payload). This is the closest a single-implementation suite can
+-- get to a foreign peer before the cross-implementation interop harness
+-- (#129) lands.
+module LibP2P.Noise.ForeignPeerSpec (spec) where
+
+import Control.Concurrent.Async (concurrently, withAsync)
+import Control.Exception (IOException)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.List (isInfixOf)
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair (..), PublicKey)
+import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), mkMemoryStreamPair)
+import LibP2P.Noise.Handshake
+  ( HandshakeResult (..)
+  , NoisePayload (..)
+  , buildHandshakePayload
+  , decodeNoisePayload
+  , decodePublicKey
+  , encodeNoisePayload
+  , initHandshakeInitiator
+  , initHandshakeResponder
+  , readHandshakeMsg
+  , writeHandshakeMsg
+  )
+import LibP2P.Switch.Types (Direction (..))
+import LibP2P.Switch.Upgrade
+  ( performStreamHandshake
+  , readFramedMessage
+  , writeFramedMessage
+  )
+import Test.Hspec
+
+-- | Generate a test identity (PeerId, KeyPair).
+mkTestIdentity :: IO (PeerId, KeyPair)
+mkTestIdentity = do
+  Right kp <- generateKeyPair
+  pure (fromPublicKey (kpPublic kp), kp)
+
+-- | A hand-rolled Noise XX responder driven from the low-level handshake
+-- primitives. 'sigTarget' selects which bytes the identity signature
+-- covers: 'id' signs the actual session static key (an honest peer);
+-- @const other@ signs unrelated bytes (a forged or replayed payload).
+-- Returns the initiator identity extracted from the msg3 payload.
+runForeignResponder
+  :: KeyPair -> (ByteString -> ByteString) -> StreamIO -> IO (PeerId, PublicKey)
+runForeignResponder identityKP sigTarget stream = do
+  (st0, staticPub) <- initHandshakeResponder identityKP
+
+  -- Message 1: <- e (empty payload)
+  msg1 <- readFramedMessage stream
+  (_p1, st1) <- either fail pure $ readHandshakeMsg st0 msg1
+
+  -- Message 2: -> e, ee, s, es (identity payload, signature over sigTarget)
+  let payload = encodeNoisePayload $ buildHandshakePayload identityKP (sigTarget staticPub)
+  (msg2, st2) <- either fail pure $ writeHandshakeMsg st1 payload
+  writeFramedMessage stream msg2
+
+  -- Message 3: <- s, se (initiator identity payload)
+  msg3 <- readFramedMessage stream
+  (p3, _stFinal) <- either fail pure $ readHandshakeMsg st2 msg3
+  np <- either fail pure $ decodeNoisePayload p3
+  pk <- either fail pure $ decodePublicKey (npIdentityKey np)
+  pure (fromPublicKey pk, pk)
+
+-- | A hand-rolled Noise XX initiator, mirror of 'runForeignResponder'.
+-- Returns the responder identity extracted from the msg2 payload.
+runForeignInitiator
+  :: KeyPair -> (ByteString -> ByteString) -> StreamIO -> IO (PeerId, PublicKey)
+runForeignInitiator identityKP sigTarget stream = do
+  (st0, staticPub) <- initHandshakeInitiator identityKP
+
+  -- Message 1: -> e (empty payload)
+  (msg1, st1) <- either fail pure $ writeHandshakeMsg st0 BS.empty
+  writeFramedMessage stream msg1
+
+  -- Message 2: <- e, ee, s, es (responder identity payload)
+  msg2 <- readFramedMessage stream
+  (p2, st2) <- either fail pure $ readHandshakeMsg st1 msg2
+  np <- either fail pure $ decodeNoisePayload p2
+  pk <- either fail pure $ decodePublicKey (npIdentityKey np)
+
+  -- Message 3: -> s, se (identity payload, signature over sigTarget)
+  let payload = encodeNoisePayload $ buildHandshakePayload identityKP (sigTarget staticPub)
+  (msg3, _stFinal) <- either fail pure $ writeHandshakeMsg st2 payload
+  writeFramedMessage stream msg3
+  pure (fromPublicKey pk, pk)
+
+-- | The production handshake terminates with this error when the payload
+-- signature does not bind the identity key to the session's static key.
+isSignatureRejection :: IOException -> Bool
+isSignatureRejection e = "identity signature verification failed" `isInfixOf` show e
+
+-- | Static key bytes that no session actually uses: signing these
+-- simulates a replayed payload (signed for a different Noise session)
+-- or a forged one (attacker without the identity private key).
+foreignStaticKey :: ByteString
+foreignStaticKey = BS.replicate 32 0x5A
+
+spec :: Spec
+spec = do
+  describe "Production handshake against a hand-rolled foreign peer" $ do
+    it "initiator extracts the foreign responder's identity from the payload" $ do
+      (pidA, kpA) <- mkTestIdentity
+      (pidB, kpB) <- mkTestIdentity
+      (streamA, streamB) <- mkMemoryStreamPair
+      ((_sess, result), (foreignSeenPid, foreignSeenKey)) <-
+        concurrently
+          (performStreamHandshake kpA Outbound streamA)
+          (runForeignResponder kpB id streamB)
+      -- Production side sees the foreign peer's identity ...
+      hrRemotePeerId result `shouldBe` pidB
+      hrRemotePublicKey result `shouldBe` kpPublic kpB
+      -- ... and the foreign peer sees ours.
+      foreignSeenPid `shouldBe` pidA
+      foreignSeenKey `shouldBe` kpPublic kpA
+
+    it "responder extracts the foreign initiator's identity from the payload" $ do
+      (pidA, kpA) <- mkTestIdentity
+      (pidB, kpB) <- mkTestIdentity
+      (streamA, streamB) <- mkMemoryStreamPair
+      ((_sess, result), (foreignSeenPid, foreignSeenKey)) <-
+        concurrently
+          (performStreamHandshake kpA Inbound streamA)
+          (runForeignInitiator kpB id streamB)
+      hrRemotePeerId result `shouldBe` pidB
+      hrRemotePublicKey result `shouldBe` kpPublic kpB
+      foreignSeenPid `shouldBe` pidA
+      foreignSeenKey `shouldBe` kpPublic kpA
+
+    it "initiator rejects a responder whose identity_sig covers the wrong static key" $ do
+      (_pidA, kpA) <- mkTestIdentity
+      (_pidB, kpB) <- mkTestIdentity
+      (streamA, streamB) <- mkMemoryStreamPair
+      -- The foreign responder advertises kpB's identity but its signature
+      -- covers a static key from some other session — exactly what a MitM
+      -- replaying an intercepted payload looks like on the wire. It blocks
+      -- waiting for msg3 (which never comes) and is cancelled by withAsync.
+      withAsync (runForeignResponder kpB (const foreignStaticKey) streamB) $ \_ ->
+        performStreamHandshake kpA Outbound streamA
+          `shouldThrow` isSignatureRejection
+
+    it "responder rejects an initiator whose identity_sig covers the wrong static key" $ do
+      (_pidA, kpA) <- mkTestIdentity
+      (_pidB, kpB) <- mkTestIdentity
+      (streamA, streamB) <- mkMemoryStreamPair
+      withAsync (runForeignInitiator kpB (const foreignStaticKey) streamB) $ \_ ->
+        performStreamHandshake kpA Inbound streamA
+          `shouldThrow` isSignatureRejection
+
+    it "initiator rejects a responder that advertises another peer's identity key" $ do
+      -- Eve presents Bob's public key but cannot produce Bob's signature
+      -- over her own session's static key: she signs with her own key.
+      (_pidA, kpA) <- mkTestIdentity
+      (_pidBob, kpBob) <- mkTestIdentity
+      (_pidEve, kpEve) <- mkTestIdentity
+      (streamA, streamB) <- mkMemoryStreamPair
+      let impersonate staticPub =
+            let honest = buildHandshakePayload kpEve staticPub
+                bobKey = npIdentityKey (buildHandshakePayload kpBob staticPub)
+             in honest { npIdentityKey = bobKey }
+          eveResponder stream = do
+            (st0, staticPub) <- initHandshakeResponder kpEve
+            msg1 <- readFramedMessage stream
+            (_p1, st1) <- either fail pure $ readHandshakeMsg st0 msg1
+            let payload = encodeNoisePayload (impersonate staticPub)
+            (msg2, _st2) <- either fail pure $ writeHandshakeMsg st1 payload
+            writeFramedMessage stream msg2
+      withAsync (eveResponder streamB) $ \_ ->
+        performStreamHandshake kpA Outbound streamA
+          `shouldThrow` isSignatureRejection

--- a/test/LibP2P/Noise/HandshakeSpec.hs
+++ b/test/LibP2P/Noise/HandshakeSpec.hs
@@ -52,6 +52,20 @@ spec = do
           remaining `shouldBe` BS.empty
         Left err -> expectationFailure err
 
+    it "boundary table: every size up to 65535 round-trips, everything above is rejected" $ do
+      let accepted = [0, 1, 65534, maxNoiseMessageSize]
+          rejected = [maxNoiseMessageSize + 1, 70000]
+      mapM_
+        (\n -> case encodeFrame (BS.replicate n 0x42) >>= decodeFrame of
+            Right (decoded, remaining) -> do
+              BS.length decoded `shouldBe` n
+              remaining `shouldBe` BS.empty
+            Left err -> expectationFailure $ "size " <> show n <> ": " <> err)
+        accepted
+      mapM_
+        (\n -> encodeFrame (BS.replicate n 0x42) `shouldSatisfy` isLeft)
+        rejected
+
   describe "chunkPlaintext" $ do
     it "keeps a small plaintext as a single chunk" $
       chunkPlaintext (BS.replicate 100 0x01) `shouldBe` [BS.replicate 100 0x01]
@@ -100,6 +114,22 @@ spec = do
       let noiseStaticPK = BS.replicate 32 0xAA
       case signStaticKey (kpPrivate kp1) noiseStaticPK of
         Right sig -> verifyStaticKey (kpPublic kp2) noiseStaticPK sig `shouldBe` False
+        Left err -> expectationFailure err
+
+    it "identity_sig covers the literal domain-separation prefix bytes" $ do
+      -- The prefix is built here from a string literal on purpose: this
+      -- pins the constant in Handshake.hs to the bytes the Noise spec
+      -- mandates, independently of the constant itself. A typo in the
+      -- prefix would keep every self-paired test green while silently
+      -- breaking interop with go-libp2p/rust-libp2p.
+      Right kp <- generateKeyPair
+      let noiseStaticPK = BS.replicate 32 0xAA
+          literalMsg = "noise-libp2p-static-key:" <> noiseStaticPK
+      case signStaticKey (kpPrivate kp) noiseStaticPK of
+        Right sig -> verify (kpPublic kp) literalMsg sig `shouldBe` True
+        Left err -> expectationFailure err
+      case sign (kpPrivate kp) literalMsg of
+        Right sig -> verifyStaticKey (kpPublic kp) noiseStaticPK sig `shouldBe` True
         Left err -> expectationFailure err
 
   describe "NoisePayload protobuf" $ do
@@ -247,26 +277,11 @@ spec = do
           verifyStaticKey remotePubKey remoteNoisePub (npIdentitySig remoteNP)
             `shouldBe` True
 
-    it "performFullHandshake rejects replayed identity payload (MitM)" $ do
-      -- Eve intercepts and runs her own Noise session with Alice,
-      -- but replays Bob's identity payload. performFullHandshake should
-      -- now detect this because it verifies identity_sig binding.
-      Right aliceIdentity <- generateKeyPair
-      Right bobIdentity <- generateKeyPair
-
-      -- We need a scenario where the identity payload doesn't match the Noise key.
-      -- The simplest test: performFullHandshake with legitimate keys still works,
-      -- then we test that the convenience API matches Upgrade.hs behavior.
-      -- Since we can't easily inject a replayed payload into performFullHandshake
-      -- (it builds payloads internally), we verify the negative case via
-      -- performFullHandshakeWithSessions: it should successfully complete
-      -- with legitimate keys (signature verification passes).
-      result <- performFullHandshake aliceIdentity bobIdentity
-      case result of
-        Left err -> expectationFailure $ "legitimate handshake should succeed: " ++ err
-        Right (aliceSeesBob, bobSeesAlice) -> do
-          aliceSeesBob `shouldBe` fromPublicKey (kpPublic bobIdentity)
-          bobSeesAlice `shouldBe` fromPublicKey (kpPublic aliceIdentity)
+    -- NOTE: performFullHandshake builds both payloads internally, so a
+    -- replayed payload cannot be injected through it. The production-path
+    -- rejection of a replayed/forged identity payload is covered in
+    -- LibP2P.Noise.ForeignPeerSpec, which drives one endpoint by hand
+    -- against performStreamHandshake.
 
     it "post-handshake encrypted transport works" $ do
       Right aliceIdentity <- generateKeyPair
@@ -287,6 +302,34 @@ spec = do
           (ciphertext2, _bobSession'') <- either fail pure $ encryptMessage bobSession' reply
           (decrypted2, _aliceSession'') <- either fail pure $ decryptMessage aliceSession' ciphertext2
           decrypted2 `shouldBe` reply
+
+    it "a 65519-byte plaintext fills exactly one maximum-size Noise message" $ do
+      Right aliceIdentity <- generateKeyPair
+      Right bobIdentity <- generateKeyPair
+
+      result <- performFullHandshakeWithSessions aliceIdentity bobIdentity
+      case result of
+        Left err -> expectationFailure err
+        Right (aliceSession, _bobSession) -> do
+          -- 65519 bytes of plaintext + 16-byte AEAD tag = 65535-byte
+          -- ciphertext, the largest Noise message the 2-byte length
+          -- prefix can declare. This is the true chunking boundary.
+          let atLimit = BS.replicate maxNoisePlaintextSize 0x01
+          (ct, aliceSession') <- either fail pure $ encryptMessage aliceSession atLimit
+          BS.length ct `shouldBe` maxNoiseMessageSize
+          case encodeFrame ct of
+            Right framed -> BS.take 2 framed `shouldBe` BS.pack [0xFF, 0xFF]
+            Left err -> expectationFailure err
+          -- One byte more can never reach the wire as a single frame:
+          -- either the cipher refuses the oversized message, or the
+          -- 65536-byte ciphertext is rejected by encodeFrame. Callers
+          -- must chunk first (see chunkPlaintext / encryptAndWrite).
+          let overLimit = BS.replicate (maxNoisePlaintextSize + 1) 0x01
+          case encryptMessage aliceSession' overLimit of
+            Left _ -> pure ()
+            Right (ct2, _) -> do
+              BS.length ct2 `shouldBe` maxNoiseMessageSize + 1
+              encodeFrame ct2 `shouldSatisfy` isLeft
 
     it "post-handshake messages are order-dependent (nonce)" $ do
       Right aliceIdentity <- generateKeyPair

--- a/test/LibP2P/Switch/UpgradeSpec.hs
+++ b/test/LibP2P/Switch/UpgradeSpec.hs
@@ -9,6 +9,7 @@ import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
 import LibP2P.Multiaddr (Multiaddr (..))
 import LibP2P.Multiaddr.Protocol (Protocol (..))
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), mkMemoryStreamPair)
+import LibP2P.Noise.Framing (maxNoisePlaintextSize)
 import LibP2P.Noise.Handshake (HandshakeResult (..))
 import LibP2P.Switch.Types (Connection (..), Direction (..), MuxerSession (..))
 import LibP2P.Switch.Upgrade
@@ -127,6 +128,40 @@ spec = do
       streamWrite encB bigPayload
       received3 <- readExact encA 70000
       received3 `shouldBe` bigPayload
+
+    it "round-trips payloads at the exact single-frame boundary (65519 and 65520 bytes)" $ do
+      (_pidA, kpA) <- mkTestIdentity
+      (_pidB, kpB) <- mkTestIdentity
+      (rawA, rawB) <- mkMemoryStreamPair
+      ((sessA, _), (sessB, _)) <-
+        concurrently
+          (performStreamHandshake kpA Outbound rawA)
+          (performStreamHandshake kpB Inbound rawB)
+      sendRefA <- newIORef sessA
+      recvRefA <- newIORef sessA
+      bufRefA  <- newIORef BS.empty
+      sendRefB <- newIORef sessB
+      recvRefB <- newIORef sessB
+      bufRefB  <- newIORef BS.empty
+      let encA = noiseSessionToStreamIO sendRefA recvRefA bufRefA rawA
+          encB = noiseSessionToStreamIO sendRefB recvRefB bufRefB rawB
+          -- 65519 bytes: the largest plaintext that fits a single Noise
+          -- frame (65535-byte message minus the 16-byte AEAD tag).
+          atLimit = BS.pack (take maxNoisePlaintextSize (cycle [0 .. 255]))
+          -- 65520 bytes: the first size that MUST be split into two
+          -- frames — before chunking existed, this single write corrupted
+          -- the connection (declared length wrapped to 0).
+          overLimit = BS.pack (take (maxNoisePlaintextSize + 1) (cycle [255, 254 .. 0]))
+      streamWrite encA atLimit
+      received <- readExact encB maxNoisePlaintextSize
+      received `shouldBe` atLimit
+      streamWrite encA overLimit
+      received2 <- readExact encB (maxNoisePlaintextSize + 1)
+      received2 `shouldBe` overLimit
+      -- The channel must stay usable in both directions afterwards.
+      streamWrite encB "still alive"
+      received3 <- readExact encA 11
+      received3 `shouldBe` "still alive"
 
   describe "Full upgrade pipeline" $ do
     it "upgradeOutbound + upgradeInbound exchange data on muxed stream" $ do


### PR DESCRIPTION
## Summary

Addresses the remaining test-coverage gaps from #172. The issue predates today's fixes, so first an audit of what is already closed on `main`:

### Already closed by earlier PRs (verified against current code)

- **#183 (noise chunking)**: `encodeFrame` accepts 65535 / rejects 65536, `chunkPlaintext` boundary tests (65519 single chunk, 65520 split, 70000 reassembly), 70000-byte encrypted round-trip through `noiseSessionToStreamIO`, `writeFramedMessage` rejection test. `maxNoiseMessageSize` / `maxNoisePlaintextSize` are no longer dead code.
- **#189 (mss caps)**: 1024-byte message cap (rejects 1025 and 2^32-1 declared lengths), varint read loop bounded at the 9-byte spec limit, all wrapped in `timeout`.

### Remaining gaps closed by this PR

**Foreign-peer harness (the core gap: "no test can express a foreign peer").** New `test/LibP2P/Noise/ForeignPeerSpec.hs` drives one endpoint by hand from the low-level handshake primitives against the production `performStreamHandshake` path, so the remote side can deviate from anything our own code would send:

- correct remote peer identity extraction from the handshake payload on both sides (production initiator vs hand-rolled responder, and mirror)
- rejection when the identity_sig covers the wrong Noise static key (replayed/forged payload), both roles — this rejection branch previously had **zero executing assertions** behind it
- rejection when the advertised identity key does not match the signature (impersonation with another peer's public key)

**Mislabelled test removed.** `HandshakeSpec`'s "performFullHandshake rejects replayed identity payload (MitM)" asserted only that a legitimate handshake succeeds; replaced with a note pointing at the real production-path rejection tests above.

**Byte exactness (the only conformance check available before #129):**

- `encodeMessage "/multistream/1.0.0"` compared against the full 20-byte spec vector (replaces the head/last/length assertions a typo could satisfy)
- a hand-rolled initiator reads the responder's raw wire bytes: header echo compared byte-for-byte, and the `na` response compared to `0x03 0x6e 0x61 0x0a`
- identity_sig pinned to the literal `"noise-libp2p-static-key:"` prefix bytes, independent of the constant in `Handshake.hs`

**Boundary sizes around the noise frame limits:**

- `encodeFrame` boundary table: 0/1/65534/65535 round-trip, 65536/70000 rejected
- 65519-byte plaintext encrypts to exactly one maximum-size (65535, `0xFFFF`-prefixed) Noise message; 65520 provably cannot reach the wire as a single frame
- encrypted `StreamIO` round-trips at exactly 65519 and 65520 bytes (the first size that must span two frames), with the channel still usable in both directions afterwards

**mss with differing protocol tables:** initiator `["/tls/1.0.0","/mplex/6.7.0","/noise"]` vs responder `["/yamux/1.0.0","/noise"]` negotiates `/noise` after multiple `na` rounds.

### Not addressed here (still open after this PR)

- EOF-capable memory stream harness (peer-disconnect mid-negotiation classes) — real-socket disconnect tests belong in `IntegrationSpec`
- lenient protobuf decoding gaps tracked as #166 (field order 2-then-1, extensions field, empty transport messages) — these are implementation changes, not test additions
- true heterogeneous-peer conformance — #129 (`libp2p/unified-testing`)

## Test plan

- `cabal build` and `cabal test` (GHC 9.10.3): **726 examples, 0 failures**
- Mutation sanity check: disabling the initiator signature check in `Upgrade.hs` makes exactly the two new initiator rejection tests fail

Refs #172