### PR TITLE
fix(relay): return RESERVATION_REFUSED when the reservation cap is reached

### DIFF
--- a/src/LibP2P/NAT/Relay.hs
+++ b/src/LibP2P/NAT/Relay.hs
@@ -87,7 +87,10 @@ handleReserve state stream peerId = do
   reservations <- readTVarIO (rsReservations state)
   let limit = rcMaxReservations (rsConfig state)
   if Map.size reservations >= limit
-    then sendHopStatus stream ResourceLimitExceeded
+    -- Per circuit-v2 spec, a reservation rejected because the relay is at
+    -- capacity is RESERVATION_REFUSED (200); RESOURCE_LIMIT_EXCEEDED (201)
+    -- is reserved for relayed-connection limits on CONNECT.
+    then sendHopStatus stream ReservationRefused
     else do
       -- Create reservation. Per circuit-v2 spec, Reservation.expire is an
       -- absolute UTC Unix time in seconds, not a duration.

--- a/test/LibP2P/NAT/Relay/RelaySpec.hs
+++ b/test/LibP2P/NAT/Relay/RelaySpec.hs
@@ -99,7 +99,7 @@ spec = do
           arExpiration ar `shouldSatisfy` (<= nowSecs + duration + 5)
         Nothing -> expectationFailure "Expected stored reservation for peer"
 
-    it "rejects reservation when max reservations exceeded" $ do
+    it "should refuse reservation with RESERVATION_REFUSED when max reservations exceeded" $ do
       let config = defaultRelayConfig { rcMaxReservations = 0 }
       relayState <- newRelayState config
       (clientStream, serverStream) <- mkStreamPair
@@ -114,13 +114,11 @@ spec = do
       result <- readHopMessage clientStream maxRelayMessageSize
       case result of
         Right resp -> do
-          -- The request must be refused: not OK and no reservation granted.
-          -- NOTE: circuit-v2.md assigns RESERVATION_REFUSED (200) to a
-          -- reservation rejected for capacity; the current implementation
-          -- returns RESOURCE_LIMIT_EXCEEDED (201). The exact status code is
-          -- tracked in #180, so this test only asserts refusal.
-          hopStatus resp `shouldNotBe` Just RelayOK
-          hopStatus resp `shouldNotBe` Nothing
+          -- circuit-v2.md assigns RESERVATION_REFUSED (200) to a reservation
+          -- rejected for capacity ("e.g. because there are too many
+          -- reservations"); RESOURCE_LIMIT_EXCEEDED (201) is reserved for
+          -- relayed-connection limits.
+          hopStatus resp `shouldBe` Just ReservationRefused
           hopReservation resp `shouldBe` Nothing
         Left err -> expectationFailure $ "Read failed: " ++ err
       -- No reservation may be stored for the refused peer


### PR DESCRIPTION
## Summary

The relay returned `RESOURCE_LIMIT_EXCEEDED` (201) when the reservation cap was reached. Per [circuit-v2.md](https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md), `RESERVATION_REFUSED` (200) covers a reservation rejected for capacity ("e.g. because there are too many reservations"), while 201 is assigned to relayed-connection limits on CONNECT. go-libp2p clients branch on these two codes for retry policy, so this was a wire-visible interop divergence.

## Changes

- `handleReserve` now sends `ReservationRefused` (200) at the reservation cap (`src/LibP2P/NAT/Relay.hs`)
- The reservation-cap test now pins the status to `ReservationRefused`; it previously asserted only "refused, not OK" with a comment deferring the exact code to this issue (`test/LibP2P/NAT/Relay/RelaySpec.hs`)

## Status-code audit

Audited all other relay status usages against the spec table; no other mismatches:

- CONNECT at per-peer circuit limit → `RESOURCE_LIMIT_EXCEEDED` (201) — correct, this is the case 201 is for
- CONNECT without peer → `MALFORMED_MESSAGE` (400) — correct
- CONNECT with no/expired reservation → `NO_RESERVATION` (204) — correct
- Stop stream unreachable / target non-OK → `CONNECTION_FAILED` (203) — correct
- Non-RESERVE/CONNECT hop message → `UNEXPECTED_MESSAGE` (401) — correct

## Testing

TDD: pinned the test first (failed with `Just ResourceLimitExceeded`), then fixed. `cabal test` on GHC 9.10.3: 826 examples, 0 failures.

Closes #180