### PR TITLE
fix(yamux): bound accept backlog, reclaim dead streams, preserve GoAway code

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -148,6 +148,7 @@ test-suite libp2p-hs-test
     LibP2P.Yamux.StreamSpec
     LibP2P.Yamux.SessionSpec
     LibP2P.Yamux.StateMachineSpec
+    LibP2P.Yamux.LifecycleSpec
     LibP2P.Transport.TCPSpec
     LibP2P.Switch.ConnPoolSpec
     LibP2P.Switch.ConnectionLifecycleSpec

--- a/src/LibP2P/Yamux/Frame.hs
+++ b/src/LibP2P/Yamux/Frame.hs
@@ -7,6 +7,8 @@ module LibP2P.Yamux.Frame
   , Flags (..)
   , YamuxHeader (..)
   , GoAwayCode (..)
+  , goAwayCodeToWord32
+  , word32ToGoAwayCode
   , encodeHeader
   , decodeHeader
   , defaultFlags
@@ -48,6 +50,20 @@ data GoAwayCode
   | GoAwayProtocol  -- ^ 0x01: Protocol error
   | GoAwayInternal  -- ^ 0x02: Internal error
   deriving (Show, Eq)
+
+-- | Wire encoding of a GoAway code (carried in the Length field).
+goAwayCodeToWord32 :: GoAwayCode -> Word32
+goAwayCodeToWord32 GoAwayNormal = 0x00
+goAwayCodeToWord32 GoAwayProtocol = 0x01
+goAwayCodeToWord32 GoAwayInternal = 0x02
+
+-- | Decode a received GoAway code. The spec defines only 0x00-0x02;
+-- anything else is Nothing and the receiver decides how to treat it.
+word32ToGoAwayCode :: Word32 -> Maybe GoAwayCode
+word32ToGoAwayCode 0x00 = Just GoAwayNormal
+word32ToGoAwayCode 0x01 = Just GoAwayProtocol
+word32ToGoAwayCode 0x02 = Just GoAwayInternal
+word32ToGoAwayCode _ = Nothing
 
 -- | Frame flags (bitmask).
 data Flags = Flags

--- a/src/LibP2P/Yamux/Session.hs
+++ b/src/LibP2P/Yamux/Session.hs
@@ -16,6 +16,7 @@ module LibP2P.Yamux.Session
   , sendGoAway
   , recvLoop
   , sendLoop
+  , acceptBacklog
   ) where
 
 import Control.Concurrent.STM
@@ -25,6 +26,13 @@ import qualified Data.Map.Strict as Map
 import Data.Word (Word32)
 import LibP2P.Yamux.Frame
 import LibP2P.Yamux.Types
+import Numeric.Natural (Natural)
+
+-- | Maximum number of inbound streams buffered while the application
+-- is not accepting (go-yamux AcceptBacklog). The spec requires this
+-- buffer to be bounded to mitigate DoS; excess SYNs are reset.
+acceptBacklog :: Natural
+acceptBacklog = 256
 
 -- | Create a new Yamux session over a transport connection.
 -- Client uses odd stream IDs starting at 1, server uses even starting at 2.
@@ -35,10 +43,10 @@ newSession role writeFn readFn = do
         RoleServer -> 2
   nextId <- newTVarIO startId
   streams <- newTVarIO Map.empty
-  acceptCh <- newTQueueIO
+  acceptCh <- newTBQueueIO acceptBacklog
   sendCh <- newTQueueIO
   shutdown <- newTVarIO False
-  remoteGoAway <- newTVarIO False
+  remoteGoAway <- newTVarIO Nothing
   pings <- newTVarIO Map.empty
   nextPingId <- newTVarIO 1
   pure
@@ -61,17 +69,21 @@ closeSession :: YamuxSession -> IO ()
 closeSession sess = sendGoAway sess GoAwayNormal
 
 -- | Open a new outbound stream. Allocates the next stream ID and sends SYN.
--- Returns YamuxSessionShutdown if the session has sent or received GoAway.
+-- Returns YamuxSessionShutdown after a local GoAway, or YamuxGoAway with
+-- the received code after a remote GoAway.
 openStream :: YamuxSession -> IO (Either YamuxError YamuxStream)
 openStream sess = do
   -- Check shutdown state
-  canOpen <- atomically $ do
+  status <- atomically $ do
     shut <- readTVar (ysessShutdown sess)
     remote <- readTVar (ysessRemoteGoAway sess)
-    pure (not shut && not remote)
-  if not canOpen
-    then pure (Left YamuxSessionShutdown)
-    else do
+    pure $ case (shut, remote) of
+      (True, _) -> Left YamuxSessionShutdown
+      (False, Just code) -> Left (YamuxGoAway code)
+      (False, Nothing) -> Right ()
+  case status of
+    Left err -> pure (Left err)
+    Right () -> do
       -- Allocate stream ID (atomically increment by 2)
       sid <- atomically $ do
         nextId <- readTVar (ysessNextStreamId sess)
@@ -97,7 +109,7 @@ openStream sess = do
 -- Returns YamuxSessionShutdown if the session is shut down.
 acceptStream :: YamuxSession -> IO (Either YamuxError YamuxStream)
 acceptStream sess = do
-  stream <- atomically $ readTQueue (ysessAcceptCh sess)
+  stream <- atomically $ readTBQueue (ysessAcceptCh sess)
   -- Send ACK (WindowUpdate frame with ACK flag)
   let hdr =
         YamuxHeader
@@ -148,10 +160,7 @@ ping sess = do
 sendGoAway :: YamuxSession -> GoAwayCode -> IO ()
 sendGoAway sess code = do
   atomically $ writeTVar (ysessShutdown sess) True
-  let errCode = case code of
-        GoAwayNormal -> 0x00
-        GoAwayProtocol -> 0x01
-        GoAwayInternal -> 0x02
+  let errCode = goAwayCodeToWord32 code
   let hdr =
         YamuxHeader
           { yhVersion = 0
@@ -276,6 +285,9 @@ lookupStream sess sid = Map.lookup sid <$> readTVarIO (ysessStreams sess)
 
 -- | Validate and register an inbound SYN (parity + duplicate check).
 -- Returns False on protocol error; the caller sends GoAway and stops.
+-- When the accept backlog is full the SYN is rejected with RST instead
+-- of being buffered (spec.md, ACK backlog: the buffer MUST be bounded);
+-- that is not a protocol error, so the session stays alive.
 acceptInboundSYN :: YamuxSession -> Word32 -> IO Bool
 acceptInboundSYN sess sid = do
   valid <- atomically $ validateInboundSYN sess sid
@@ -284,9 +296,24 @@ acceptInboundSYN sess sid = do
     else do
       stream <- newStream sess sid StreamSYNReceived
       atomically $ do
-        modifyTVar' (ysessStreams sess) (Map.insert sid stream)
-        writeTQueue (ysessAcceptCh sess) stream
+        full <- isFullTBQueue (ysessAcceptCh sess)
+        if full
+          then writeTQueue (ysessSendCh sess) (rstHeader sid, BS.empty)
+          else do
+            modifyTVar' (ysessStreams sess) (Map.insert sid stream)
+            writeTBQueue (ysessAcceptCh sess) stream
       pure True
+
+-- | Data frame carrying only the RST flag for the given stream.
+rstHeader :: Word32 -> YamuxHeader
+rstHeader sid =
+  YamuxHeader
+    { yhVersion = 0
+    , yhType = FrameData
+    , yhFlags = defaultFlags {flagRST = True}
+    , yhStreamId = sid
+    , yhLength = 0
+    }
 
 -- | Reserve receive window for a declared Data-frame length before the
 -- payload is read off the transport. Returns False on a flow-control
@@ -336,16 +363,23 @@ applyRemoteFin sess sid = do
         StreamSYNSent -> writeTVar (ysState stream) StreamRemoteClose
         StreamSYNReceived -> writeTVar (ysState stream) StreamRemoteClose
         StreamEstablished -> writeTVar (ysState stream) StreamRemoteClose
-        StreamLocalClose -> writeTVar (ysState stream) StreamClosed
+        StreamLocalClose -> do
+          -- Both sides FIN'd: the stream is dead, reclaim its map slot
+          writeTVar (ysState stream) StreamClosed
+          modifyTVar' (ysessStreams sess) (Map.delete sid)
         _ -> pure ()
     Nothing -> pure ()
 
--- | Shared RST transition: any state -> Reset.
+-- | Shared RST transition: any state -> Reset. A reset stream is dead,
+-- so its map slot is reclaimed in the same transaction; the application
+-- still holds the handle and observes StreamReset through it.
 applyRemoteRst :: YamuxSession -> Word32 -> IO ()
 applyRemoteRst sess sid = do
   mStream <- lookupStream sess sid
   case mStream of
-    Just stream -> atomically $ writeTVar (ysState stream) StreamReset
+    Just stream -> atomically $ do
+      writeTVar (ysState stream) StreamReset
+      modifyTVar' (ysessStreams sess) (Map.delete sid)
     Nothing -> pure ()
 
 -- | Handle a Ping frame (StreamID must be 0).
@@ -375,10 +409,16 @@ handlePing sess hdr
   | otherwise = pure ()
 
 -- | Handle a GoAway frame (StreamID must be 0).
--- Parse error code and set ysessRemoteGoAway.
+-- Preserve the received error code so callers can distinguish a clean
+-- shutdown (0x00) from a protocol (0x01) or internal (0x02) error.
+-- A code outside the spec-defined range is itself a protocol violation
+-- and is recorded as GoAwayProtocol.
 handleGoAway :: YamuxSession -> YamuxHeader -> IO ()
-handleGoAway sess _hdr = do
-  atomically $ writeTVar (ysessRemoteGoAway sess) True
+handleGoAway sess hdr = do
+  let code = case word32ToGoAwayCode (yhLength hdr) of
+        Just c -> c
+        Nothing -> GoAwayProtocol
+  atomically $ writeTVar (ysessRemoteGoAway sess) (Just code)
 
 -- | Send loop: dequeues frames from ysessSendCh and writes to transport.
 sendLoop :: YamuxSession -> IO ()

--- a/src/LibP2P/Yamux/Stream.hs
+++ b/src/LibP2P/Yamux/Stream.hs
@@ -12,8 +12,15 @@ module LibP2P.Yamux.Stream
 import Control.Concurrent.STM
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
 import LibP2P.Yamux.Frame
 import LibP2P.Yamux.Types
+
+-- | Reclaim a dead stream's slot in the session map (STM so callers
+-- can combine it with the terminal state transition atomically).
+unregisterStream :: YamuxStream -> STM ()
+unregisterStream stream =
+  modifyTVar' (ysessStreams (ysSession stream)) (Map.delete (ysStreamId stream))
 
 -- | Write data to a stream. Blocks when send window is 0.
 -- Writable states: SYNSent (optimistic), Established, RemoteClose.
@@ -121,7 +128,9 @@ streamClose stream = do
         writeTVar (ysState stream) StreamLocalClose
         pure (Right ())
       StreamRemoteClose -> do
+        -- Both sides FIN'd: the stream is dead, reclaim its map slot
         writeTVar (ysState stream) StreamClosed
+        unregisterStream stream
         pure (Right ())
       StreamSYNSent -> do
         writeTVar (ysState stream) StreamLocalClose
@@ -151,7 +160,9 @@ streamClose stream = do
 -- | Reset the stream by sending RST flag.
 streamReset :: YamuxStream -> IO ()
 streamReset stream = do
-  atomically $ writeTVar (ysState stream) StreamReset
+  atomically $ do
+    writeTVar (ysState stream) StreamReset
+    unregisterStream stream
   -- Send RST frame
   let hdr =
         YamuxHeader

--- a/src/LibP2P/Yamux/Types.hs
+++ b/src/LibP2P/Yamux/Types.hs
@@ -12,7 +12,7 @@ module LibP2P.Yamux.Types
   , YamuxSession (..)
   ) where
 
-import Control.Concurrent.STM (TMVar, TQueue, TVar)
+import Control.Concurrent.STM (TBQueue, TMVar, TQueue, TVar)
 import Data.ByteString (ByteString)
 import qualified Data.Map.Strict as Map
 import Data.Word (Word32)
@@ -61,10 +61,10 @@ data YamuxSession = YamuxSession
   { ysessRole :: !SessionRole
   , ysessNextStreamId :: !(TVar Word32) -- ^ Next ID to allocate
   , ysessStreams :: !(TVar (Map.Map Word32 YamuxStream)) -- ^ Active streams
-  , ysessAcceptCh :: !(TQueue YamuxStream) -- ^ Inbound streams (max 256 pending)
+  , ysessAcceptCh :: !(TBQueue YamuxStream) -- ^ Inbound streams, bounded to acceptBacklog (256); excess SYNs are reset
   , ysessSendCh :: !(TQueue (YamuxHeader, ByteString)) -- ^ Outbound frame queue
   , ysessShutdown :: !(TVar Bool) -- ^ Local GoAway sent
-  , ysessRemoteGoAway :: !(TVar Bool) -- ^ Remote GoAway received
+  , ysessRemoteGoAway :: !(TVar (Maybe GoAwayCode)) -- ^ Code of the remote GoAway, if one was received
   , ysessPings :: !(TVar (Map.Map Word32 (TMVar ()))) -- ^ Pending ping responses
   , ysessNextPingId :: !(TVar Word32)
   , ysessWrite :: !(ByteString -> IO ()) -- ^ Underlying transport write

--- a/test/LibP2P/Yamux/HostilePeer.hs
+++ b/test/LibP2P/Yamux/HostilePeer.hs
@@ -17,6 +17,7 @@ module LibP2P.Yamux.HostilePeer
   , acceptWithin
   , awaitState
   , awaitTrue
+  , awaitRemoteGoAway
   ) where
 
 import Control.Concurrent.Async (withAsync)
@@ -103,3 +104,17 @@ awaitTrue var = do
   case result of
     Just () -> pure ()
     Nothing -> expectationFailure "expected TVar to become True within 1s"
+
+-- | Block until the session records a remote GoAway with the given
+-- code, failing after 1s.
+awaitRemoteGoAway :: YamuxSession -> GoAwayCode -> Expectation
+awaitRemoteGoAway sess expected = do
+  result <- timeout 1000000 $ atomically $ do
+    got <- readTVar (ysessRemoteGoAway sess)
+    check (got == Just expected)
+  case result of
+    Just () -> pure ()
+    Nothing -> do
+      actual <- readTVarIO (ysessRemoteGoAway sess)
+      expectationFailure $
+        "expected remote GoAway " <> show (Just expected) <> " but got " <> show actual

--- a/test/LibP2P/Yamux/LifecycleSpec.hs
+++ b/test/LibP2P/Yamux/LifecycleSpec.hs
@@ -1,0 +1,176 @@
+-- | Yamux session lifecycle defects (issue #164).
+--
+-- Covers the accept-backlog bound, terminal-state preservation across
+-- acceptStream, reclamation of closed/reset streams from the session
+-- map, and preservation of the received GoAway error code.
+module LibP2P.Yamux.LifecycleSpec (spec) where
+
+import Control.Concurrent.STM
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Data.Word (Word32)
+import LibP2P.Yamux.Frame
+import LibP2P.Yamux.HostilePeer
+import LibP2P.Yamux.Session
+import LibP2P.Yamux.Stream (streamClose, streamRead, streamReset)
+import LibP2P.Yamux.Types
+import Test.Hspec
+
+synF, finF, rstF :: Flags
+synF = defaultFlags {flagSYN = True}
+finF = defaultFlags {flagFIN = True}
+rstF = defaultFlags {flagRST = True}
+
+dataHdr :: Flags -> Word32 -> Word32 -> YamuxHeader
+dataHdr = YamuxHeader 0 FrameData
+
+pingHdr :: Word32 -> YamuxHeader
+pingHdr = YamuxHeader 0 FramePing synF 0
+
+-- | Round-trip a Ping through the session. recvLoop dispatches frames
+-- serially, so receiving the echo proves every frame injected before
+-- the Ping has been fully processed.
+pingFence :: HostilePeer -> Word32 -> Expectation
+pingFence hp opaque = do
+  injectFrame hp (pingHdr opaque) BS.empty
+  (hdr, _) <- expectFrame hp
+  yhType hdr `shouldBe` FramePing
+  yhLength hdr `shouldBe` opaque
+
+-- | Open an inbound stream on a server-role session via a Data SYN and
+-- accept it, consuming the WindowUpdate ACK the session emits.
+openAccepted :: HostilePeer -> IO YamuxStream
+openAccepted hp = do
+  injectFrame hp (dataHdr synF 1 0) BS.empty
+  stream <- acceptWithin hp
+  (ackHdr, _) <- expectFrame hp
+  yhType ackHdr `shouldBe` FrameWindowUpdate
+  flagACK (yhFlags ackHdr) `shouldBe` True
+  pure stream
+
+streamMapKeys :: HostilePeer -> IO [Word32]
+streamMapKeys hp = Map.keys <$> readTVarIO (ysessStreams (hpSession hp))
+
+spec :: Spec
+spec = do
+  describe "Accept backlog bound (spec.md: buffer MUST be bounded)" $ do
+    it "resets the 257th unaccepted inbound SYN and keeps the session alive" $
+      withHostilePeer RoleServer $ \hp -> do
+        -- 256 SYNs fill the backlog (client parity: odd IDs 1..511)
+        mapM_
+          (\sid -> injectFrame hp (dataHdr synF sid 0) BS.empty)
+          [1, 3 .. 511]
+        -- The 257th SYN must be rejected with RST, not buffered
+        injectFrame hp (dataHdr synF 513 0) BS.empty
+        (rstHdr, _) <- expectFrame hp
+        flagRST (yhFlags rstHdr) `shouldBe` True
+        yhStreamId rstHdr `shouldBe` 513
+        -- Session survives: not a protocol error, no GoAway
+        pingFence hp 1
+        shut <- readTVarIO (ysessShutdown (hpSession hp))
+        shut `shouldBe` False
+        -- The rejected stream is not registered
+        keys <- streamMapKeys hp
+        length keys `shouldBe` 256
+        keys `shouldNotContain` [513]
+
+    it "frees a backlog slot once a stream is accepted" $
+      withHostilePeer RoleServer $ \hp -> do
+        mapM_
+          (\sid -> injectFrame hp (dataHdr synF sid 0) BS.empty)
+          [1, 3 .. 511]
+        stream <- acceptWithin hp
+        ysStreamId stream `shouldBe` 1
+        (ackHdr, _) <- expectFrame hp
+        flagACK (yhFlags ackHdr) `shouldBe` True
+        -- A new SYN now fits again instead of being reset
+        injectFrame hp (dataHdr synF 513 0) BS.empty
+        pingFence hp 2
+        keys <- streamMapKeys hp
+        keys `shouldContain` [513]
+
+  describe "Terminal states survive acceptStream (issue #164.2)" $ do
+    it "returns a stream still in Reset when RST arrived before accept" $
+      withHostilePeer RoleServer $ \hp -> do
+        injectFrame hp (dataHdr synF 1 0) BS.empty
+        injectFrame hp (dataHdr rstF 1 0) BS.empty
+        pingFence hp 3 -- both frames dispatched before we accept
+        stream <- acceptWithin hp
+        st <- readTVarIO (ysState stream)
+        st `shouldBe` StreamReset
+
+  describe "Stream reclamation (issue #164.5)" $ do
+    it "removes a stream from the session map on remote RST" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        injectFrame hp (dataHdr rstF 1 0) BS.empty
+        awaitState stream StreamReset
+        keys <- streamMapKeys hp
+        keys `shouldNotContain` [1]
+
+    it "removes a stream from the session map on local reset" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        streamReset stream
+        keys <- streamMapKeys hp
+        keys `shouldNotContain` [1]
+
+    it "removes a stream once local FIN is followed by remote FIN" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        Right () <- streamClose stream -- Established -> LocalClose
+        (finOut, _) <- expectFrame hp
+        flagFIN (yhFlags finOut) `shouldBe` True
+        injectFrame hp (dataHdr finF 1 0) BS.empty -- LocalClose -> Closed
+        awaitState stream StreamClosed
+        keys <- streamMapKeys hp
+        keys `shouldNotContain` [1]
+
+    it "removes a stream once remote FIN is followed by local close" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        injectFrame hp (dataHdr finF 1 0) BS.empty -- Established -> RemoteClose
+        awaitState stream StreamRemoteClose
+        Right () <- streamClose stream -- RemoteClose -> Closed
+        st <- readTVarIO (ysState stream)
+        st `shouldBe` StreamClosed
+        keys <- streamMapKeys hp
+        keys `shouldNotContain` [1]
+
+    it "keeps a reclaimed stream's handle observable as Reset" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        injectFrame hp (dataHdr rstF 1 0) BS.empty
+        awaitState stream StreamReset
+        -- The map slot is gone, but the application-held handle still
+        -- reports the reset instead of hanging
+        result <- streamRead stream
+        result `shouldBe` Left YamuxStreamReset
+
+    it "keeps half-closed streams registered" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        injectFrame hp (dataHdr finF 1 0) BS.empty
+        awaitState stream StreamRemoteClose
+        keys <- streamMapKeys hp
+        keys `shouldContain` [1]
+
+  describe "GoAway code preservation (issue #164.3)" $ do
+    it "records GoAwayInternal (0x02) and surfaces it from openStream" $
+      withHostilePeer RoleClient $ \hp -> do
+        injectFrame hp (YamuxHeader 0 FrameGoAway defaultFlags 0 0x02) BS.empty
+        awaitRemoteGoAway (hpSession hp) GoAwayInternal
+        result <- openStream (hpSession hp)
+        case result of
+          Left err -> err `shouldBe` YamuxGoAway GoAwayInternal
+          Right _ -> expectationFailure "openStream succeeded after remote GoAway"
+
+    it "records GoAwayNormal (0x00) so a clean shutdown is distinguishable" $
+      withHostilePeer RoleClient $ \hp -> do
+        injectFrame hp (YamuxHeader 0 FrameGoAway defaultFlags 0 0x00) BS.empty
+        awaitRemoteGoAway (hpSession hp) GoAwayNormal
+
+    it "records a spec-undefined code as GoAwayProtocol" $
+      withHostilePeer RoleClient $ \hp -> do
+        injectFrame hp (YamuxHeader 0 FrameGoAway defaultFlags 0 0x7F) BS.empty
+        awaitRemoteGoAway (hpSession hp) GoAwayProtocol

--- a/test/LibP2P/Yamux/SessionSpec.hs
+++ b/test/LibP2P/Yamux/SessionSpec.hs
@@ -221,14 +221,14 @@ spec = do
         result <- openStream client
         shouldBeLeft YamuxSessionShutdown result
 
-    it "openStream fails after remote GoAway received" $ do
+    it "openStream fails after remote GoAway received, surfacing the code" $ do
       withSessionPair $ \(client, server) -> do
         sendGoAway server GoAwayNormal
         atomically $ do
           got <- readTVar (ysessRemoteGoAway client)
-          check got
+          check (got == Just GoAwayNormal)
         result <- openStream client
-        shouldBeLeft YamuxSessionShutdown result
+        shouldBeLeft (YamuxGoAway GoAwayNormal) result
 
     it "existing streams continue after GoAway" $ do
       withSessionPair $ \(client, server) -> do

--- a/test/LibP2P/Yamux/StateMachineSpec.hs
+++ b/test/LibP2P/Yamux/StateMachineSpec.hs
@@ -189,13 +189,13 @@ spec = do
         awaitTrue (ysessShutdown (hpSession hp))
 
   describe "GoAway from the peer" $ do
-    it "raw GoAway(0x01) prevents new outbound streams" $
+    it "raw GoAway(0x01) prevents new outbound streams and surfaces the code" $
       withHostilePeer RoleClient $ \hp -> do
         injectFrame hp (YamuxHeader 0 FrameGoAway noF 0 0x01) BS.empty
-        awaitTrue (ysessRemoteGoAway (hpSession hp))
+        awaitRemoteGoAway (hpSession hp) GoAwayProtocol
         result <- openStream (hpSession hp)
         case result of
-          Left err -> err `shouldBe` YamuxSessionShutdown
+          Left err -> err `shouldBe` YamuxGoAway GoAwayProtocol
           Right _ -> expectationFailure "openStream succeeded after remote GoAway"
 
   describe "Window accounting" $ do


### PR DESCRIPTION
Fixes the session-lifecycle defect cluster from #164. Each sub-defect was re-verified against current main (post #185/#196/#201) before changing anything.

## Per-defect status

| Sub-defect | Status on main | Change |
|---|---|---|
| 1. Unbounded accept backlog | **Live** — `ysessAcceptCh` was a plain `TQueue` | Now a `TBQueue` bounded to `acceptBacklog = 256` (go-yamux `AcceptBacklog`). A SYN arriving with a full backlog is rejected with RST and never registered; the session stays alive. Accepting a stream frees the slot. |
| 2. Terminal states overwritten by `acceptStream` | **Already fixed** by #185 (transition is conditional on `StreamSYNReceived`) | Regression test added: RST before accept comes back as `StreamReset`, not `Established`. |
| 3. GoAway code discarded | **Live** — `handleGoAway` dropped `yhLength` | `ysessRemoteGoAway` is now `TVar (Maybe GoAwayCode)`; the received code is decoded (spec-undefined codes recorded as `GoAwayProtocol`) and `openStream` surfaces it as `YamuxGoAway code`, so callers distinguish clean shutdown (0x00) from protocol/internal errors. |
| 4. Streams never freed | **Live** — no `Map.delete` on `ysessStreams` anywhere | Streams are deleted from the session map in the same STM transaction as their transition to `Closed` (both FINs, either order) or `Reset` (remote RST, local `streamReset`). Half-closed streams stay registered; application-held handles still observe the terminal state. |

## Tests

New `test/LibP2P/Yamux/LifecycleSpec.hs` drives every case through the hostile-peer harness with raw frame injection: 257-SYN flood gets RST on the 257th with the session surviving, backlog slot reuse after accept, reclamation on all four terminal paths, half-close retention, and GoAway codes 0x00/0x02/undefined. Existing `StateMachineSpec`/`SessionSpec` GoAway expectations updated for the surfaced code.

`cabal build` clean, `cabal test`: 838 examples, 0 failures (GHC 9.10.3).

Closes #164