### PR TITLE
test: replace assert-nothing NAT tests with behavioural assertions

### DIFF
--- a/test/LibP2P/NAT/AutoNAT/AutoNATSpec.hs
+++ b/test/LibP2P/NAT/AutoNAT/AutoNATSpec.hs
@@ -327,6 +327,72 @@ spec = do
       dialed <- readIORef dialedRef
       dialed `shouldBe` []
 
+    it "passes the authenticated peer id to the dial-back, not a value from the message body" $ do
+      dialedPidsRef <- newIORef ([] :: [PeerId])
+      (clientStream, serverStream) <- mkStreamPair
+      let config = AutoNATConfig
+            { natThreshold = 3
+            , natDialBack = \pid _addrs -> do
+                modifyIORef' dialedPidsRef (pid :)
+                pure (Right ())
+            }
+          dialMsg = mkDialMsg remotePeerId [publicAddr]
+      writeAutoNATMessage clientStream dialMsg
+      handleAutoNAT config serverStream remotePeerId remoteObservedAddr
+      _ <- readAutoNATMessage clientStream maxAutoNATMessageSize
+      dialedPids <- readIORef dialedPidsRef
+      -- The dial-back target identity must be the peer authenticated on the
+      -- connection (which, after the mismatch check, is the only value that
+      -- can reach this point).
+      dialedPids `shouldBe` [remotePeerId]
+
+    it "includes the successfully dialled address in the OK response" $ do
+      (clientStream, serverStream) <- mkStreamPair
+      let config = AutoNATConfig
+            { natThreshold = 3
+            , natDialBack = \_pid _addrs -> pure (Right ())
+            }
+          -- privateAddr fails the observed-IP filter; publicAddr passes
+          dialMsg = mkDialMsg remotePeerId [privateAddr, publicAddr]
+      writeAutoNATMessage clientStream dialMsg
+      handleAutoNAT config serverStream remotePeerId remoteObservedAddr
+      result <- readAutoNATMessage clientStream maxAutoNATMessageSize
+      case result of
+        Right resp ->
+          case anMsgDialResponse resp of
+            Just dr -> do
+              anRespStatus dr `shouldBe` Just StatusOK
+              -- Spec (autonat): on success the response SHOULD carry the
+              -- address that was successfully dialled.
+              anRespAddr dr `shouldBe` Just (toBytes publicAddr)
+            Nothing -> expectationFailure "Expected DialResponse"
+        Left err -> expectationFailure $ "Read failed: " ++ err
+
+    it "rejects a relayed observed address with a trailing p2p-circuit component" $ do
+      dialedRef <- newIORef ([] :: [[Multiaddr]])
+      (clientStream, serverStream) <- mkStreamPair
+      let config = AutoNATConfig
+            { natThreshold = 3
+            , natDialBack = \_pid addrs -> do
+                modifyIORef' dialedRef (addrs :)
+                pure (Right ())
+            }
+          -- P2PCircuit in the last position (the existing relayed-address
+          -- test places it mid-list)
+          trailingRelayed = Multiaddr [IP4 0xCB007101, TCP 4001, P2P (BS.pack [1,2,3]), P2PCircuit]
+          dialMsg = mkDialMsg remotePeerId [publicAddr]
+      writeAutoNATMessage clientStream dialMsg
+      handleAutoNAT config serverStream remotePeerId trailingRelayed
+      result <- readAutoNATMessage clientStream maxAutoNATMessageSize
+      case result of
+        Right resp ->
+          case anMsgDialResponse resp of
+            Just dr -> anRespStatus dr `shouldBe` Just EDialRefused
+            Nothing -> expectationFailure "Expected DialResponse"
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      dialed <- readIORef dialedRef
+      dialed `shouldBe` []
+
     it "caps the number of dial-back addresses per request" $ do
       dialedRef <- newIORef ([] :: [[Multiaddr]])
       (clientStream, serverStream) <- mkStreamPair

--- a/test/LibP2P/NAT/AutoNAT/MessageSpec.hs
+++ b/test/LibP2P/NAT/AutoNAT/MessageSpec.hs
@@ -4,6 +4,7 @@ import Test.Hspec
 
 import qualified Data.ByteString as BS
 import Control.Concurrent.STM (newTQueueIO, atomically, writeTQueue, readTQueue, TQueue)
+import Data.List (isInfixOf)
 import Data.Word (Word8)
 import LibP2P.NAT.AutoNAT.Message
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
@@ -193,7 +194,7 @@ spec = do
           fakePayload = BS.replicate 10 0x00
           oversized = fakeLen <> fakePayload
       case decodeAutoNATFramed 1000 oversized of
-        Left err -> err `shouldSatisfy` \e -> "too large" `elem` words e || True
+        Left err -> err `shouldSatisfy` ("too large" `isInfixOf`)
         Right _ -> expectationFailure "Should have rejected oversized message"
 
     it "writeAutoNATMessage + readAutoNATMessage over StreamIO pair" $ do

--- a/test/LibP2P/NAT/DCUtR/DCUtRSpec.hs
+++ b/test/LibP2P/NAT/DCUtR/DCUtRSpec.hs
@@ -10,9 +10,10 @@ import Control.Concurrent.STM
   , newTVarIO, readTVarIO, readTVar, writeTVar, modifyTVar', registerDelay, retry
   )
 import Control.Monad (when)
-import Data.IORef (newIORef, readIORef, modifyIORef', atomicModifyIORef')
+import Data.IORef (newIORef, readIORef, writeIORef, modifyIORef', atomicModifyIORef')
 import Data.Time.Clock (getCurrentTime, diffUTCTime)
 import Data.Word (Word8)
+import LibP2P.Core.Varint (encodeUvarint)
 import LibP2P.NAT.DCUtR.Message
 import LibP2P.NAT.DCUtR
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
@@ -42,6 +43,11 @@ addrA = Multiaddr [IP4 0xCB007105, TCP 4001]  -- /ip4/203.0.113.5/tcp/4001
 
 addrB :: Multiaddr
 addrB = Multiaddr [IP4 0xCB007106, TCP 4002]  -- /ip4/203.0.113.6/tcp/4002
+
+-- | True for DCUtRFailed results.
+isFailed :: DCUtRResult -> Bool
+isFailed (DCUtRFailed _) = True
+isFailed DCUtRSuccess    = False
 
 spec :: Spec
 spec = do
@@ -95,15 +101,17 @@ spec = do
             DCUtRSuccess -> pure ()
             DCUtRFailed err -> expectationFailure $ "Handler failed: " ++ err
 
-    it "handles dial failure gracefully" $ do
+    it "returns DCUtRFailed on both sides when every dial fails" $ do
       (streamA, streamB) <- mkStreamPair
+      aDials <- newIORef (0 :: Int)
+      bDials <- newIORef (0 :: Int)
       let configA = DCUtRConfig
             { dcMaxAttempts = 1
-            , dcDialer = \_ -> pure (Left "dial failed")
+            , dcDialer = \_ -> modifyIORef' aDials (+ 1) >> pure (Left "dial failed")
             }
           configB = DCUtRConfig
             { dcMaxAttempts = 1
-            , dcDialer = \_ -> pure (Left "dial failed")
+            , dcDialer = \_ -> modifyIORef' bDials (+ 1) >> pure (Left "dial failed")
             }
           addrsA = [addrA]
           addrsB = [addrB]
@@ -111,13 +119,57 @@ spec = do
         withAsync (handleDCUtR configA streamA addrsA) $ \handlerAsync -> do
           resultB <- wait initiatorAsync
           resultA <- wait handlerAsync
-          -- Should report failure when dial fails
-          case resultB of
-            DCUtRFailed _ -> pure ()
-            DCUtRSuccess -> pure ()  -- may still report success from message exchange
-          case resultA of
-            DCUtRFailed _ -> pure ()
-            DCUtRSuccess -> pure ()
+          -- The message exchange succeeding must NOT be reported as a
+          -- successful hole punch: both sides dialled and both dials failed.
+          resultB `shouldSatisfy` isFailed
+          resultA `shouldSatisfy` isFailed
+          readIORef aDials >>= (`shouldBe` 1)
+          readIORef bDials >>= (`shouldBe` 1)
+
+    it "handler fails when SYNC arrives in place of the initial CONNECT" $ do
+      (peerStream, handlerStream) <- mkStreamPair
+      dials <- newIORef (0 :: Int)
+      let config = DCUtRConfig
+            { dcMaxAttempts = 3
+            , dcDialer = \_ -> modifyIORef' dials (+ 1) >> pure (Right ())
+            }
+      -- Spec: the exchange must begin with CONNECT
+      writeHolePunchMessage peerStream (HolePunchMessage { hpType = HPSync, hpObsAddrs = [] })
+      result <- handleDCUtR config handlerStream [addrA]
+      result `shouldSatisfy` isFailed
+      -- A protocol violation must abort without any hole punch attempt
+      readIORef dials >>= (`shouldBe` 0)
+
+    it "handler fails when a second CONNECT arrives in place of SYNC" $ do
+      (peerStream, handlerStream) <- mkStreamPair
+      dials <- newIORef (0 :: Int)
+      let config = DCUtRConfig
+            { dcMaxAttempts = 3
+            , dcDialer = \_ -> modifyIORef' dials (+ 1) >> pure (Right ())
+            }
+          badPeer = do
+            writeHolePunchMessage peerStream
+              (HolePunchMessage { hpType = HPConnect, hpObsAddrs = [toBytes addrB] })
+            _ <- readHolePunchMessage peerStream maxDCUtRMessageSize
+            writeHolePunchMessage peerStream
+              (HolePunchMessage { hpType = HPConnect, hpObsAddrs = [toBytes addrB] })
+      withAsync badPeer $ \_ -> do
+        result <- handleDCUtR config handlerStream [addrA]
+        result `shouldSatisfy` isFailed
+        readIORef dials >>= (`shouldBe` 0)
+
+    it "handler refuses a framed message larger than 4 KiB read from the stream" $ do
+      (peerStream, handlerStream) <- mkStreamPair
+      dials <- newIORef (0 :: Int)
+      let config = DCUtRConfig
+            { dcMaxAttempts = 3
+            , dcDialer = \_ -> modifyIORef' dials (+ 1) >> pure (Right ())
+            }
+      -- Length prefix claiming a 5000-byte message: past the 4 KiB cap
+      streamWrite peerStream (encodeUvarint 5000)
+      result <- handleDCUtR config handlerStream [addrA]
+      result `shouldSatisfy` isFailed
+      readIORef dials >>= (`shouldBe` 0)
 
   describe "DCUtR RTT measurement" $ do
     it "measures non-negative RTT" $ do
@@ -295,6 +347,48 @@ spec = do
           case mRTT of
             Just rtt -> rtt `shouldSatisfy` (>= 0.1)
             Nothing -> expectationFailure "RTT not measured"
+
+  describe "DCUtR hole punch timing" $ do
+    it "initiator waits approximately RTT/2 after SYNC before dialling" $ do
+      (peerStream, initiatorStream) <- mkStreamPair
+      syncSentAt <- newIORef Nothing
+      dialledAt <- newIORef Nothing
+      writeCount <- newIORef (0 :: Int)
+      -- Record when the initiator's second write (the SYNC) happens
+      let timedStream = initiatorStream
+            { streamWrite = \bs -> do
+                n <- atomicModifyIORef' writeCount (\c -> (c + 1, c + 1))
+                when (n == 2) (getCurrentTime >>= writeIORef syncSentAt . Just)
+                streamWrite initiatorStream bs
+            }
+          config = DCUtRConfig
+            { dcMaxAttempts = 1
+            , dcDialer = \_ -> do
+                getCurrentTime >>= writeIORef dialledAt . Just
+                pure (Right ())
+            }
+          -- Manual peer: delay the CONNECT answer by 200 ms so the measured
+          -- RTT is approximately 200 ms
+          slowPeer = do
+            _ <- readHolePunchMessage peerStream maxDCUtRMessageSize
+            threadDelay 200000
+            writeHolePunchMessage peerStream
+              (HolePunchMessage { hpType = HPConnect, hpObsAddrs = [toBytes addrA] })
+            _ <- readHolePunchMessage peerStream maxDCUtRMessageSize  -- SYNC
+            pure ()
+      withAsync slowPeer $ \_ -> do
+        result <- initiateDCUtR config timedStream [addrB]
+        result `shouldBe` DCUtRSuccess
+        mSync <- readIORef syncSentAt
+        mDial <- readIORef dialledAt
+        case (,) <$> mSync <*> mDial of
+          Just (tSync, tDial) -> do
+            -- Spec: the initiator waits RTT/2 (≈ 100 ms here) between SYNC
+            -- and dialling. Allow generous scheduler slack in both
+            -- directions, but a missing wait (≈ 0 ms) must fail.
+            diffUTCTime tDial tSync `shouldSatisfy` (>= 0.06)
+            diffUTCTime tDial tSync `shouldSatisfy` (<= 1)
+          Nothing -> expectationFailure "SYNC or dial time not recorded"
 
   describe "DCUtR constants" $ do
     it "max message size is 4096 bytes" $ do

--- a/test/LibP2P/NAT/Relay/ClientSpec.hs
+++ b/test/LibP2P/NAT/Relay/ClientSpec.hs
@@ -3,11 +3,12 @@ module LibP2P.NAT.Relay.ClientSpec (spec) where
 import Test.Hspec
 
 import qualified Data.ByteString as BS
-import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.Async (withAsync, wait)
 import Control.Concurrent.STM (newTQueueIO, atomically, writeTQueue, readTQueue, TQueue)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Word (Word8, Word64)
 import LibP2P.NAT.Relay.Message
+import LibP2P.NAT.Relay
 import LibP2P.NAT.Relay.Client
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
 import LibP2P.Crypto.PeerId (PeerId (..))
@@ -181,37 +182,59 @@ spec = do
         Right msg -> stopStatus msg `shouldBe` Just RelayOK
         Left err -> expectationFailure $ "readStopMessage failed: " ++ err
 
-  describe "Relay client end-to-end mock flow" $ do
-    it "reserve → connect → stop → bridge" $ do
-      -- This test simulates the complete relay flow with mock streams
-      -- 1. Client reserves on relay
-      -- 2. Another peer connects through relay
-      -- 3. Target handles stop
-      -- We just verify the message exchange works end-to-end
-      (clientToRelay, relayFromClient) <- mkStreamPair
-      -- Step 1: Client sends RESERVE
-      writeHopMessage clientToRelay HopMessage
-        { hopType = Just HopReserve
-        , hopPeer = Nothing, hopReservation = Nothing
-        , hopLimit = Nothing, hopStatus = Nothing
-        }
-      req <- readHopMessage relayFromClient maxRelayMessageSize
-      case req of
-        Right msg -> hopType msg `shouldBe` Just HopReserve
-        Left err -> expectationFailure $ "Failed to read RESERVE: " ++ err
-      -- Relay responds OK
-      writeHopMessage relayFromClient HopMessage
-        { hopType = Just HopStatus
-        , hopPeer = Nothing
-        , hopReservation = Just Reservation
-            { rsvExpire = Just 1700000000
-            , rsvAddrs = [BS.pack [4, 127, 0, 0, 1, 6, 0x10, 0x01]]
-            , rsvVoucher = Nothing
-            }
-        , hopLimit = Nothing
-        , hopStatus = Just RelayOK
-        }
-      resp <- readHopMessage clientToRelay maxRelayMessageSize
-      case resp of
-        Right msg -> hopStatus msg `shouldBe` Just RelayOK
-        Left err -> expectationFailure $ "Failed to read RESERVE response: " ++ err
+  describe "Relay client end-to-end flow against the relay server" $ do
+    it "reserve → connect → stop → bridge using the real server and client code" $ do
+      -- Full single-process circuit:
+      --   A (reserver) reserves on the relay via makeReservation/handleReserve
+      --   B (source) connects to A via connectViaRelay/handleConnect
+      --   A accepts the stop CONNECT via handleStop
+      --   Application data flows both ways through the bridged circuit
+      relayState <- newRelayState defaultRelayConfig
+      let reserver = testPeerId    -- A: the peer holding the reservation
+          source = targetPeerId    -- B: the peer connecting through the relay
+      -- Step 1: A reserves on the relay
+      (aHop, relayAHop) <- mkStreamPair
+      let relayReserveSide = do
+            req <- readHopMessage relayAHop maxRelayMessageSize
+            case req of
+              Right msg | hopType msg == Just HopReserve ->
+                handleReserve relayState relayAHop reserver
+              _ -> expectationFailure "relay expected a RESERVE request"
+      withAsync relayReserveSide $ \reserveAsync -> do
+        rsvResult <- makeReservation aHop
+        wait reserveAsync
+        case rsvResult of
+          Right resp -> do
+            hopStatus resp `shouldBe` Just RelayOK
+            (hopReservation resp >>= rsvExpire) `shouldSatisfy` (/= Nothing)
+          Left err -> expectationFailure $ "makeReservation failed: " ++ err
+      -- Step 2: B connects to A through the relay; A accepts via handleStop
+      (bHop, relayBHop) <- mkStreamPair
+      (relayStop, targetStop) <- mkStreamPair
+      let relayConnectSide = do
+            req <- readHopMessage relayBHop maxRelayMessageSize
+            case req of
+              Right msg | hopType msg == Just HopConnect ->
+                handleConnect relayState relayBHop source msg
+                  (\pid -> pure (if pid == reserver then Just relayStop else Nothing))
+              _ -> expectationFailure "relay expected a CONNECT request"
+      withAsync relayConnectSide $ \_connectAsync ->
+        withAsync (handleStop targetStop) $ \stopAsync -> do
+          connResult <- connectViaRelay bHop reserver
+          case connResult of
+            Right resp -> hopStatus resp `shouldBe` Just RelayOK
+            Left err -> expectationFailure $ "connectViaRelay failed: " ++ err
+          stopResult <- wait stopAsync
+          case stopResult of
+            Right (srcPid, mLimit) -> do
+              -- The stop CONNECT must identify the connecting peer
+              srcPid `shouldBe` source
+              mLimit `shouldSatisfy` (/= Nothing)
+            Left err -> expectationFailure $ "handleStop failed: " ++ err
+          -- Step 3: application data flows through the bridged circuit
+          streamWrite bHop (BS.pack [1, 2, 3])
+          fwd <- mapM (\_ -> streamReadByte targetStop) [1..3 :: Int]
+          fwd `shouldBe` [1, 2, 3]
+          streamWrite targetStop (BS.pack [9, 8])
+          back <- mapM (\_ -> streamReadByte bHop) [1..2 :: Int]
+          back `shouldBe` [9, 8]

--- a/test/LibP2P/NAT/Relay/RelaySpec.hs
+++ b/test/LibP2P/NAT/Relay/RelaySpec.hs
@@ -13,6 +13,8 @@ import Data.IORef (newIORef, readIORef, modifyIORef')
 import LibP2P.NAT.Relay.Message
 import LibP2P.NAT.Relay
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.Multiaddr (Multiaddr (..), toBytes, fromBytes)
+import LibP2P.Multiaddr.Protocol (Protocol (..))
 import LibP2P.Crypto.PeerId (PeerId (..))
 
 -- | Create an in-memory stream pair for testing.
@@ -111,8 +113,19 @@ spec = do
       handleReserve relayState serverStream testPeerId
       result <- readHopMessage clientStream maxRelayMessageSize
       case result of
-        Right resp -> hopStatus resp `shouldBe` Just ResourceLimitExceeded
+        Right resp -> do
+          -- The request must be refused: not OK and no reservation granted.
+          -- NOTE: circuit-v2.md assigns RESERVATION_REFUSED (200) to a
+          -- reservation rejected for capacity; the current implementation
+          -- returns RESOURCE_LIMIT_EXCEEDED (201). The exact status code is
+          -- tracked in #180, so this test only asserts refusal.
+          hopStatus resp `shouldNotBe` Just RelayOK
+          hopStatus resp `shouldNotBe` Nothing
+          hopReservation resp `shouldBe` Nothing
         Left err -> expectationFailure $ "Read failed: " ++ err
+      -- No reservation may be stored for the refused peer
+      reservations <- readTVarIO (rsReservations relayState)
+      Map.member testPeerId reservations `shouldBe` False
 
   describe "Relay server handleConnect" $ do
     it "should reject CONNECT with NO_RESERVATION when the target reservation has expired" $ do
@@ -244,6 +257,96 @@ spec = do
         Right resp -> hopStatus resp `shouldBe` Just NoReservation
         Left err -> expectationFailure $ "Read failed: " ++ err
 
+    it "should reject a CONNECT without a peer field with MALFORMED_MESSAGE" $ do
+      relayState <- newRelayState defaultRelayConfig
+      (clientStream, serverStream) <- mkStreamPair
+      let connectReq = HopMessage
+            { hopType = Just HopConnect
+            , hopPeer = Nothing
+            , hopReservation = Nothing
+            , hopLimit = Nothing
+            , hopStatus = Nothing
+            }
+      writeHopMessage clientStream connectReq
+      handleConnect relayState serverStream testPeerId connectReq (\_pid -> pure Nothing)
+      result <- readHopMessage clientStream maxRelayMessageSize
+      case result of
+        Right resp -> hopStatus resp `shouldBe` Just MalformedMessage
+        Left err -> expectationFailure $ "Read failed: " ++ err
+
+    it "should respond CONNECTION_FAILED when the stop stream to the target cannot be opened" $ do
+      relayState <- newRelayState defaultRelayConfig
+      now <- getPOSIXTime
+      let valid = ActiveReservation
+            { arPeerId = targetPeerId
+            , arExpiration = floor now + 3600
+            }
+      atomically $ modifyTVar' (rsReservations relayState) (Map.insert targetPeerId valid)
+      (clientStream, serverStream) <- mkStreamPair
+      let connectReq = HopMessage
+            { hopType = Just HopConnect
+            , hopPeer = Just RelayPeer
+                { rpId = let PeerId bs = targetPeerId in bs
+                , rpAddrs = []
+                }
+            , hopReservation = Nothing
+            , hopLimit = Nothing
+            , hopStatus = Nothing
+            }
+      writeHopMessage clientStream connectReq
+      -- Target has a valid reservation, but the relay cannot reach it
+      handleConnect relayState serverStream testPeerId connectReq (\_pid -> pure Nothing)
+      result <- readHopMessage clientStream maxRelayMessageSize
+      case result of
+        Right resp -> hopStatus resp `shouldBe` Just ConnectionFailed
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      -- The failed circuit must not leak circuit slots
+      counts <- readTVarIO (rsCircuitCounts relayState)
+      counts `shouldBe` Map.empty
+
+    it "should respond CONNECTION_FAILED when the target answers the stop CONNECT with a non-OK status" $ do
+      relayState <- newRelayState defaultRelayConfig
+      now <- getPOSIXTime
+      let valid = ActiveReservation
+            { arPeerId = targetPeerId
+            , arExpiration = floor now + 3600
+            }
+      atomically $ modifyTVar' (rsReservations relayState) (Map.insert targetPeerId valid)
+      (clientStream, serverStream) <- mkStreamPair
+      (relayStopStream, targetStream) <- mkStreamPair
+      let connectReq = HopMessage
+            { hopType = Just HopConnect
+            , hopPeer = Just RelayPeer
+                { rpId = let PeerId bs = targetPeerId in bs
+                , rpAddrs = []
+                }
+            , hopReservation = Nothing
+            , hopLimit = Nothing
+            , hopStatus = Nothing
+            }
+      writeHopMessage clientStream connectReq
+      let runConnect = handleConnect relayState serverStream testPeerId connectReq
+                         (\_pid -> pure (Just relayStopStream))
+      withAsync runConnect $ \connectAsync -> do
+        -- Fake target refuses the incoming circuit
+        stopReq <- readStopMessage targetStream maxRelayMessageSize
+        case stopReq of
+          Right m -> stopType m `shouldBe` Just StopConnect
+          Left err -> expectationFailure $ "Stop read failed: " ++ err
+        writeStopMessage targetStream StopMessage
+          { stopType = Just StopStatus
+          , stopPeer = Nothing
+          , stopLimit = Nothing
+          , stopStatus = Just ConnectionFailed
+          }
+        result <- readHopMessage clientStream maxRelayMessageSize
+        case result of
+          Right resp -> hopStatus resp `shouldBe` Just ConnectionFailed
+          Left err -> expectationFailure $ "Read failed: " ++ err
+        wait connectAsync
+        counts <- readTVarIO (rsCircuitCounts relayState)
+        counts `shouldBe` Map.empty
+
   describe "bridgeStreams" $ do
     it "forwards data bidirectionally" $ do
       (streamA1, streamA2) <- mkStreamPair
@@ -264,26 +367,54 @@ spec = do
         c3 <- streamReadByte streamA1
         [c1, c2, c3] `shouldBe` [4, 5, 6]
 
-    it "enforces data limit" $ do
+    it "should stop forwarding and close both streams when the data limit is exceeded" $ do
       (streamA1, streamA2) <- mkStreamPair
       (streamB1, streamB2) <- mkStreamPair
-      -- Limit to 5 bytes of data per direction
-      let limitCfg = Just RelayLimit { rlDuration = Nothing, rlData = Just 5 }
-      -- Bridge in background; should terminate after limit exceeded
+      closedA <- newIORef False
+      closedB <- newIORef False
+      forwardedToB <- newIORef (0 :: Int)
+      let trackClose ref s = s { streamClose = modifyIORef' ref (const True) }
+          countWrites s = s
+            { streamWrite = \bs -> do
+                modifyIORef' forwardedToB (+ BS.length bs)
+                streamWrite s bs
+            }
+          -- Limit of 5 bytes per direction
+          limitCfg = Just RelayLimit { rlDuration = Nothing, rlData = Just 5 }
+      -- Queue 6 bytes (one past the limit) before starting the bridge.
+      -- NOTE (#177): the bridge currently only detects the limit after
+      -- reading byte limit+1 from the source; sending exactly `limit` bytes
+      -- does not terminate the circuit. This test therefore sends limit+1
+      -- bytes and asserts termination, forwarding cut-off, and stream close.
+      streamWrite streamA1 (BS.pack [1, 2, 3, 4, 5, 6])
       result <- race
-        (bridgeStreams limitCfg streamA2 streamB1)
-        (do
-          -- Send 5 bytes (at limit)
-          streamWrite streamA1 (BS.pack [1, 2, 3, 4, 5])
-          -- Read them on the other side
-          bs <- mapM (\_ -> streamReadByte streamB2) [1..5 :: Int]
-          -- Small delay to let bridge detect limit
-          threadDelay 50000
-          pure bs
-        )
-      case result of
-        Left () -> pure ()  -- bridge terminated first (expected after limit)
-        Right bs -> bs `shouldBe` [1, 2, 3, 4, 5]
+        (bridgeStreams limitCfg
+           (trackClose closedA streamA2)
+           (countWrites (trackClose closedB streamB1)))
+        (threadDelay 2000000)
+      -- The bridge must terminate on its own, not via the timeout
+      result `shouldBe` Left ()
+      -- Exactly the limit's worth of bytes was forwarded, and no more
+      readIORef forwardedToB `shouldReturn` 5
+      bs <- mapM (\_ -> streamReadByte streamB2) [1..5 :: Int]
+      bs `shouldBe` [1, 2, 3, 4, 5]
+      -- Both sides of the circuit must be torn down
+      readIORef closedA `shouldReturn` True
+      readIORef closedB `shouldReturn` True
+
+    it "should count the data limit per direction, not shared across both" $ do
+      (streamA1, streamA2) <- mkStreamPair
+      (streamB1, streamB2) <- mkStreamPair
+      let limitCfg = Just RelayLimit { rlDuration = Nothing, rlData = Just 5 }
+      withAsync (bridgeStreams limitCfg streamA2 streamB1) $ \_ -> do
+        -- 4 bytes in each direction: 8 total exceeds a shared 5-byte budget
+        -- but stays under a correct per-direction one, so all must arrive.
+        streamWrite streamA1 (BS.pack [1, 2, 3, 4])
+        streamWrite streamB2 (BS.pack [5, 6, 7, 8])
+        a2b <- mapM (\_ -> streamReadByte streamB2) [1..4 :: Int]
+        b2a <- mapM (\_ -> streamReadByte streamA1) [1..4 :: Int]
+        a2b `shouldBe` [1, 2, 3, 4]
+        b2a `shouldBe` [5, 6, 7, 8]
 
     it "should close both streams when the duration limit elapses" $ do
       (_streamA1, streamA2) <- mkStreamPair
@@ -302,13 +433,24 @@ spec = do
       readIORef closedB `shouldReturn` True
 
   describe "Relay address parsing" $ do
-    it "buildRelayAddr constructs valid relay multiaddr bytes" $ do
-      let relayAddr = BS.pack [4, 203, 0, 113, 1, 6, 0x0F, 0xA1]  -- /ip4/203.0.113.1/tcp/4001
-          relayId = BS.pack [0x00, 0x24, 0xAA]
-          targetId = BS.pack [0x00, 0x24, 0xBB]
+    it "round-trips buildRelayAddrBytes through the multiaddr decoder" $ do
+      -- /ip4/203.0.113.1/tcp/4001 in binary form
+      let relayAddr = BS.pack [4, 203, 0, 113, 1, 6, 0x0F, 0xA1]
+          -- Valid identity multihashes (code 0x00, length, digest)
+          relayId = BS.pack [0x00, 0x03, 0xAA, 0xBB, 0xCC]
+          targetId = BS.pack [0x00, 0x03, 0x11, 0x22, 0x33]
           result = buildRelayAddrBytes relayAddr relayId targetId
-      -- Should contain the relay addr, P2P(relay), P2PCircuit, P2P(target)
-      BS.null result `shouldBe` False
+      -- The bytes must decode back to
+      -- /ip4/203.0.113.1/tcp/4001/p2p/<relay>/p2p-circuit/p2p/<target>
+      fromBytes result `shouldBe`
+        Right (Multiaddr [IP4 0xCB007101, TCP 4001, P2P relayId, P2PCircuit, P2P targetId])
 
     it "isRelayedConnection detects P2PCircuit in address" $ do
-      isRelayedConnection (BS.pack []) `shouldBe` False
+      let relayAddr = BS.pack [4, 203, 0, 113, 1, 6, 0x0F, 0xA1]
+          relayId = BS.pack [0x00, 0x03, 0xAA, 0xBB, 0xCC]
+          targetId = BS.pack [0x00, 0x03, 0x11, 0x22, 0x33]
+          circuitAddr = buildRelayAddrBytes relayAddr relayId targetId
+          directAddr = toBytes (Multiaddr [IP4 0xCB007101, TCP 4001, P2P relayId])
+      isRelayedConnection circuitAddr `shouldBe` True
+      isRelayedConnection directAddr `shouldBe` False
+      isRelayedConnection BS.empty `shouldBe` False


### PR DESCRIPTION
## Summary

Issue #177 flagged the NAT stack's test split (48 wire-format vs ~18 rule-checking behavioural) and six tests that assert nothing. Today's merged fixes (#188 autonat filter, #190 relay limits, #192 dcutr parallel dial/retry, #182 expire timestamp) already closed the expire-timestamp, dial-back filter, circuit-limit, and parallel-dial/retry gaps together with their tests. This PR closes the remaining test-only gaps.

## Six assert-nothing tests, fixed

| Test | Before | After |
|---|---|---|
| RelaySpec "enforces data limit" | both `race` branches passed | sends limit+1 bytes; asserts the bridge terminates on its own, forwards exactly 5 bytes, and closes both streams |
| RelaySpec `buildRelayAddrBytes` | only `BS.null result == False` | full round-trip through `fromBytes` to the exact protocol list |
| RelaySpec `isRelayedConnection` | only empty-input negative | positive (built circuit addr), negative (direct addr), empty |
| DCUtRSpec "handles dial failure gracefully" | accepted both `DCUtRFailed` and `DCUtRSuccess` | requires `DCUtRFailed` on **both** sides, with exact dial counts |
| ClientSpec "reserve → connect → stop → bridge" | one hand-written RESERVE round trip, no `src/` call | drives `handleReserve`/`handleConnect` (server) against `makeReservation`/`connectViaRelay`/`handleStop` (client) and bridges application data both ways — the first test to walk the full circuit |
| AutoNAT MessageSpec oversized-frame | `… \|\| True` tautology | asserts the error mentions "too large" |

## New behavioural coverage

- **AutoNAT**: the authenticated peer id (not the message body) reaches the dial-back; the OK response carries the successfully dialled address (spec SHOULD); a trailing-position `p2p-circuit` observed address is refused (existing test only covered mid-list).
- **Relay server**: `MALFORMED_MESSAGE` for CONNECT without a peer field; `CONNECTION_FAILED` when the stop stream cannot be opened and when the target answers non-OK — both also asserting no circuit-slot leak; the data limit is counted per direction, not shared.
- **DCUtR**: SYNC-in-place-of-CONNECT and double-CONNECT protocol violations abort without any hole punch attempt; an oversized (>4 KiB) frame is refused at the stream-read level; the initiator waits ~RTT/2 after SYNC before dialling (200 ms artificial RTT, generous bounds).

## Status-code note (#180)

The reservation-cap test no longer asserts `RESOURCE_LIMIT_EXCEEDED` as correct — circuit-v2 assigns `RESERVATION_REFUSED` (200) to reservation rejection, tracked in #180. The test now asserts refusal (non-OK status, no reservation granted or stored) with a comment referencing #180, so the fix for #180 will not need to invert a test.

## TDD sanity check

The new data-limit test was verified to fail when the limit check in `forwardWithLimit` is disabled (bridge never terminates, `race` returns `Right ()`), and passes against the real code.

## Test results

`cabal test` (GHC 9.10.3): **727 examples, 0 failures**. The timing-sensitive RTT/2 test was run repeatedly without flakes.

## Remaining gaps (need src or infrastructure changes, out of scope here)

- Reservation refresh from an existing holder at capacity (cap check precedes membership check in `handleReserve`)
- `rsvAddrs` population and the signed reservation voucher (features not implemented)
- Relayed-connection refusal for RESERVE/CONNECT (needs an observed-multiaddr parameter on the handlers; same root cause as #167)
- Exact-at-limit termination without consuming byte limit+1 (`forwardWithLimit` reads before checking)
- `isRelayedConnection` false positive on `0xA2 0x02` inside a peer id (substring heuristic)
- Switch protocol registration and multi-host scenarios (#152, being handled separately)

Refs #177