### PR TITLE
test: exercise the real sendPing path and assert identify/ping wire framing

### DIFF
--- a/test/LibP2P/IntegrationSpec.hs
+++ b/test/LibP2P/IntegrationSpec.hs
@@ -162,6 +162,12 @@ spec = do
             idListenAddrs info `shouldSatisfy` (not . null)
 
   describe "Multi-protocol" $ do
+    -- WARNING(#163): this test certifies behaviour the spec forbids.
+    -- specs/ping/ping.md: "The dialing peer MUST NOT keep more than one
+    -- outbound stream for the ping protocol per peer." It passes only
+    -- because sendPing opens a new stream per call. When #163 is fixed
+    -- (stream reuse + close), this test must be inverted — assert a
+    -- single outbound stream across both pings — not extended.
     it "multiple Ping requests on different streams over same connection" $ do
       withConnectedPair $ \_nodeA _nodeB conn -> do
         -- Send two Pings on separate streams over the same muxed connection

--- a/test/LibP2P/Protocol/Identify/IdentifySpec.hs
+++ b/test/LibP2P/Protocol/Identify/IdentifySpec.hs
@@ -17,6 +17,7 @@ import Control.Concurrent.STM
 import Control.Exception (SomeException, catch, throwIO)
 import qualified Data.ByteString as BS
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.List (sort)
 import qualified Data.Map.Strict as Map
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (kpPublic)
@@ -127,12 +128,17 @@ spec = do
       idProtocolVersion info `shouldBe` Just "ipfs/0.1.0"
       idAgentVersion info `shouldBe` Just "libp2p-hs/0.1.0"
 
-    it "buildLocalIdentify includes registered protocols" $ do
+    it "buildLocalIdentify advertises exactly the registered protocol set" $ do
       sw <- mkTestSwitch
       info <- buildLocalIdentify sw Nothing
-      let protos = idProtocols info
-      protos `shouldSatisfy` (\ps -> "/test/1.0.0" `elem` ps)
-      protos `shouldSatisfy` (\ps -> "/test/2.0.0" `elem` ps)
+      -- Set equality, not membership: over-advertising protocols we do
+      -- not actually handle must fail this test too.
+      sort (idProtocols info) `shouldBe` ["/test/1.0.0", "/test/2.0.0"]
+
+    it "buildLocalIdentify omits observedAddr without a connection context" $ do
+      sw <- mkTestSwitch
+      info <- buildLocalIdentify sw Nothing
+      idObservedAddr info `shouldBe` Nothing
 
     it "buildLocalIdentify includes public key" $ do
       sw <- mkTestSwitch
@@ -277,6 +283,18 @@ spec = do
       streamWrite streamA (encodeFramedIdentify testInfo)
       result <- readFramedIdentify streamB maxIdentifySize
       result `shouldBe` Right testInfo
+
+    it "readFramedIdentify rejects a truncated frame" $ do
+      (streamA, streamB) <- mkClosableStreamPair
+      -- The length prefix promises 100 bytes but only 40 arrive before
+      -- EOF: the reader must return Left, never a partial Right.
+      streamWrite streamA (encodeUvarint 100 <> BS.replicate 40 0x08)
+      streamClose streamA
+      result <- readFramedIdentify streamB maxIdentifySize
+      case result of
+        Left err -> err `shouldSatisfy` (not . null)
+        Right info -> expectationFailure $
+          "expected truncated frame to be rejected, got: " ++ show info
 
     it "readFramedIdentify rejects an oversized length prefix" $ do
       (streamA, streamB) <- mkClosableStreamPair

--- a/test/LibP2P/Protocol/Identify/MessageSpec.hs
+++ b/test/LibP2P/Protocol/Identify/MessageSpec.hs
@@ -58,14 +58,44 @@ spec = do
         Right result -> idProtocols result `shouldBe` ["/noise", "/yamux/1.0.0", "/ipfs/id/1.0.0"]
         Left err -> expectationFailure $ "Decode failed: " ++ show err
 
-    it "decode rejects oversized message" $ do
-      -- Create a message larger than maxIdentifySize
-      let bigPubKey = BS.replicate (maxIdentifySize + 100) 0x42
-          info = IdentifyInfo Nothing Nothing (Just bigPubKey) [] Nothing []
-          encoded = encodeIdentify info
-      -- The encoded message should be parseable (proto3-wire doesn't enforce size)
-      -- Size check is done at read time by readFramedIdentify, not at decode time
-      BS.length encoded `shouldSatisfy` (> maxIdentifySize)
+    it "encodes each field with the spec's field number and wire type" $ do
+      -- specs/identify/README.md protobuf: publicKey = 1, listenAddrs = 2,
+      -- protocols = 3, observedAddr = 4, protocolVersion = 5,
+      -- agentVersion = 6 — all length-delimited (wire type 2), so the
+      -- first tag byte of a single-field message is (field << 3) | 2.
+      let empty = IdentifyInfo Nothing Nothing Nothing [] Nothing []
+          firstByte info = BS.head (encodeIdentify info)
+      firstByte empty { idPublicKey = Just (BS.pack [1]) }   `shouldBe` 0x0a
+      firstByte empty { idListenAddrs = [BS.pack [1]] }      `shouldBe` 0x12
+      firstByte empty { idProtocols = ["/x/1.0.0"] }         `shouldBe` 0x1a
+      firstByte empty { idObservedAddr = Just (BS.pack [1]) } `shouldBe` 0x22
+      firstByte empty { idProtocolVersion = Just "v" }       `shouldBe` 0x2a
+      firstByte empty { idAgentVersion = Just "v" }          `shouldBe` 0x32
+
+    it "decodes a go-libp2p-shaped message (hand-written golden vector)" $ do
+      -- Hand-constructed per the spec protobuf, deliberately NOT produced
+      -- by encodeIdentify, so encoder and decoder cannot agree on a
+      -- convention that is internally consistent but externally wrong.
+      let golden = BS.concat
+            [ -- listenAddrs = 2 (bytes): /ip4/127.0.0.1/tcp/4001
+              BS.pack [0x12, 0x08, 0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x0f, 0xa1]
+              -- protocols = 3 (string): "/ipfs/id/1.0.0"
+            , BS.pack [0x1a, 0x0e], "/ipfs/id/1.0.0"
+              -- protocols = 3 (string): "/ipfs/ping/1.0.0"
+            , BS.pack [0x1a, 0x10], "/ipfs/ping/1.0.0"
+              -- protocolVersion = 5 (string): "ipfs/0.1.0"
+            , BS.pack [0x2a, 0x0a], "ipfs/0.1.0"
+              -- agentVersion = 6 (string): "go-libp2p/0.36.4"
+            , BS.pack [0x32, 0x10], "go-libp2p/0.36.4"
+            ]
+      case decodeIdentify golden of
+        Left err -> expectationFailure $ "Decode failed: " ++ show err
+        Right info -> do
+          idAgentVersion info `shouldBe` Just "go-libp2p/0.36.4"
+          idProtocolVersion info `shouldBe` Just "ipfs/0.1.0"
+          idListenAddrs info `shouldBe`
+            [BS.pack [0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x0f, 0xa1]]
+          idProtocols info `shouldBe` ["/ipfs/id/1.0.0", "/ipfs/ping/1.0.0"]
 
     it "decode skips unknown fields" $ do
       -- Encode known fields, then append unknown field bytes

--- a/test/LibP2P/Protocol/Ping/PingSpec.hs
+++ b/test/LibP2P/Protocol/Ping/PingSpec.hs
@@ -1,12 +1,13 @@
 module LibP2P.Protocol.Ping.PingSpec (spec) where
 
-import Control.Concurrent.Async (async, wait)
+import Control.Concurrent.Async (async, cancel, wait)
 import Control.Concurrent.STM
   ( TMVar
   , TQueue
   , atomically
   , newEmptyTMVarIO
   , newTQueueIO
+  , newTVarIO
   , putTMVar
   , readTQueue
   , readTVar
@@ -14,19 +15,32 @@ import Control.Concurrent.STM
   , writeTQueue
   )
 import Control.Exception (throwIO)
-import Crypto.Random (getRandomBytes)
+import Data.Bits (xor)
 import qualified Data.ByteString as BS
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import qualified Data.Map.Strict as Map
-import Data.Time.Clock (diffUTCTime, getCurrentTime)
 import Data.Word (Word8)
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (kpPublic)
 import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
-import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.Multiaddr (Multiaddr (..))
+import LibP2P.Multiaddr.Protocol (Protocol (..))
+import LibP2P.MultistreamSelect.Negotiation
+  ( NegotiationResult (..)
+  , StreamIO (..)
+  , negotiateResponder
+  )
 import LibP2P.Protocol.Ping
 import LibP2P.Switch (newSwitch)
-import LibP2P.Switch.Types (Switch (..))
+import LibP2P.Switch.Types
+  ( ConnState (..)
+  , Connection (..)
+  , Direction (..)
+  , MuxerSession (..)
+  , Switch (..)
+  )
 import System.IO.Error (mkIOError, eofErrorType)
+import System.Timeout (timeout)
 import Test.Hspec
 
 -- | Create a closable stream pair where the writer can signal EOF.
@@ -53,16 +67,30 @@ mkClosableStreamPair = do
       streamB = StreamIO (writeQ qBtoA closedB) (readQ qAtoB) (closeWriter qBtoA closedB)
   pure (streamA, closeWriter qAtoB closedA, streamB)
 
--- | Create a simple bidirectional memory stream pair (no close).
-mkMemoryPair :: IO (StreamIO, StreamIO)
-mkMemoryPair = do
-  qAtoB <- newTQueueIO :: IO (TQueue Word8)
-  qBtoA <- newTQueueIO :: IO (TQueue Word8)
-  let writeQ q bs = mapM_ (atomically . writeTQueue q) (BS.unpack bs)
-      readQ q = atomically (readTQueue q)
-  pure ( StreamIO (writeQ qAtoB) (readQ qBtoA) (pure ())
-       , StreamIO (writeQ qBtoA) (readQ qAtoB) (pure ())
-       )
+-- | Wrap a StreamIO so every write chunk is recorded (most recent first).
+recordWrites :: IORef [BS.ByteString] -> StreamIO -> StreamIO
+recordWrites ref s = s
+  { streamWrite = \bs -> modifyIORef' ref (bs :) >> streamWrite s bs }
+
+-- | Build an outbound Connection whose muxer hands out the given stream.
+-- This is what lets tests drive the real 'sendPing' initiator path.
+mkPingConnection :: StreamIO -> IO Connection
+mkPingConnection stream = do
+  stateVar <- newTVarIO ConnOpen
+  pure Connection
+    { connPeerId     = PeerId "ping-remote"
+    , connDirection  = Outbound
+    , connLocalAddr  = Multiaddr [IP4 0x7f000001, TCP 0]
+    , connRemoteAddr = Multiaddr [IP4 0x7f000001, TCP 4001]
+    , connSecurity   = "/noise"
+    , connMuxer      = "/yamux/1.0.0"
+    , connSession    = MuxerSession
+        { muxOpenStream   = pure stream
+        , muxAcceptStream = fail "test connection: no inbound streams"
+        , muxClose        = pure ()
+        }
+    , connState      = stateVar
+    }
 
 -- | Read exactly n bytes from a stream.
 readNBytes :: StreamIO -> Int -> IO BS.ByteString
@@ -70,7 +98,7 @@ readNBytes stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1..n]
 
 spec :: Spec
 spec = do
-  describe "Ping protocol" $ do
+  describe "Ping responder (handlePing)" $ do
     it "handlePing echoes 32 bytes" $ do
       (streamA, closeA, streamB) <- mkClosableStreamPair
       handler <- async $ handlePing streamB (PeerId "test-peer")
@@ -98,42 +126,120 @@ spec = do
       wait handler
 
     it "handlePing exits on stream close" $ do
-      (streamA, closeA, streamB) <- mkClosableStreamPair
+      (_streamA, closeA, streamB) <- mkClosableStreamPair
       handler <- async $ handlePing streamB (PeerId "test-peer")
       closeA
       -- Handler should exit gracefully (not hang or crash)
       wait handler
 
-    it "sendPing round-trip measures RTT" $ do
-      (streamA, streamB) <- mkMemoryPair
-      -- Simulate echo responder
-      let echoer = do
-            payload <- readNBytes streamB pingSize
-            streamWrite streamB payload
-      echoTask <- async echoer
-      -- Simulate initiator: send random 32 bytes, read echo, measure time
-      payload <- getRandomBytes pingSize :: IO BS.ByteString
-      t0 <- getCurrentTime
-      streamWrite streamA payload
-      resp <- readNBytes streamA pingSize
-      t1 <- getCurrentTime
-      wait echoTask
-      resp `shouldBe` payload
-      diffUTCTime t1 t0 `shouldSatisfy` (>= 0)
+    it "handlePing exits without echoing when the final read is short" $ do
+      (streamA, closeA, streamB) <- mkClosableStreamPair
+      handler <- async $ handlePing streamB (PeerId "test-peer")
+      -- One byte short of a full ping payload, then EOF (ping.md: the
+      -- payload is exactly 32 bytes; a truncated read must not be echoed).
+      streamWrite streamA (BS.pack [1..31])
+      closeA
+      wait handler
+      -- The responder must not have written anything back.
+      echoed <- timeout 100000 (streamReadByte streamA)
+      echoed `shouldBe` Nothing
 
-    it "sendPing detects mismatch" $ do
-      (streamA, streamB) <- mkMemoryPair
-      -- Bad echoer: returns wrong data
-      let badEchoer = do
-            _payload <- readNBytes streamB pingSize
-            streamWrite streamB (BS.replicate pingSize 0xFF)
-      echoTask <- async badEchoer
-      let payload = BS.pack [1..32]
-      streamWrite streamA payload
-      resp <- readNBytes streamA pingSize
-      wait echoTask
-      resp `shouldNotBe` payload
+  describe "Ping initiator (sendPing)" $ do
+    it "sendPing round-trips against handlePing and returns a non-negative RTT" $ do
+      (streamA, closeA, streamB) <- mkClosableStreamPair
+      conn <- mkPingConnection streamA
+      responder <- async $ do
+        negResult <- negotiateResponder streamB [pingProtocolId]
+        negResult `shouldBe` Accepted pingProtocolId
+        handlePing streamB (PeerId "initiator")
+      result <- sendPing conn
+      case result of
+        Left err -> expectationFailure $ "sendPing failed: " ++ show err
+        Right (PingResult rtt) -> rtt `shouldSatisfy` (>= 0)
+      -- NOTE(#163): sendPing does not close the stream after the echo, so
+      -- the responder's echo loop never sees EOF on its own. Close from
+      -- the test to let it exit; do not assert responder termination here.
+      closeA
+      wait responder
 
+    it "sendPing returns Left PingMismatch when the echo is corrupted" $ do
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      conn <- mkPingConnection streamA
+      responder <- async $ do
+        negResult <- negotiateResponder streamB [pingProtocolId]
+        negResult `shouldBe` Accepted pingProtocolId
+        payload <- readNBytes streamB pingSize
+        -- Corrupt the first byte before echoing (ping.md: the echo MUST
+        -- match the sent payload).
+        let corrupted = BS.cons (BS.head payload `xor` 0xFF) (BS.tail payload)
+        streamWrite streamB corrupted
+      result <- sendPing conn
+      wait responder
+      result `shouldBe` Left PingMismatch
+
+    it "sendPing returns Left PingStreamError on mid-payload EOF" $ do
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      conn <- mkPingConnection streamA
+      responder <- async $ do
+        negResult <- negotiateResponder streamB [pingProtocolId]
+        negResult `shouldBe` Accepted pingProtocolId
+        payload <- readNBytes streamB pingSize
+        -- Echo only half the payload, then close: the initiator must
+        -- surface a stream error instead of hanging or succeeding.
+        streamWrite streamB (BS.take 16 payload)
+        streamClose streamB
+      result <- sendPing conn
+      wait responder
+      case result of
+        Left (PingStreamError _) -> pure ()
+        other -> expectationFailure $
+          "expected Left PingStreamError, got: " ++ show other
+
+    it "sendPing returns Left PingStreamError when the responder rejects the protocol" $ do
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      conn <- mkPingConnection streamA
+      -- Responder speaks multistream-select but supports no protocols, so
+      -- it answers "na" to /ipfs/ping/1.0.0 and keeps waiting for further
+      -- proposals (which never come) — hence cancel, not wait.
+      responder <- async $ negotiateResponder streamB []
+      result <- sendPing conn
+      cancel responder
+      case result of
+        Left (PingStreamError _) -> pure ()
+        other -> expectationFailure $
+          "expected Left PingStreamError, got: " ++ show other
+
+    it "sendPing writes a fresh random 32-byte payload per ping, unframed" $ do
+      let runRecordedPing = do
+            (streamA, closeA, streamB) <- mkClosableStreamPair
+            writesRef <- newIORef ([] :: [BS.ByteString])
+            conn <- mkPingConnection (recordWrites writesRef streamA)
+            responder <- async $ do
+              negResult <- negotiateResponder streamB [pingProtocolId]
+              negResult `shouldBe` Accepted pingProtocolId
+              handlePing streamB (PeerId "initiator")
+            result <- sendPing conn
+            case result of
+              Left err -> expectationFailure $ "sendPing failed: " ++ show err
+              Right _  -> pure ()
+            closeA  -- see NOTE(#163) above
+            wait responder
+            readIORef writesRef
+      chunks1 <- runRecordedPing
+      -- The initiator writes exactly three chunks: the multistream header,
+      -- the protocol proposal, and the ping payload (most recent first).
+      length chunks1 `shouldBe` 3
+      let payload1 = head chunks1
+      -- ping.md: the payload is 32 raw bytes — no varint prefix, no
+      -- framing. A length-prefixed write would be 33+ bytes here.
+      BS.length payload1 `shouldBe` pingSize
+      -- A second ping must use a freshly generated random payload.
+      chunks2 <- runRecordedPing
+      let payload2 = head chunks2
+      BS.length payload2 `shouldBe` pingSize
+      payload2 `shouldNotBe` payload1
+
+  describe "Ping registration" $ do
     it "registerPingHandler adds handler to switch" $ do
       Right kp <- generateKeyPair
       let pid = fromPublicKey (kpPublic kp)


### PR DESCRIPTION
Closes the test-coverage gaps from #170 that are still open on current `main`, after re-verifying every claimed gap against the code as of #196.

## Gaps already closed by earlier fixes (no change needed)

| Gap (from #170) | Closed by |
|---|---|
| `handleIdentify` writes a length-delimited message, not a bare protobuf | #184 — `IdentifySpec` asserts the varint prefix equals the payload length |
| `readIdentify` rejects a frame whose varint length exceeds `maxIdentifySize` | #184 — `readFramedIdentify rejects an oversized length prefix` |
| `handleIdentify` populates `observedAddr` from the connection remote address | #195 (+ #167) — covered in `IdentifySpec` |
| `sendPing` never invoked anywhere | Partially: `IntegrationSpec` now calls the real `sendPing`/`requestIdentify` over TCP — but the unit tier still reimplemented it inline (fixed here) |

## Gaps closed in this PR

| Gap | Test |
|---|---|
| `sendPing` never called by any unit test | `PingSpec` now drives the real `sendPing` over a mock `Connection` (`muxOpenStream` hands out an in-memory stream) against `negotiateResponder` + `handlePing` |
| Fake mismatch test (`resp shouldNotBe payload` on raw bytes) | `sendPing returns Left PingMismatch when the echo is corrupted` — asserts the real error value |
| `sendPing` on mid-payload EOF | `sendPing returns Left PingStreamError on mid-payload EOF` (16 bytes then close → `Left`, no hang) |
| `sendPing` on protocol rejection | `sendPing returns Left PingStreamError when the responder rejects the protocol` |
| Ping payload never observed on the wire | `sendPing writes a fresh random 32-byte payload per ping, unframed` — records write chunks; the payload chunk is exactly 32 bytes (a length-prefixed write would be 33+) and differs between calls |
| `handlePing` short final read | `handlePing exits without echoing when the final read is short` — 31 bytes then EOF → handler exits, nothing written back |
| `decode rejects oversized message` asserted nothing (`BS.replicate` works) | Deleted; replaced by the two tests below |
| Field numbers never pinned | `encodes each field with the spec's field number and wire type` — single-field messages must start with `0x0a`/`0x12`/`0x1a`/`0x22`/`0x2a`/`0x32` |
| Decoder only ever fed our own encoder's output | `decodes a go-libp2p-shaped message (hand-written golden vector)` — byte vector hand-constructed per the spec protobuf, not produced by `encodeIdentify` |
| Truncated frame | `readFramedIdentify rejects a truncated frame` — varint says 100, 40 bytes then EOF → `Left`, never a partial `Right` |
| `observedAddr` absent without connection context | `buildLocalIdentify omits observedAddr without a connection context` |
| `elem` checks cannot detect over-advertising | `buildLocalIdentify advertises exactly the registered protocol set` — set equality |
| `IntegrationSpec` certifies the #163-forbidden behaviour silently | Flagged with a `WARNING(#163)` comment stating it must be inverted, not extended, when #163 lands |

## Remaining (tracked elsewhere, not addressed here)

- **Ping stream lifecycle** (`sendPing` closes write side, responder terminates on its own, stream reuse, no leaked handler threads) — these assert the fix for open bug #163, which is being handled separately. The new round-trip tests close the stream from the test side with a `NOTE(#163)` comment.
- **`PingTimeout`** — requires adding a timeout to `sendPing` (an implementation change, out of scope for a test-only PR; natural to fold into the #163 fix).
- **Identify push merge semantics + `pushIdentify` sender + publicKey/peer-id validation** — assert the fix for open bug #165; `handleIdentifyPush` still does a wholesale `Map.insert`, so merge tests would fail today.
- **Cross-implementation identify/ping in `interop/`** — the structural fix for the homogeneous-E2E blind spot; belongs with the unified-testing work (#129).

## Verification

- `cabal build` + `cabal test` (GHC 9.10.x): 723 examples, 0 failures.
- TDD sanity check: disabling the echo comparison in `sendPing` and shifting the `publicKey` protobuf field to 7 made exactly the new tests fail (`PingMismatch`, field-number, round-trip, framed round-trip); breakage reverted before commit.

Refs #170 — the remaining items above are blocked on #163/#165/#129 and should close with those issues.
