### PR TITLE
test: cover yamux state-machine cells with a hostile-peer harness

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -140,8 +140,10 @@ test-suite libp2p-hs-test
     LibP2P.Crypto.KeyImportSpec
     LibP2P.MultistreamSelect.NegotiationSpec
     LibP2P.Yamux.FrameSpec
+    LibP2P.Yamux.HostilePeer
     LibP2P.Yamux.StreamSpec
     LibP2P.Yamux.SessionSpec
+    LibP2P.Yamux.StateMachineSpec
     LibP2P.Transport.TCPSpec
     LibP2P.Switch.ConnPoolSpec
     LibP2P.Switch.ConnectionLifecycleSpec

--- a/src/LibP2P/Yamux/Session.hs
+++ b/src/LibP2P/Yamux/Session.hs
@@ -171,11 +171,13 @@ recvLoop sess = go
       -- Read 12-byte header
       headerBytes <- ysessRead sess headerSize
       case decodeHeader headerBytes of
-        Left _err -> pure () -- Protocol error, stop
-        Right hdr -> do
+        -- Malformed header (unknown frame type): tell the peer why we
+        -- are leaving before terminating, as go-yamux does
+        Left _err -> sendGoAway sess GoAwayProtocol
+        Right hdr ->
           -- Verify version
           if yhVersion hdr /= 0
-            then pure () -- Protocol error
+            then sendGoAway sess GoAwayProtocol
             else do
               continue <- dispatchFrame sess hdr
               when continue go

--- a/test/LibP2P/Yamux/FrameSpec.hs
+++ b/test/LibP2P/Yamux/FrameSpec.hs
@@ -55,11 +55,17 @@ spec = do
       BS.index encoded 2 `shouldBe` 0x00
       BS.index encoded 3 `shouldBe` 0x08
 
-    it "encodes GoAway normal" $ do
-      let hdr = YamuxHeader 0 FrameGoAway defaultFlags 0 0
-      let encoded = encodeHeader hdr
-      BS.index encoded 1 `shouldBe` 0x03
-      BS.index encoded 8 `shouldBe` 0x00 -- error code 0
+    it "encodes all three GoAway codes in the low byte of the Length field" $ do
+      -- The error code lives in the 32-bit Length field; codes 0x00,
+      -- 0x01 and 0x02 differ only at byte 11 (the least significant)
+      mapM_
+        ( \code -> do
+            let encoded = encodeHeader (YamuxHeader 0 FrameGoAway defaultFlags 0 code)
+            BS.index encoded 1 `shouldBe` 0x03
+            BS.take 3 (BS.drop 8 encoded) `shouldBe` BS.pack [0x00, 0x00, 0x00]
+            BS.index encoded 11 `shouldBe` fromIntegral code
+        )
+        ([0x00, 0x01, 0x02] :: [Word32])
 
   describe "decodeHeader" $ do
     it "decodes Data SYN stream=1 len=5" $ do
@@ -108,15 +114,6 @@ spec = do
       property $ \(sid :: Word32) (len :: Word32) ->
         let hdr = YamuxHeader 0 FrameData defaultFlags sid len
          in decodeHeader (encodeHeader hdr) === Right hdr
-
-  describe "Stream ID conventions" $ do
-    it "client uses odd IDs (1,3,5,...)" $ do
-      let clientIds = [1, 3, 5, 7, 9] :: [Word32]
-      all odd clientIds `shouldBe` True
-
-    it "server uses even IDs (2,4,6,...)" $ do
-      let serverIds = [2, 4, 6, 8, 10] :: [Word32]
-      all even serverIds `shouldBe` True
 
   describe "Constants" $ do
     it "initial window size is 256 KiB" $

--- a/test/LibP2P/Yamux/HostilePeer.hs
+++ b/test/LibP2P/Yamux/HostilePeer.hs
@@ -1,0 +1,105 @@
+-- | Hostile-peer test harness for Yamux (issue #171).
+--
+-- Runs our session implementation on one side and gives the test raw
+-- byte-level control of the other side, so tests can inject arbitrary
+-- frames (including ones our own sender never emits) and decode every
+-- frame the session writes.
+--
+-- This replaces the symmetric self-pair harness for adversarial and
+-- state-machine tests: with two of our sessions wired together, any
+-- frame shape a conformant-but-differently-written peer may send is
+-- structurally unreachable.
+module LibP2P.Yamux.HostilePeer
+  ( HostilePeer (..)
+  , withHostilePeer
+  , injectFrame
+  , expectFrame
+  , acceptWithin
+  , awaitState
+  , awaitTrue
+  ) where
+
+import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.STM
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import LibP2P.Yamux.Frame
+import LibP2P.Yamux.Session
+import LibP2P.Yamux.Types
+import System.Timeout (timeout)
+import Test.Hspec
+
+-- | Our session under test plus raw byte access to both directions.
+data HostilePeer = HostilePeer
+  { hpSession :: YamuxSession
+  -- ^ The session under test (recvLoop/sendLoop already running)
+  , hpInject :: ByteString -> IO ()
+  -- ^ Write raw bytes into the session's receive side
+  , hpNextFrame :: IO (YamuxHeader, ByteString)
+  -- ^ Decode the next frame the session wrote (header + Data payload)
+  }
+
+-- | Run an action against a session wired to a raw byte peer.
+withHostilePeer :: SessionRole -> (HostilePeer -> IO a) -> IO a
+withHostilePeer role action = do
+  toSession <- newTQueueIO
+  fromSession <- newTQueueIO
+  let writeTo q bs = mapM_ (atomically . writeTQueue q) (BS.unpack bs)
+      readFrom q n = BS.pack <$> mapM (const (atomically (readTQueue q))) [1 .. n]
+  sess <- newSession role (writeTo fromSession) (readFrom toSession)
+  let nextFrame = do
+        hdrBytes <- readFrom fromSession headerSize
+        case decodeHeader hdrBytes of
+          Left err -> fail ("frame recorder: " <> err)
+          Right hdr -> do
+            payload <-
+              if yhType hdr == FrameData && yhLength hdr > 0
+                then readFrom fromSession (fromIntegral (yhLength hdr))
+                else pure BS.empty
+            pure (hdr, payload)
+  withAsync (sendLoop sess) $ \_ ->
+    withAsync (recvLoop sess) $ \_ ->
+      action (HostilePeer sess (writeTo toSession) nextFrame)
+
+-- | Inject a frame (header plus optional Data payload) as raw bytes.
+injectFrame :: HostilePeer -> YamuxHeader -> ByteString -> IO ()
+injectFrame hp hdr payload = hpInject hp (encodeHeader hdr <> payload)
+
+-- | Read the session's next outbound frame, failing loudly after 1s
+-- instead of hanging the suite.
+expectFrame :: HostilePeer -> IO (YamuxHeader, ByteString)
+expectFrame hp = do
+  mFrame <- timeout 1000000 (hpNextFrame hp)
+  case mFrame of
+    Just frame -> pure frame
+    Nothing -> fail "expected an outbound frame within 1s, got none"
+
+-- | Accept an inbound stream, failing loudly after 1s.
+acceptWithin :: HostilePeer -> IO YamuxStream
+acceptWithin hp = do
+  mRes <- timeout 1000000 (acceptStream (hpSession hp))
+  case mRes of
+    Just (Right s) -> pure s
+    Just (Left err) -> fail ("acceptStream: " <> show err)
+    Nothing -> fail "acceptStream timed out after 1s"
+
+-- | Block until the stream reaches the given state, failing after 1s.
+awaitState :: YamuxStream -> StreamState -> Expectation
+awaitState stream expected = do
+  result <- timeout 1000000 $ atomically $ do
+    st <- readTVar (ysState stream)
+    check (st == expected)
+  case result of
+    Just () -> pure ()
+    Nothing -> do
+      actual <- readTVarIO (ysState stream)
+      expectationFailure $
+        "expected stream state " <> show expected <> " but stuck at " <> show actual
+
+-- | Block until the TVar becomes True, failing after 1s.
+awaitTrue :: TVar Bool -> Expectation
+awaitTrue var = do
+  result <- timeout 1000000 $ atomically (readTVar var >>= check)
+  case result of
+    Just () -> pure ()
+    Nothing -> expectationFailure "expected TVar to become True within 1s"

--- a/test/LibP2P/Yamux/SessionSpec.hs
+++ b/test/LibP2P/Yamux/SessionSpec.hs
@@ -1,11 +1,13 @@
 module LibP2P.Yamux.SessionSpec (spec) where
 
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (async, concurrently, concurrently_, wait, withAsync)
+import Control.Concurrent.Async (async, concurrently, concurrently_, poll, wait, withAsync)
 import Control.Concurrent.STM
 import qualified Data.ByteString as BS
+import Data.Maybe (isNothing)
 import System.Timeout (timeout)
 import LibP2P.Yamux.Frame
+import LibP2P.Yamux.HostilePeer
 import LibP2P.Yamux.Session
 import LibP2P.Yamux.Stream (streamClose, streamRead, streamReset, streamWrite)
 import LibP2P.Yamux.Types
@@ -164,15 +166,47 @@ spec = do
         result <- ping client
         result `shouldBe` Right ()
 
-    it "Ping echoes exact opaque value in Length field" $ do
-      withSessionPair $ \(client, _server) -> do
-        result <- ping client
-        result `shouldBe` Right ()
+    it "echoes the exact opaque value in the Ping ACK" $
+      withHostilePeer RoleServer $ \hp -> do
+        injectFrame hp (YamuxHeader 0 FramePing (defaultFlags {flagSYN = True}) 0 0xDEADBEEF) BS.empty
+        (ack, _) <- expectFrame hp
+        yhType ack `shouldBe` FramePing
+        flagACK (yhFlags ack) `shouldBe` True
+        yhStreamId ack `shouldBe` 0
+        yhLength ack `shouldBe` 0xDEADBEEF
 
-    it "Ping uses StreamID 0" $ do
-      withSessionPair $ \(client, _server) -> do
-        result <- ping client
-        result `shouldBe` Right ()
+    it "sends Ping SYN on StreamID 0 and resolves on the matching ACK" $
+      withHostilePeer RoleClient $ \hp -> do
+        pingA <- async (ping (hpSession hp))
+        (syn, _) <- expectFrame hp
+        yhType syn `shouldBe` FramePing
+        flagSYN (yhFlags syn) `shouldBe` True
+        yhStreamId syn `shouldBe` 0
+        injectFrame hp (YamuxHeader 0 FramePing (defaultFlags {flagACK = True}) 0 (yhLength syn)) BS.empty
+        result <- timeout 1000000 (wait pingA)
+        result `shouldBe` Just (Right ())
+
+    it "does not resolve a pending ping from a mismatched opaque value" $
+      withHostilePeer RoleClient $ \hp -> do
+        pingA <- async (ping (hpSession hp))
+        (syn, _) <- expectFrame hp
+        let opaque = yhLength syn
+        injectFrame hp (YamuxHeader 0 FramePing (defaultFlags {flagACK = True}) 0 (opaque + 100)) BS.empty
+        threadDelay 100000
+        stillPending <- poll pingA
+        stillPending `shouldSatisfy` isNothing
+        injectFrame hp (YamuxHeader 0 FramePing (defaultFlags {flagACK = True}) 0 opaque) BS.empty
+        result <- timeout 1000000 (wait pingA)
+        result `shouldBe` Just (Right ())
+
+    it "ignores an unsolicited Ping ACK" $
+      withHostilePeer RoleServer $ \hp -> do
+        injectFrame hp (YamuxHeader 0 FramePing (defaultFlags {flagACK = True}) 0 99) BS.empty
+        -- Session must survive: a subsequent Ping SYN still gets echoed
+        injectFrame hp (YamuxHeader 0 FramePing (defaultFlags {flagSYN = True}) 0 7) BS.empty
+        (ack, _) <- expectFrame hp
+        yhType ack `shouldBe` FramePing
+        yhLength ack `shouldBe` 7
 
   describe "GoAway" $ do
     it "GoAway Normal (0x00) sets ysessShutdown" $ do
@@ -233,6 +267,40 @@ spec = do
           check (st == StreamClosed)
         stClient <- readTVarIO (ysState clientStream)
         stClient `shouldBe` StreamClosed
+
+  describe "Half-close semantics" $ do
+    it "keeps the remote-to-local direction open after a local FIN" $ do
+      withSessionPair $ \(client, server) -> do
+        (clientStream, serverStream) <-
+          concurrently
+            (openStream client >>= \(Right s) -> pure s)
+            (acceptStream server >>= \(Right s) -> pure s)
+        atomically $ do
+          st <- readTVar (ysState clientStream)
+          check (st == StreamEstablished)
+        -- Client half-closes: its write side is dead
+        Right () <- streamClose clientStream
+        wr <- streamWrite clientStream "late"
+        wr `shouldBe` Left YamuxStreamClosed
+        -- Server observes EOF on its read side
+        finSeen <- timeout 1000000 $ atomically $ do
+          st <- readTVar (ysState serverStream)
+          check (st == StreamRemoteClose)
+        finSeen `shouldBe` Just ()
+        eof <- streamRead serverStream
+        eof `shouldBe` Left YamuxStreamClosed
+        -- The other direction still flows: server writes, client reads
+        Right () <- streamWrite serverStream "reply"
+        Right got <- streamRead clientStream
+        got `shouldBe` "reply"
+        -- Server closes too; both ends reach Closed and client sees EOF
+        Right () <- streamClose serverStream
+        closed <- timeout 1000000 $ atomically $ do
+          st <- readTVar (ysState clientStream)
+          check (st == StreamClosed)
+        closed `shouldBe` Just ()
+        end <- streamRead clientStream
+        end `shouldBe` Left YamuxStreamClosed
 
   describe "SYN validation" $ do
     it "SYN with wrong parity triggers GoAway (server rejects even ID)" $ do

--- a/test/LibP2P/Yamux/StateMachineSpec.hs
+++ b/test/LibP2P/Yamux/StateMachineSpec.hs
@@ -1,0 +1,222 @@
+-- | Yamux stream state-machine coverage (issue #171).
+--
+-- The HashiCorp yamux spec (spec.md, Flag Field) says SYN, ACK, FIN and
+-- RST "may be sent with a data or window update message", so one state
+-- transition table must hold for both frame types. These tests inject
+-- raw frames through the hostile-peer harness to exercise the
+-- (state x flag x frame-type) cells our own sender never produces.
+module LibP2P.Yamux.StateMachineSpec (spec) where
+
+import Control.Concurrent.STM
+import qualified Data.ByteString as BS
+import Data.Word (Word32)
+import LibP2P.Yamux.Frame
+import LibP2P.Yamux.HostilePeer
+import LibP2P.Yamux.Session
+import LibP2P.Yamux.Stream (streamClose, streamRead, streamWrite)
+import LibP2P.Yamux.Types
+import System.Timeout (timeout)
+import Test.Hspec
+
+synF, ackF, finF, rstF, noF :: Flags
+synF = defaultFlags {flagSYN = True}
+ackF = defaultFlags {flagACK = True}
+finF = defaultFlags {flagFIN = True}
+rstF = defaultFlags {flagRST = True}
+noF = defaultFlags
+
+dataHdr, wuHdr :: Flags -> Word32 -> Word32 -> YamuxHeader
+dataHdr = YamuxHeader 0 FrameData
+wuHdr = YamuxHeader 0 FrameWindowUpdate
+
+pingHdr :: Flags -> Word32 -> YamuxHeader
+pingHdr f = YamuxHeader 0 FramePing f 0
+
+-- | Round-trip a Ping through the session. Because recvLoop dispatches
+-- frames serially, receiving the echo proves every frame injected
+-- before the Ping has been fully processed.
+pingFence :: HostilePeer -> Word32 -> Expectation
+pingFence hp opaque = do
+  injectFrame hp (pingHdr synF opaque) BS.empty
+  (hdr, _) <- expectFrame hp
+  yhType hdr `shouldBe` FramePing
+  yhLength hdr `shouldBe` opaque
+
+-- | Open an inbound stream on a server-role session via a Data SYN and
+-- accept it, consuming the WindowUpdate ACK the session emits.
+openAccepted :: HostilePeer -> IO YamuxStream
+openAccepted hp = do
+  injectFrame hp (dataHdr synF 1 0) BS.empty
+  stream <- acceptWithin hp
+  (ackHdr, _) <- expectFrame hp
+  yhType ackHdr `shouldBe` FrameWindowUpdate
+  flagACK (yhFlags ackHdr) `shouldBe` True
+  pure stream
+
+spec :: Spec
+spec = do
+  describe "SYNSent state (outbound stream, before ACK)" $ do
+    it "establishes when ACK arrives on a Data frame" $
+      withHostilePeer RoleClient $ \hp -> do
+        Right stream <- openStream (hpSession hp)
+        (synOut, _) <- expectFrame hp
+        flagSYN (yhFlags synOut) `shouldBe` True
+        injectFrame hp (dataHdr ackF 1 0) BS.empty
+        awaitState stream StreamEstablished
+
+    it "half-closes when FIN arrives on a Data frame" $
+      withHostilePeer RoleClient $ \hp -> do
+        Right stream <- openStream (hpSession hp)
+        _ <- expectFrame hp -- Data SYN
+        injectFrame hp (dataHdr finF 1 0) BS.empty
+        awaitState stream StreamRemoteClose
+
+    it "resets when RST arrives on a Data frame" $
+      withHostilePeer RoleClient $ \hp -> do
+        Right stream <- openStream (hpSession hp)
+        _ <- expectFrame hp -- Data SYN
+        injectFrame hp (dataHdr rstF 1 0) BS.empty
+        awaitState stream StreamReset
+        result <- streamWrite stream "data"
+        result `shouldBe` Left YamuxStreamReset
+
+    it "resets when RST arrives on a WindowUpdate frame" $
+      withHostilePeer RoleClient $ \hp -> do
+        Right stream <- openStream (hpSession hp)
+        _ <- expectFrame hp -- Data SYN
+        injectFrame hp (wuHdr rstF 1 0) BS.empty
+        awaitState stream StreamReset
+
+  describe "WindowUpdate SYN (go-libp2p stream open pattern)" $ do
+    it "creates an inbound stream and applies the window delta from the SYN" $
+      withHostilePeer RoleServer $ \hp -> do
+        -- WindowUpdate+SYN with a delta announces a larger initial
+        -- window as part of stream open (spec.md, Flow Control)
+        injectFrame hp (wuHdr synF 1 initialWindowSize) BS.empty
+        stream <- acceptWithin hp
+        (ackHdr, _) <- expectFrame hp
+        yhType ackHdr `shouldBe` FrameWindowUpdate
+        flagACK (yhFlags ackHdr) `shouldBe` True
+        yhStreamId ackHdr `shouldBe` 1
+        result <- timeout 1000000 $ atomically $ do
+          w <- readTVar (ysSendWindow stream)
+          check (w == 2 * initialWindowSize)
+        result `shouldBe` Just ()
+
+    it "rejects a duplicate stream ID on a WindowUpdate SYN with GoAway(0x01) on the wire" $
+      withHostilePeer RoleServer $ \hp -> do
+        injectFrame hp (wuHdr synF 1 0) BS.empty
+        _ <- acceptWithin hp
+        _ <- expectFrame hp -- WindowUpdate ACK
+        injectFrame hp (wuHdr synF 1 0) BS.empty
+        (goAway, _) <- expectFrame hp
+        yhType goAway `shouldBe` FrameGoAway
+        yhStreamId goAway `shouldBe` 0
+        yhLength goAway `shouldBe` 0x01 -- protocol error code
+        awaitTrue (ysessShutdown (hpSession hp))
+
+  describe "Established state, flags on WindowUpdate frames" $ do
+    it "half-closes when FIN arrives on a WindowUpdate frame" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        injectFrame hp (wuHdr finF 1 0) BS.empty
+        awaitState stream StreamRemoteClose
+        eof <- streamRead stream
+        eof `shouldBe` Left YamuxStreamClosed
+
+    it "resets when RST arrives on a WindowUpdate frame" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        injectFrame hp (wuHdr rstF 1 0) BS.empty
+        awaitState stream StreamReset
+        result <- streamRead stream
+        result `shouldBe` Left YamuxStreamReset
+
+  describe "Half-closed and terminal states" $ do
+    it "ignores a duplicate FIN in RemoteClose" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        injectFrame hp (dataHdr finF 1 0) BS.empty
+        awaitState stream StreamRemoteClose
+        injectFrame hp (dataHdr finF 1 0) BS.empty
+        pingFence hp 7 -- guarantees the second FIN was dispatched
+        st <- readTVarIO (ysState stream)
+        st `shouldBe` StreamRemoteClose
+
+    it "does not resurrect a Closed stream on a later FIN" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        Right () <- streamClose stream -- Established -> LocalClose
+        (finOut, _) <- expectFrame hp
+        flagFIN (yhFlags finOut) `shouldBe` True
+        injectFrame hp (dataHdr finF 1 0) BS.empty -- LocalClose -> Closed
+        awaitState stream StreamClosed
+        injectFrame hp (dataHdr finF 1 0) BS.empty
+        pingFence hp 8
+        st <- readTVarIO (ysState stream)
+        st `shouldBe` StreamClosed
+
+  describe "Frames for unknown stream IDs" $ do
+    it "keeps the session alive when RST arrives for an unknown stream" $
+      withHostilePeer RoleServer $ \hp -> do
+        injectFrame hp (dataHdr rstF 5 0) BS.empty
+        pingFence hp 9
+        shut <- readTVarIO (ysessShutdown (hpSession hp))
+        shut `shouldBe` False
+
+    it "discards a WindowUpdate for an unknown stream without terminating" $
+      withHostilePeer RoleServer $ \hp -> do
+        injectFrame hp (wuHdr noF 7 4096) BS.empty
+        pingFence hp 10
+        shut <- readTVarIO (ysessShutdown (hpSession hp))
+        shut `shouldBe` False
+
+  describe "Session termination on malformed input" $ do
+    it "sends GoAway(0x01) before terminating on an unknown frame type" $
+      withHostilePeer RoleServer $ \hp -> do
+        hpInject hp (BS.pack [0x00, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        (goAway, _) <- expectFrame hp
+        yhType goAway `shouldBe` FrameGoAway
+        yhLength goAway `shouldBe` 0x01
+        awaitTrue (ysessShutdown (hpSession hp))
+
+    it "sends GoAway(0x01) before terminating on a non-zero version" $
+      withHostilePeer RoleServer $ \hp -> do
+        injectFrame hp (YamuxHeader 1 FrameData noF 1 0) BS.empty
+        (goAway, _) <- expectFrame hp
+        yhType goAway `shouldBe` FrameGoAway
+        yhLength goAway `shouldBe` 0x01
+        awaitTrue (ysessShutdown (hpSession hp))
+
+  describe "GoAway from the peer" $ do
+    it "raw GoAway(0x01) prevents new outbound streams" $
+      withHostilePeer RoleClient $ \hp -> do
+        injectFrame hp (YamuxHeader 0 FrameGoAway noF 0 0x01) BS.empty
+        awaitTrue (ysessRemoteGoAway (hpSession hp))
+        result <- openStream (hpSession hp)
+        case result of
+          Left err -> err `shouldBe` YamuxSessionShutdown
+          Right _ -> expectationFailure "openStream succeeded after remote GoAway"
+
+  describe "Window accounting" $ do
+    it "replenishes exactly the consumed bytes after a partial read" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        injectFrame hp (dataHdr noF 1 60) (BS.replicate 60 0xAA)
+        injectFrame hp (dataHdr noF 1 40) (BS.replicate 40 0xBB)
+        -- Receive window shrinks by the declared lengths on arrival
+        debit <- timeout 1000000 $ atomically $ do
+          w <- readTVar (ysRecvWindow stream)
+          check (w == initialWindowSize - 100)
+        debit `shouldBe` Just ()
+        -- Reading one chunk must credit back exactly those 60 bytes
+        Right chunk <- streamRead stream
+        chunk `shouldBe` BS.replicate 60 0xAA
+        (wu, _) <- expectFrame hp
+        yhType wu `shouldBe` FrameWindowUpdate
+        yhStreamId wu `shouldBe` 1
+        yhLength wu `shouldBe` 60
+        credit <- timeout 1000000 $ atomically $ do
+          w <- readTVar (ysRecvWindow stream)
+          check (w == initialWindowSize - 40)
+        credit `shouldBe` Just ()


### PR DESCRIPTION
## Summary

Addresses the core of #171: adds a hostile-peer harness (`test/LibP2P/Yamux/HostilePeer.hs`) with raw frame injection and an outbound frame recorder, plus `StateMachineSpec.hs` covering the (state x flag x frame-type) cells our own sender never produces. Verified against current main first: PR #185 had already covered the SYNReceived FIN row (D and W), WindowUpdate-SYN injection, and the pre-read length checks; this PR covers what remained.

## State-machine coverage (D = flag on Data frame, W = on WindowUpdate)

| state | SYN | ACK | FIN | RST |
|---|---|---|---|---|
| no stream | D ✅ / W ✅ | — | — | D **✅** / W — |
| SYNSent | — | D **✅** / W ✅ | D **✅** / W ✅ | D **✅** / W **✅** |
| SYNReceived | — | — | D ✅ / W ✅ (#185) | — |
| Established | D ✅ / W **✅** (dup → GoAway 0x01 on the wire) | — | D ✅ / W **✅** | D ✅ / W **✅** |
| LocalClose | — | — | D ✅ / W — | — |
| RemoteClose | — | — | D **✅** (dup FIN ignored) | — |
| Closed | — | — | D **✅** (stays terminal) | — |

**Bold** = new in this PR (10 before → 19 matrix marks). Also new outside the matrix:

- WindowUpdate+SYN open applies the announced window delta (go-libp2p pattern)
- RST / WindowUpdate for unknown stream IDs do not kill the session
- raw GoAway from the peer blocks new outbound streams
- window accounting: after a partial read, exactly the consumed bytes are credited back and a matching WindowUpdate appears on the wire
- half-close: local FIN kills the write side only; remote-to-local data still flows until the second FIN
- malformed frame type / non-zero version: GoAway(0x01) observed on the wire before termination

## Small spec-required fix included

`recvLoop` previously exited **silently** on a malformed frame type or non-zero version. Per spec.md (GoAway) and matching go-yamux, it now sends GoAway(protocol error) before terminating. TDD verified: both new termination tests failed against the old behaviour ("expected an outbound frame within 1s, got none") and pass after the 4-line fix.

## The five assert-nothing tests

| Test | Disposition |
|---|---|
| `FrameSpec` "client uses odd IDs" | deleted — tautology over a literal list; real behaviour covered by `SessionSpec` "client session allocates odd IDs: 1, 3, 5" |
| `FrameSpec` "server uses even IDs" | deleted — same, covered by the even-ID allocation test |
| `SessionSpec` "Ping echoes exact opaque value" | rewritten — injects opaque `0xDEADBEEF`, decodes the recorded ACK and asserts the echoed value, ACK flag and StreamID 0 |
| `SessionSpec` "Ping uses StreamID 0" | rewritten — decodes the recorded Ping SYN, asserts StreamID 0, and resolves the ping only via the matching ACK |
| `SessionSpec` "Ping SYN -> ACK response received" | kept as the one real end-to-end ping case |

Also strengthened `FrameSpec` "encodes GoAway normal" (flagged in the issue): it asserted byte 8, which is 0x00 for all three codes; it now round-trips codes 0x00/0x01/0x02 through byte 11.

Two adversarial ping tests added: mismatched opaque does not resolve a pending ping; an unsolicited ACK is ignored without killing the session.

## Deliberately not covered here

- #164 cells (accept-backlog bound, send-window saturation on huge delta, stream-map growth, GoAway code surfacing, terminal-state overwrite by RST/accept) — separate open issue; no test asserts that behaviour as correct.
- Reference-model property test over random legal frame sequences and go-libp2p trace replays — substantial follow-up work listed in #171.
- EOF-mid-frame — not expressible with the byte-queue harness (reads block instead of failing); needs a read function that can signal EOF, as the issue notes.

Test suite: 733 examples, 0 failures (was 716) with GHC 9.10.x.

Refs #171
