### PR TITLE
test: add wire-conformance and fault-injection tiers, expand integration harness

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -185,6 +185,8 @@ test-suite libp2p-hs-test
     LibP2P.Protocol.GossipSub.HeartbeatSpec
     LibP2P.Protocol.GossipSub.HandlerSpec
     LibP2P.IntegrationSpec
+    LibP2P.FaultInjectionSpec
+    LibP2P.WireConformanceSpec
   build-depends:
     base       >= 4.18 && < 5,
     bytestring >= 0.10 && < 0.13,

--- a/test/LibP2P/FaultInjectionSpec.hs
+++ b/test/LibP2P/FaultInjectionSpec.hs
@@ -1,0 +1,162 @@
+-- | Fault-injection tests (T5 tier, #178).
+--
+-- These tests drive the stack through failure paths that no happy-path
+-- tier can reach: peers that send garbage instead of a handshake, peers
+-- that disconnect mid-negotiation, and servers that accept TCP but never
+-- speak libp2p. The assertions are always twofold: the failing exchange
+-- terminates (no hang), and the node stays healthy afterwards.
+--
+-- The hostile peer is played by the raw 'Transport' interface, below the
+-- upgrade pipeline, so arbitrary bytes can be written to the socket.
+module LibP2P.FaultInjectionSpec (spec) where
+
+import Control.Concurrent.Async (withAsync)
+import Control.Exception (SomeException, bracket, try)
+import qualified Data.ByteString as BS
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair, publicKey)
+import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.Multiaddr (Multiaddr (..))
+import LibP2P.Multiaddr.Protocol (Protocol (..))
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.Protocol.Ping (PingResult (..), registerPingHandler, sendPing)
+import LibP2P.Switch (addTransport, newSwitch, switchClose)
+import LibP2P.Switch.Dial (dial)
+import LibP2P.Switch.Listen (defaultConnectionGater, switchListen)
+import LibP2P.Switch.Types (Switch)
+import LibP2P.Transport
+  ( Listener (..)
+  , RawConnection (..)
+  , Transport (..)
+  )
+import LibP2P.Transport.TCP (newTCPTransport)
+import System.Timeout (timeout)
+import Test.Hspec
+
+-- | Generate a test identity (PeerId, KeyPair).
+mkTestIdentity :: IO (PeerId, KeyPair)
+mkTestIdentity = do
+  Right kp <- generateKeyPair
+  let pid = fromPublicKey (publicKey kp)
+  pure (pid, kp)
+
+-- | Loopback address with port 0 (OS assigns ephemeral port).
+loopbackAddr :: Multiaddr
+loopbackAddr = Multiaddr [IP4 0x7f000001, TCP 0]
+
+-- | A full node (Switch + TCP + Ping) listening on loopback.
+withListeningNode :: ((Switch, PeerId, Multiaddr) -> IO a) -> IO a
+withListeningNode action = bracket setup teardown action
+  where
+    setup = do
+      (pid, kp) <- mkTestIdentity
+      sw <- newSwitch pid kp
+      tcp <- newTCPTransport
+      addTransport sw tcp
+      registerPingHandler sw
+      addrs <- switchListen sw defaultConnectionGater [loopbackAddr]
+      pure (sw, pid, head addrs)
+    teardown (sw, _pid, _addr) = switchClose sw
+
+-- | A dial-only node (Switch + TCP + Ping), no listener.
+withDialerNode :: (Switch -> IO a) -> IO a
+withDialerNode action = bracket setup switchClose action
+  where
+    setup = do
+      (pid, kp) <- mkTestIdentity
+      sw <- newSwitch pid kp
+      tcp <- newTCPTransport
+      addTransport sw tcp
+      registerPingHandler sw
+      pure sw
+
+-- | Prove the listener is still alive: a well-formed dial + ping succeeds.
+expectHealthyListener :: PeerId -> Multiaddr -> IO ()
+expectHealthyListener pid listenAddr =
+  withDialerNode $ \sw -> do
+    dialResult <- timeout 10000000 $ dial sw pid [listenAddr]
+    case dialResult of
+      Just (Right conn) -> do
+        pingResult <- timeout 5000000 $ sendPing conn
+        case pingResult of
+          Just (Right (PingResult rtt)) -> rtt `shouldSatisfy` (> 0)
+          other ->
+            expectationFailure $ "ping after fault failed: " ++ show other
+      Just (Left err) ->
+        expectationFailure $ "dial after fault failed: " ++ show err
+      Nothing ->
+        expectationFailure "dial after fault timed out (listener wedged?)"
+
+-- | Raw-connect to an address and run an action on the socket.
+withRawDial :: Multiaddr -> (RawConnection -> IO a) -> IO a
+withRawDial addr action = do
+  tcp <- newTCPTransport
+  bracket (transportDial tcp addr) rcClose action
+
+-- | The multistream-select header bytes:
+-- varint(19) "/multistream/1.0.0\n" (hand-written, not via our encoder).
+mssHeaderBytes :: BS.ByteString
+mssHeaderBytes = BS.singleton 0x13 <> "/multistream/1.0.0\n"
+
+spec :: Spec
+spec = do
+  describe "listener under hostile input" $ do
+    it "survives a peer that sends garbage instead of a handshake" $ do
+      withListeningNode $ \(_sw, pid, listenAddr) -> do
+        withRawDial listenAddr $ \raw -> do
+          -- 0xff bytes are a hostile varint: continuation bit forever.
+          streamWrite (rcStreamIO raw) (BS.replicate 1024 0xff)
+        expectHealthyListener pid listenAddr
+
+    it "survives a peer that disconnects mid multistream-select" $ do
+      withListeningNode $ \(_sw, pid, listenAddr) -> do
+        withRawDial listenAddr $ \raw ->
+          -- Valid mss header, then the peer vanishes before proposing
+          -- a security protocol.
+          streamWrite (rcStreamIO raw) mssHeaderBytes
+        expectHealthyListener pid listenAddr
+
+    it "survives a peer that connects and immediately disconnects" $ do
+      withListeningNode $ \(_sw, pid, listenAddr) -> do
+        withRawDial listenAddr $ \_raw -> pure ()
+        expectHealthyListener pid listenAddr
+
+  describe "dialer against a hostile server" $ do
+    it "dial fails cleanly (no hang) when the server sends garbage" $ do
+      tcp <- newTCPTransport
+      bracket (transportListen tcp loopbackAddr) listenerClose $ \listener -> do
+        let serveGarbage = do
+              result <- try $ bracket (listenerAccept listener) rcClose $
+                \raw -> streamWrite (rcStreamIO raw) (BS.replicate 4096 0xff)
+              case result of
+                Left (_ :: SomeException) -> pure ()
+                Right () -> pure ()
+        withAsync serveGarbage $ \_server -> do
+          (fakePid, _) <- mkTestIdentity
+          withDialerNode $ \sw -> do
+            result <- timeout 15000000 $ dial sw fakePid [listenerAddr listener]
+            case result of
+              Just (Left _err) -> pure ()  -- failed, and failed promptly
+              Just (Right _) ->
+                expectationFailure "dial must not succeed against garbage"
+              Nothing ->
+                expectationFailure "dial hung against a garbage-speaking server"
+
+    it "dial fails cleanly when the server closes right after accepting" $ do
+      tcp <- newTCPTransport
+      bracket (transportListen tcp loopbackAddr) listenerClose $ \listener -> do
+        let acceptAndSlam = do
+              result <- try $ listenerAccept listener >>= rcClose
+              case result of
+                Left (_ :: SomeException) -> pure ()
+                Right () -> pure ()
+        withAsync acceptAndSlam $ \_server -> do
+          (fakePid, _) <- mkTestIdentity
+          withDialerNode $ \sw -> do
+            result <- timeout 15000000 $ dial sw fakePid [listenerAddr listener]
+            case result of
+              Just (Left _err) -> pure ()
+              Just (Right _) ->
+                expectationFailure "dial must not succeed against a slammed socket"
+              Nothing ->
+                expectationFailure "dial hung against a slamming server"

--- a/test/LibP2P/IntegrationSpec.hs
+++ b/test/LibP2P/IntegrationSpec.hs
@@ -5,19 +5,42 @@
 module LibP2P.IntegrationSpec (spec) where
 
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (forConcurrently)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM
   ( atomically
+  , modifyTVar'
   , readTVar
+  , retry
   , writeTVar
   )
 import Control.Exception (SomeException, bracket, try)
+import Control.Monad (replicateM)
+import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
+import Data.Time.Clock (getCurrentTime)
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (KeyPair, publicKey)
-import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
-import LibP2P.Multiaddr (Multiaddr (..))
+import LibP2P.Crypto.PeerId (PeerId, fromPublicKey, peerIdBytes)
+import LibP2P.DHT
+  ( DHTMode (..)
+  , DHTNode (..)
+  , decodePeerAddrs
+  , newDHTNode
+  , registerDHTHandler
+  )
+import LibP2P.DHT.Distance (peerIdToKey)
+-- Qualified: DHTMessage's msgKey clashes with PubSubMessage's msgKey.
+import qualified LibP2P.DHT.Message as DHTMsg
+import LibP2P.DHT.RoutingTable (insertPeer)
+import LibP2P.DHT.Types (BucketEntry (..), ConnectionType (..))
+import LibP2P.Multiaddr (Multiaddr (..), toBytes)
 import LibP2P.Multiaddr.Protocol (Protocol (..))
+import LibP2P.MultistreamSelect.Negotiation
+  ( NegotiationResult (..)
+  , StreamIO (..)
+  , negotiateInitiator
+  )
 import LibP2P.Protocol.GossipSub.Handler
   ( gossipJoin
   , gossipPublish
@@ -49,8 +72,13 @@ import LibP2P.Switch.Listen
   , defaultConnectionGater
   , switchListen
   )
-import LibP2P.Switch (addTransport, newSwitch, switchClose)
-import LibP2P.Switch.Types (Connection (..), DialError (..), Switch (..))
+import LibP2P.Switch (addTransport, newSwitch, setStreamHandler, switchClose)
+import LibP2P.Switch.Types
+  ( Connection (..)
+  , DialError (..)
+  , MuxerSession (..)
+  , Switch (..)
+  )
 import LibP2P.Transport.TCP (newTCPTransport)
 import System.Timeout (timeout)
 import Test.Hspec
@@ -65,6 +93,10 @@ mkTestIdentity = do
 -- | Loopback address with port 0 (OS assigns ephemeral port).
 loopbackAddr :: Multiaddr
 loopbackAddr = Multiaddr [IP4 0x7f000001, TCP 0]
+
+-- | Read exactly n bytes from a stream.
+readN :: StreamIO -> Int -> IO BS.ByteString
+readN stream n = BS.pack <$> replicateM n (streamReadByte stream)
 
 -- | Create a test node: Switch + TCP transport + Identify + Ping.
 -- Returns the Switch, PeerId, and KeyPair.
@@ -81,40 +113,51 @@ withTestNode action = bracket setup teardown (\(sw, pid, _kp) -> action sw pid)
       pure (sw, pid, kp)
     teardown (sw, _pid, _kp) = switchClose sw
 
+-- | Create a listening test node: Switch + TCP + Identify + Ping,
+-- bound to a loopback address. The Switch is closed on exit, even
+-- when the action throws.
+withListeningNode :: ((Switch, PeerId, Multiaddr) -> IO a) -> IO a
+withListeningNode action = bracket setup teardown action
+  where
+    setup = do
+      (pid, kp) <- mkTestIdentity
+      sw <- newSwitch pid kp
+      tcp <- newTCPTransport
+      addTransport sw tcp
+      registerIdentifyHandlers sw
+      registerPingHandler sw
+      addrs <- switchListen sw defaultConnectionGater [loopbackAddr]
+      pure (sw, pid, head addrs)
+    teardown (sw, _pid, _addr) = switchClose sw
+
+-- | Block until the given peer shows up in the switch's connection pool.
+-- Replaces the previous fixed 300ms sleep: the pool is STM state, so the
+-- test can wait on the exact condition instead of a wall-clock guess.
+waitForPeerInPool :: Switch -> PeerId -> IO ()
+waitForPeerInPool sw pid = do
+  seen <- timeout 5000000 $ atomically $ do
+    mConn <- lookupConn (swConnPool sw) pid
+    maybe retry (const (pure ())) mConn
+  case seen of
+    Just () -> pure ()
+    Nothing -> fail "waitForPeerInPool: peer never appeared in the pool"
+
 -- | Create two connected test nodes: node B listens, node A dials.
 -- Returns both Switches, PeerIds, and the connection from A to B.
+-- Both Switches are torn down via bracket even when the action fails,
+-- so a failing assertion cannot leak listeners into later tests.
 withConnectedPair :: ((Switch, PeerId) -> (Switch, PeerId) -> Connection -> IO a) -> IO a
-withConnectedPair action = do
-  -- Node B (listener)
-  (pidB, kpB) <- mkTestIdentity
-  swB <- newSwitch pidB kpB
-  tcpB <- newTCPTransport
-  addTransport swB tcpB
-  registerIdentifyHandlers swB
-  registerPingHandler swB
-  addrs <- switchListen swB defaultConnectionGater [loopbackAddr]
-  let listenAddr = head addrs
-  -- Node A (dialer)
-  (pidA, kpA) <- mkTestIdentity
-  swA <- newSwitch pidA kpA
-  tcpA <- newTCPTransport
-  addTransport swA tcpA
-  registerIdentifyHandlers swA
-  registerPingHandler swA
-  -- Dial from A to B
-  dialResult <- dial swA pidB [listenAddr]
-  case dialResult of
-    Left err -> do
-      switchClose swB
-      switchClose swA
-      fail $ "withConnectedPair: dial failed: " ++ show err
-    Right conn -> do
-      -- Allow listener to complete pool insertion
-      threadDelay 300000
-      result <- action (swA, pidA) (swB, pidB) conn
-      switchClose swA
-      switchClose swB
-      pure result
+withConnectedPair action =
+  withListeningNode $ \(swB, pidB, listenAddr) ->
+    withTestNode $ \swA pidA -> do
+      dialResult <- dial swA pidB [listenAddr]
+      case dialResult of
+        Left err -> fail $ "withConnectedPair: dial failed: " ++ show err
+        Right conn -> do
+          -- The dialer returns before the listener finishes pool insertion;
+          -- wait on the pool itself rather than sleeping.
+          waitForPeerInPool swB pidA
+          action (swA, pidA) (swB, pidB) conn
 
 spec :: Spec
 spec = do
@@ -128,6 +171,17 @@ spec = do
         case poolConn of
           Nothing -> expectationFailure "listener should see dialer in pool"
           Just c  -> connPeerId c `shouldBe` pidA
+
+    it "upgraded connection records /noise security and /yamux/1.0.0 muxing on both sides" $ do
+      withConnectedPair $ \(_swA, pidA) (swB, _pidB) conn -> do
+        connSecurity conn `shouldBe` "/noise"
+        connMuxer conn `shouldBe` "/yamux/1.0.0"
+        poolConn <- atomically $ lookupConn (swConnPool swB) pidA
+        case poolConn of
+          Nothing -> expectationFailure "listener should see dialer in pool"
+          Just c -> do
+            connSecurity c `shouldBe` "/noise"
+            connMuxer c `shouldBe` "/yamux/1.0.0"
 
   describe "Ping over real TCP" $ do
     it "sendPing returns valid RTT (>0, <1s for loopback)" $ do
@@ -161,6 +215,18 @@ spec = do
             -- B is listening, so idListenAddrs should be non-empty
             idListenAddrs info `shouldSatisfy` (not . null)
 
+    it "observedAddr echoes the dialer's own address as seen by the listener" $ do
+      -- Regression for #167: the responder must fill observedAddr with the
+      -- initiator's source address. On loopback that address is exactly the
+      -- dialer's local socket address (ephemeral port included).
+      withConnectedPair $ \_nodeA _nodeB conn -> do
+        result <- timeout 5000000 $ requestIdentify conn
+        case result of
+          Nothing -> expectationFailure "identify timed out"
+          Just (Left err) -> expectationFailure $ "identify failed: " ++ err
+          Just (Right info) ->
+            idObservedAddr info `shouldBe` Just (toBytes (connLocalAddr conn))
+
   describe "Multi-protocol" $ do
     -- WARNING(#163): this test certifies behaviour the spec forbids.
     -- specs/ping/ping.md: "The dialing peer MUST NOT keep more than one
@@ -179,6 +245,111 @@ spec = do
         case pingResult2 of
           Left err -> expectationFailure $ "ping 2 failed: " ++ show err
           Right (PingResult rtt2) -> rtt2 `shouldSatisfy` (> 0)
+
+    it "unknown protocol gets na over real TCP and the connection stays usable" $ do
+      withConnectedPair $ \_nodeA _nodeB conn -> do
+        stream <- muxOpenStream (connSession conn)
+        result <- timeout 5000000 $
+          negotiateInitiator stream ["/test/does-not-exist/1.0.0"]
+        result `shouldBe` Just NoProtocol
+        -- The failed negotiation must not poison the muxed connection.
+        pingAfter <- timeout 5000000 $ sendPing conn
+        case pingAfter of
+          Just (Right (PingResult rtt)) -> rtt `shouldSatisfy` (> 0)
+          Just (Left err) ->
+            expectationFailure $ "ping after failed negotiation: " ++ show err
+          Nothing ->
+            expectationFailure "connection unusable after failed negotiation"
+
+  describe "DHT over real TCP" $ do
+    it "FIND_NODE returns the responder's routing table entries with addresses" $ do
+      -- Regression for #168/#194: the outbound RPC path must reach a real
+      -- peer over the Switch, and Peer records must carry multiaddrs.
+      withConnectedPair $ \(swA, _pidA) (swB, pidB) _conn -> do
+        dhtB <- newDHTNode swB DHTServer
+        registerDHTHandler dhtB
+        dhtA <- newDHTNode swA DHTClient
+        -- Seed B's routing table with a fabricated third peer.
+        (pidC, _kpC) <- mkTestIdentity
+        now <- getCurrentTime
+        let addrC = Multiaddr [IP4 0x7f000001, TCP 4001]
+            entryC = BucketEntry pidC (peerIdToKey pidC) [addrC] now NotConnected
+        atomically $ modifyTVar' (dhtRoutingTable dhtB) (fst . insertPeer entryC)
+        let request = DHTMsg.emptyDHTMessage
+              { DHTMsg.msgType = DHTMsg.FindNode
+              , DHTMsg.msgKey = peerIdBytes pidC
+              }
+        result <- timeout 10000000 $ dhtSendRequest dhtA pidB request
+        case result of
+          Nothing -> expectationFailure "FIND_NODE timed out"
+          Just (Left err) -> expectationFailure $ "FIND_NODE failed: " ++ err
+          Just (Right resp) -> do
+            DHTMsg.msgType resp `shouldBe` DHTMsg.FindNode
+            map DHTMsg.dhtPeerId (DHTMsg.msgCloserPeers resp)
+              `shouldContain` [peerIdBytes pidC]
+            concatMap DHTMsg.dhtPeerAddrs (DHTMsg.msgCloserPeers resp)
+              `shouldContain` [toBytes addrC]
+
+    it "three nodes: dialer learns a third peer via FIND_NODE, dials it, and pings it" $ do
+      -- A full discovery walk over three real nodes: A asks B for C,
+      -- decodes C's address from the wire response, dials C, and pings.
+      withListeningNode $ \(_swC, pidC, addrC) ->
+        withConnectedPair $ \(swA, _pidA) (swB, pidB) _conn -> do
+          dhtB <- newDHTNode swB DHTServer
+          registerDHTHandler dhtB
+          dhtA <- newDHTNode swA DHTClient
+          now <- getCurrentTime
+          let entryC = BucketEntry pidC (peerIdToKey pidC) [addrC] now NotConnected
+          atomically $ modifyTVar' (dhtRoutingTable dhtB) (fst . insertPeer entryC)
+          let request = DHTMsg.emptyDHTMessage
+                { DHTMsg.msgType = DHTMsg.FindNode
+                , DHTMsg.msgKey = peerIdBytes pidC
+                }
+          result <- timeout 10000000 $ dhtSendRequest dhtA pidB request
+          case result of
+            Nothing -> expectationFailure "FIND_NODE timed out"
+            Just (Left err) -> expectationFailure $ "FIND_NODE failed: " ++ err
+            Just (Right resp) -> do
+              let records = filter
+                    ((== peerIdBytes pidC) . DHTMsg.dhtPeerId)
+                    (DHTMsg.msgCloserPeers resp)
+                  learnedAddrs =
+                    decodePeerAddrs (concatMap DHTMsg.dhtPeerAddrs records)
+              learnedAddrs `shouldBe` [addrC]
+              dialResult <- timeout 10000000 $ dial swA pidC learnedAddrs
+              case dialResult of
+                Just (Right connC) -> do
+                  pingResult <- timeout 5000000 $ sendPing connC
+                  case pingResult of
+                    Just (Right (PingResult rtt)) -> rtt `shouldSatisfy` (> 0)
+                    other -> expectationFailure $
+                      "ping to discovered peer failed: " ++ show other
+                Just (Left err) -> expectationFailure $
+                  "dial to discovered peer failed: " ++ show err
+                Nothing ->
+                  expectationFailure "dial to discovered peer timed out"
+
+  describe "Concurrent streams over real TCP" $ do
+    it "4 concurrent streams echo distinct payloads larger than one noise frame" $ do
+      -- 66000 bytes exceeds the 65535-byte noise frame limit, so a single
+      -- stream write must be chunked across noise frames (#183) and
+      -- reassembled intact — on four streams at once.
+      withConnectedPair $ \_nodeA (swB, _pidB) conn -> do
+        let echoProto = "/libp2p-hs/test-echo/1.0.0"
+            payloadSize = 66000
+        setStreamHandler swB echoProto $ \_c stream -> do
+          payload <- readN stream payloadSize
+          streamWrite stream payload
+        result <- timeout 60000000 $
+          forConcurrently [0 .. 3 :: Int] $ \i -> do
+            stream <- muxOpenStream (connSession conn)
+            negotiated <- negotiateInitiator stream [echoProto]
+            negotiated `shouldBe` Accepted echoProto
+            let payload = BS.replicate payloadSize (fromIntegral (0x41 + i))
+            streamWrite stream payload
+            echoed <- readN stream payloadSize
+            pure (echoed == payload)
+        result `shouldBe` Just [True, True, True, True]
 
   describe "GossipSub over real TCP" $ do
     it "two nodes join topic, publish -> receive" $ do

--- a/test/LibP2P/WireConformanceSpec.hs
+++ b/test/LibP2P/WireConformanceSpec.hs
@@ -1,0 +1,213 @@
+-- | Wire-conformance golden vectors (T3b tier, #178).
+--
+-- Every expected byte string in this module is hand-derived from the
+-- upstream specs (multistream-select README, identify/README.md protobuf,
+-- kad-dht protobuf, pubsub RPC protobuf, noise payload protobuf) — never
+-- from our own encoders. A self-consistent but wrong codec round-trips
+-- perfectly through encode/decode tests; it cannot survive a byte-exact
+-- fixture derived from the spec.
+--
+-- Complements the existing byte-exact vectors in Yamux.FrameSpec and the
+-- decode-direction go-libp2p-shaped vector in Identify.MessageSpec.
+module LibP2P.WireConformanceSpec (spec) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
+import LibP2P.DHT.Message
+  ( DHTMessage (..)
+  , DHTPeer (..)
+  , MessageType (..)
+  , decodeFramed
+  , emptyDHTMessage
+  , encodeFramed
+  )
+import LibP2P.DHT.Types (ConnectionType (..))
+import LibP2P.MultistreamSelect.Negotiation
+  ( NegotiationResult (..)
+  , StreamIO (..)
+  , negotiateInitiator
+  , negotiateResponder
+  )
+import LibP2P.MultistreamSelect.Wire (encodeMessage)
+import LibP2P.Noise.Handshake (NoisePayload (..), encodeNoisePayload)
+import LibP2P.Protocol.GossipSub.Message (encodeRPC)
+import LibP2P.Protocol.GossipSub.Types (RPC (..), SubOpts (..))
+import LibP2P.Protocol.Identify (encodeFramedIdentify)
+import LibP2P.Protocol.Identify.Message (IdentifyInfo (..))
+import Test.Hspec
+
+-- | A scripted stream: reads come from a canned byte sequence (recorded
+-- from / equivalent to a foreign implementation), writes are captured
+-- for byte-exact assertion. Reading past the script raises EOF.
+mkScriptedStream :: ByteString -> IO (StreamIO, IO ByteString)
+mkScriptedStream canned = do
+  writtenRef <- newIORef BS.empty
+  readRef <- newIORef canned
+  let stream = StreamIO
+        { streamWrite = \bs -> modifyIORef' writtenRef (`BS.append` bs)
+        , streamReadByte = do
+            buf <- readIORef readRef
+            case BS.uncons buf of
+              Nothing -> ioError (userError "scripted stream: EOF")
+              Just (b, rest) -> writeIORef readRef rest >> pure b
+        , streamClose = pure ()
+        }
+  pure (stream, readIORef writtenRef)
+
+-- multistream-select vectors (multiformats/multistream-select README:
+-- every message is <varint-length><UTF-8 payload>\n, length includes \n).
+
+-- | varint(19) "/multistream/1.0.0" \n
+mssHeader :: ByteString
+mssHeader = BS.singleton 0x13 <> "/multistream/1.0.0\n"
+
+-- | varint(7) "/noise" \n
+mssNoise :: ByteString
+mssNoise = BS.singleton 0x07 <> "/noise\n"
+
+-- | varint(13) "/yamux/1.0.0" \n
+mssYamux :: ByteString
+mssYamux = BS.singleton 0x0d <> "/yamux/1.0.0\n"
+
+-- | varint(3) "na" \n
+mssNa :: ByteString
+mssNa = BS.singleton 0x03 <> "na\n"
+
+spec :: Spec
+spec = do
+  describe "multistream-select messages" $ do
+    it "header is 0x13 '/multistream/1.0.0' 0x0a" $
+      encodeMessage "/multistream/1.0.0" `shouldBe` mssHeader
+
+    it "'/noise' proposal is 0x07 '/noise' 0x0a" $
+      encodeMessage "/noise" `shouldBe` mssNoise
+
+    it "'na' rejection is 0x03 'na' 0x0a" $
+      encodeMessage "na" `shouldBe` mssNa
+
+  describe "multistream-select transcripts against a scripted foreign peer" $ do
+    it "initiator emits exactly header + proposal when the peer accepts" $ do
+      (stream, getWritten) <- mkScriptedStream (mssHeader <> mssNoise)
+      result <- negotiateInitiator stream ["/noise"]
+      result `shouldBe` Accepted "/noise"
+      written <- getWritten
+      written `shouldBe` mssHeader <> mssNoise
+
+    it "initiator falls back to its second protocol on na" $ do
+      (stream, getWritten) <- mkScriptedStream (mssHeader <> mssNa <> mssYamux)
+      result <- negotiateInitiator stream ["/noise", "/yamux/1.0.0"]
+      result `shouldBe` Accepted "/yamux/1.0.0"
+      written <- getWritten
+      written `shouldBe` mssHeader <> mssNoise <> mssYamux
+
+    it "responder emits exactly header + echo for a supported proposal" $ do
+      (stream, getWritten) <- mkScriptedStream (mssHeader <> mssNoise)
+      result <- negotiateResponder stream ["/noise"]
+      result `shouldBe` Accepted "/noise"
+      written <- getWritten
+      written `shouldBe` mssHeader <> mssNoise
+
+    it "responder answers na to an unknown proposal, then accepts a known one" $ do
+      let unknown = BS.singleton 0x0b <> "/tls/1.0.0\n"
+      (stream, getWritten) <- mkScriptedStream (mssHeader <> unknown <> mssNoise)
+      result <- negotiateResponder stream ["/noise"]
+      result `shouldBe` Accepted "/noise"
+      written <- getWritten
+      written `shouldBe` mssHeader <> mssNa <> mssNoise
+
+  describe "identify protobuf (specs/identify/README.md)" $ do
+    -- Fields: 1 publicKey, 2 listenAddrs (rep), 3 protocols (rep),
+    -- 4 observedAddr, 5 protocolVersion, 6 agentVersion.
+    it "framed message matches a hand-derived vector with all fields set" $ do
+      let info = IdentifyInfo
+            { idProtocolVersion = Just "ipfs/0.1.0"
+            , idAgentVersion    = Just "libp2p-hs/0.1.0"
+            , idPublicKey       = Just "PK"
+            , idListenAddrs     =
+                [BS.pack [0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x0f, 0xa1]]
+                -- /ip4/127.0.0.1/tcp/4001
+            , idObservedAddr    =
+                Just (BS.pack [0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x30, 0x39])
+                -- /ip4/127.0.0.1/tcp/12345
+            , idProtocols       = ["/ipfs/id/1.0.0", "/ipfs/ping/1.0.0"]
+            }
+          expected = BS.concat
+            [ BS.singleton 0x57  -- varint frame length: 87-byte protobuf
+            , BS.pack [0x0a, 0x02], "PK"                            -- field 1
+            , BS.pack [0x12, 0x08]                                  -- field 2
+            , BS.pack [0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x0f, 0xa1]
+            , BS.pack [0x1a, 0x0e], "/ipfs/id/1.0.0"                -- field 3
+            , BS.pack [0x1a, 0x10], "/ipfs/ping/1.0.0"              -- field 3
+            , BS.pack [0x22, 0x08]                                  -- field 4
+            , BS.pack [0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x30, 0x39]
+            , BS.pack [0x2a, 0x0a], "ipfs/0.1.0"                    -- field 5
+            , BS.pack [0x32, 0x0f], "libp2p-hs/0.1.0"               -- field 6
+            ]
+      encodeFramedIdentify info `shouldBe` expected
+
+  describe "kad-dht protobuf (specs/kad-dht/README.md)" $ do
+    it "framed FIND_NODE request matches a hand-derived vector" $ do
+      let request = emptyDHTMessage
+            { msgType = FindNode
+            , msgKey = "some-peer-id"
+            }
+          expected = BS.concat
+            [ BS.singleton 0x10          -- varint frame length: 16
+            , BS.pack [0x08, 0x04]       -- field 1 (type): FIND_NODE = 4
+            , BS.pack [0x12, 0x0c]       -- field 2 (key): 12 raw bytes
+            , "some-peer-id"
+            ]
+      encodeFramed request `shouldBe` expected
+
+    it "decodes a hand-derived FIND_NODE response with one closerPeer" $ do
+      -- Message.Peer: 1 id (bytes), 2 addrs (rep bytes), 3 connection (enum).
+      let addrBytes = BS.pack [0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x0f, 0xa1]
+          wire = BS.concat
+            [ BS.singleton 0x18          -- varint frame length: 24
+            , BS.pack [0x08, 0x04]       -- field 1 (type): FIND_NODE = 4
+            , BS.pack [0x42, 0x14]       -- field 8 (closerPeers): 20 bytes
+            , BS.pack [0x0a, 0x06], "peer-1"
+            , BS.pack [0x12, 0x08], addrBytes
+            , BS.pack [0x18, 0x01]       -- connection: CONNECTED = 1
+            ]
+          expected = emptyDHTMessage
+            { msgType = FindNode
+            , msgCloserPeers =
+                [ DHTPeer
+                    { dhtPeerId = "peer-1"
+                    , dhtPeerAddrs = [addrBytes]
+                    , dhtPeerConnType = Connected
+                    }
+                ]
+            }
+      decodeFramed 4096 wire `shouldBe` Right expected
+
+  describe "gossipsub RPC protobuf (specs/pubsub/README.md)" $ do
+    it "subscription-only RPC matches a hand-derived vector" $ do
+      -- RPC: 1 subscriptions (rep SubOpts); SubOpts: 1 subscribe, 2 topicid.
+      let rpc = RPC
+            { rpcSubscriptions = [SubOpts True "news"]
+            , rpcPublish = []
+            , rpcControl = Nothing
+            }
+          expected = BS.concat
+            [ BS.pack [0x0a, 0x08]       -- field 1: 8-byte SubOpts
+            , BS.pack [0x08, 0x01]       -- subscribe = true
+            , BS.pack [0x12, 0x04]       -- topicid, 4 bytes
+            , "news"
+            ]
+      encodeRPC rpc `shouldBe` expected
+
+  describe "noise handshake payload protobuf (specs/noise/README.md)" $ do
+    it "NoiseHandshakePayload matches a hand-derived vector" $ do
+      -- Fields: 1 identity_key (bytes), 2 identity_sig (bytes).
+      let payload = NoisePayload
+            { npIdentityKey = "IDKEY"
+            , npIdentitySig = "IDSIG"
+            }
+          expected = BS.concat
+            [ BS.pack [0x0a, 0x05], "IDKEY"
+            , BS.pack [0x12, 0x05], "IDSIG"
+            ]
+      encodeNoisePayload payload `shouldBe` expected


### PR DESCRIPTION
## Summary

#178 was filed against the pre-#182 codebase. After the #182–#205 wave, much of it is already resolved; this PR adds the highest-value pieces that were genuinely still missing: the T3b wire-conformance tier, a T5 fault-injection starter, the T2 harness fixes, and the T2 cases the issue listed that were not covered by #195/#196/#194.

## Tier-by-tier status against #178 (as of today's main)

| Tier | Issue said | Status now | This PR |
|---|---|---|---|
| T2 in-process two-host | 17 cases, leaks on failure, sleeps | #196 added ConnectionLifecycleSpec (teardown, remote disconnect, switchClose closes conns, stream accounting, dial dedup) — the "teardown group" of the issue is done | `withConnectedPair` now brackets both switches and STM-waits on the pool instead of `threadDelay 300000`; adds observedAddr echo (#167), FIND_NODE over real TCP (#168/#194), three-node discover→dial→ping, unknown-protocol `na` + connection reuse, connSecurity/connMuxer on both sides, 4 concurrent streams > one noise frame (#183) |
| T3a spec-clause conformance | ZERO | Partially covered by #184/#195/#199/#200/#201/#203/#204 (identify varint framing + observedAddr, ping wire framing, mss/varint limits, peer-id vectors, protocol table) | Ping stream-lifecycle clauses (single outbound stream, reuse, half-close) remain blocked on open bug #163 — writing them now just re-fails #163; the full MUST/SHOULD sweep is still open |
| T3b asymmetric wire vectors | ZERO | Only yamux frames (FrameSpec) and one decode-direction identify vector were byte-exact | **New WireConformanceSpec**: hand-derived golden vectors for mss messages and full negotiation transcripts against a scripted foreign peer, identify framed protobuf (encode direction), kad-dht FIND_NODE (both directions), gossipsub subscription RPC, noise handshake payload |
| T4 cross-impl interop | ping + gossipsub only | Unchanged (`interop/`, CI in `interop.yml`) | Untouched — adding identify/dht modes belongs to #129 (upstream unified-testing contract) |
| T5 fault injection | ZERO | Still zero | **New FaultInjectionSpec**: garbage handshake, mid-mss disconnect, immediate slam against the listener (health re-verified by a real dial+ping afterwards); dialer against garbage-speaking and slamming servers (clean failure, no hang) |
| T6 soak | ZERO | Still zero | Not included — needs a separate slow-suite arrangement |

Dead paths listed in the issue (`removeConn`, `releaseConnection`, `swEvents`, `switchClose` vs connections) were wired and tested by #196; DHT sender wiring by #194; NAT registration by #198; identify framing/observedAddr by #184/#195.

## What this PR adds

- `test/LibP2P/WireConformanceSpec.hs` (12 examples) — every expected byte string is hand-derived from the spec, never from our encoders, so a self-consistent wrong codec cannot pass. The scripted-peer transcripts assert the exact bytes our initiator/responder emit against canned foreign-peer bytes, offline, no Docker.
- `test/LibP2P/FaultInjectionSpec.hs` (5 examples) — hostile peer played via the raw `Transport` interface below the upgrade pipeline.
- `test/LibP2P/IntegrationSpec.hs` — harness `bracket` + STM condition wait (the issue's two mechanical defects), plus 6 new end-to-end cases including a genuine three-node walk: A learns C from B via FIND_NODE on the wire, decodes the multiaddr from the response, dials C, and pings it.

Suite: 849 examples, 0 failures (3 consecutive runs of the timing-sensitive groups to check for flakes). TDD sanity: breaking `observedAddr` fails the new T2 case; stripping the mss trailing newline fails the golden vectors while round-trip tests would still pass.

## Still open after this PR

- T3a full MUST/SHOULD sweep (ping clauses blocked on #163; do the sweep after #163 lands)
- Identify/dht/holepunch interop modes → #129/#130/#131
- T6 soak tier (repeated connect/disconnect cycles)
- GossipSub integration test still uses sleeps — its subscription propagation has no STM-observable hook yet
- Connection eviction policy (design gap flagged at the end of #178)

Refs #178
