### PR TITLE
fix(crypto): canonical protobuf decoding, RFC 6979 nonces, validated secp256k1 point decompression

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -196,6 +196,8 @@ test-suite libp2p-hs-test
     stm        >= 2.4 && < 2.6,
     containers >= 0.6 && < 0.8,
     crypton    >= 1.0  && < 1.1,
+    crypton-asn1-encoding >= 0.9 && < 0.11,
+    crypton-asn1-types >= 0.4 && < 0.5,
     ppad-base58 >= 0.2 && < 0.3,
     hspec      >= 2.11 && < 2.12,
     QuickCheck >= 2.14 && < 2.16

--- a/src/LibP2P/Crypto/ECDSA.hs
+++ b/src/LibP2P/Crypto/ECDSA.hs
@@ -5,17 +5,19 @@
 -- - Private key: DER-encoded RFC 5915 ECPrivateKey (SEC1), with the named
 --   curve parameters and the public key included, as emitted by Go's
 --   x509.MarshalECPrivateKey.
--- - Signatures: ECDSA over SHA-256, DER-encoded (SEQUENCE { r, s }).
+-- - Signatures: ECDSA over SHA-256 with deterministic nonces (RFC 6979),
+--   DER-encoded (SEQUENCE { r, s }).
 --
 -- Operates on raw 'ByteString' so this module has no dependency on
 -- "LibP2P.Crypto.Key".
 module LibP2P.Crypto.ECDSA
   ( generate
-  , signIO
+  , sign
   , verify
   , derivePublicKey
   ) where
 
+import Crypto.Hash (Digest, hashWith)
 import Crypto.Hash.Algorithms (SHA256 (..))
 import Crypto.Number.Serialize (i2ospOf_, os2ip)
 import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
@@ -65,15 +67,16 @@ randomScalar = do
   if d >= 1 && d < curveOrder then pure d else randomScalar
 
 -- | Sign a message with a SEC1-DER private key (ECDSA/SHA-256, DER output).
--- Runs in IO because ECDSA signing requires a random nonce.
-signIO :: ByteString -> ByteString -> IO (Either String ByteString)
-signIO privDer msg =
-  case decodePrivateKey privDer of
-    Left err -> pure (Left err)
-    Right d -> do
-      let priv = ECDSA.PrivateKey curve d
-      sig <- ECDSA.sign priv SHA256 msg
-      pure (Right (encodeSignature sig))
+-- Nonces are deterministic per RFC 6979, so signing is pure: the same key
+-- and message always produce the same signature.
+sign :: ByteString -> ByteString -> Either String ByteString
+sign privDer msg = do
+  d <- decodePrivateKey privDer
+  let priv = ECDSA.PrivateKey curve d
+      digest = hashWith SHA256 msg :: Digest SHA256
+      sig = ECDSA.deterministicNonce SHA256 priv digest $ \k ->
+        ECDSA.signDigestWith k priv digest
+  pure (encodeSignature sig)
 
 -- | Derive the SPKI-DER public key from a SEC1-DER private key.
 derivePublicKey :: ByteString -> Either String ByteString

--- a/src/LibP2P/Crypto/Key.hs
+++ b/src/LibP2P/Crypto/Key.hs
@@ -55,10 +55,10 @@ publicKey = kpPublic
 
 -- | Sign a message with a private key.
 --
--- Ed25519 and RSA signing are deterministic and therefore pure. secp256k1 (ECDSA)
--- requires a random nonce, so its signing lives in IO
--- ('LibP2P.Crypto.Secp256k1.signIO'); local peer identities in this
--- implementation are Ed25519. Returns Left on invalid key bytes.
+-- Signing is deterministic (and therefore pure) for every key type:
+-- Ed25519 and RSA (PKCS#1 v1.5) are deterministic by construction, and
+-- secp256k1/ECDSA use RFC 6979 deterministic nonces. Returns Left on
+-- invalid key bytes.
 sign :: PrivateKey -> ByteString -> Either String ByteString
 sign (PrivateKey Ed25519 skRaw) msg
   | BS.length skRaw /= 64 =
@@ -71,10 +71,8 @@ sign (PrivateKey Ed25519 skRaw) msg
               sig = Ed.sign sk pk msg
            in Right (convert sig)
 sign (PrivateKey RSA skRaw) msg = RSA.sign skRaw msg
-sign (PrivateKey Secp256k1 _) _ =
-  Left "sign: secp256k1 signing runs in IO (LibP2P.Crypto.Secp256k1.signIO)"
-sign (PrivateKey ECDSA _) _ =
-  Left "sign: ECDSA signing runs in IO (LibP2P.Crypto.ECDSA.signIO)"
+sign (PrivateKey Secp256k1 skRaw) msg = Secp256k1.sign skRaw msg
+sign (PrivateKey ECDSA skRaw) msg = ECDSA.sign skRaw msg
 
 -- | Verify a signature against a public key and message.
 -- Supports every libp2p key type so remote peers of any type can be authenticated.

--- a/src/LibP2P/Crypto/Protobuf.hs
+++ b/src/LibP2P/Crypto/Protobuf.hs
@@ -85,11 +85,13 @@ decodeKeyMessage ctx bs = do
   (_, rest3) <- takeExpectedByte 0x12 rest2 "expected tag 0x12 for field 2"
   (dataLen, rest4) <- decodeUvarint rest3
   let len = fromIntegral dataLen :: Int
-  if BS.length rest4 < len
-    then Left $ ctx <> ": not enough bytes for key data"
-    else
-      let keyData = BS.take len rest4
-       in Right (kt, keyData)
+  case compare (BS.length rest4) len of
+    LT -> Left $ ctx <> ": not enough bytes for key data"
+    -- The peer-ids spec requires canonical serialization (Peer IDs are
+    -- derived from these bytes); trailing data would give one key several
+    -- byte representations, so reject it.
+    GT -> Left $ ctx <> ": trailing bytes after key data (non-canonical encoding)"
+    EQ -> Right (kt, rest4)
   where
     takeExpectedByte :: Word8 -> ByteString -> String -> Either String (Word8, ByteString)
     takeExpectedByte expected input msg

--- a/src/LibP2P/Crypto/Secp256k1.hs
+++ b/src/LibP2P/Crypto/Secp256k1.hs
@@ -3,17 +3,20 @@
 -- Wire formats follow the libp2p peer-ids spec:
 -- - Public key: 33-byte SEC1 compressed point (0x02/0x03 prefix + 32-byte X).
 -- - Private key: 32-byte big-endian scalar.
--- - Signatures: ECDSA over SHA-256, DER-encoded (SEQUENCE { r, s }).
+-- - Signatures: ECDSA over SHA-256 with deterministic nonces (RFC 6979),
+--   DER-encoded (SEQUENCE { r, s }).
 --
 -- Operates on raw 'ByteString' so this module has no dependency on
 -- "LibP2P.Crypto.Key".
 module LibP2P.Crypto.Secp256k1
   ( generate
-  , signIO
+  , sign
   , verify
   , derivePublicKey
+  , decodePoint
   ) where
 
+import Crypto.Hash (Digest, hashWith)
 import Crypto.Hash.Algorithms (SHA256 (..))
 import Crypto.Number.ModArithmetic (expFast)
 import Crypto.Number.Serialize (i2ospOf_, os2ip)
@@ -65,14 +68,17 @@ randomScalar = do
   if d >= 1 && d < curveOrder then pure d else randomScalar
 
 -- | Sign a message with a 32-byte private scalar (ECDSA/SHA-256, DER output).
--- Runs in IO because ECDSA signing requires a random nonce.
-signIO :: ByteString -> ByteString -> IO (Either String ByteString)
-signIO privRaw msg
-  | BS.length privRaw /= 32 = pure (Left "Secp256k1.signIO: private key must be 32 bytes")
-  | otherwise = do
+-- Nonces are deterministic per RFC 6979, so signing is pure: the same key
+-- and message always produce the same signature.
+sign :: ByteString -> ByteString -> Either String ByteString
+sign privRaw msg
+  | BS.length privRaw /= 32 = Left "Secp256k1.sign: private key must be 32 bytes"
+  | otherwise =
       let priv = ECDSA.PrivateKey curve (os2ip privRaw)
-      sig <- ECDSA.sign priv SHA256 msg
-      pure (Right (encodeSignature sig))
+          digest = hashWith SHA256 msg :: Digest SHA256
+          sig = ECDSA.deterministicNonce SHA256 priv digest $ \k ->
+            ECDSA.signDigestWith k priv digest
+       in Right (encodeSignature sig)
 
 -- | Derive the 33-byte compressed public key from a 32-byte private scalar.
 derivePublicKey :: ByteString -> Either String ByteString
@@ -88,27 +94,37 @@ verify pubRaw msg sigDer =
     _ -> False
 
 -- | Encode a curve point as a 33-byte SEC1 compressed public key.
+-- The point at infinity is SEC1-encoded as a single zero byte; it never
+-- arises from a valid private scalar.
 encodePoint :: Point -> ByteString
-encodePoint PointO = BS.replicate 33 0
+encodePoint PointO = BS.singleton 0x00
 encodePoint (Point x y) =
   let prefix = if even y then 0x02 else 0x03
    in BS.cons prefix (i2ospOf_ 32 x)
 
--- | Decode a 33-byte SEC1 compressed public key into a curve point.
+-- | Decode a 33-byte SEC1 compressed public key into a curve point,
+-- rejecting inputs that do not name a point on the curve: X coordinates
+-- outside the field and X coordinates for which x^3 + ax + b is a
+-- quadratic non-residue (the candidate square root then fails the curve
+-- equation). The point at infinity is not decodable (its SEC1 form is a
+-- single zero byte, rejected by the length check).
 decodePoint :: ByteString -> Either String Point
 decodePoint bs
   | BS.length bs /= 33 = Left "Secp256k1.decodePoint: expected 33 bytes"
   | prefix /= 0x02 && prefix /= 0x03 = Left "Secp256k1.decodePoint: bad prefix"
-  | otherwise =
-      let (p, a, b) = curveParams
-          x = os2ip (BS.drop 1 bs)
-          rhs = (x * x * x + a * x + b) `mod` p
-          y0 = expFast rhs ((p + 1) `div` 4) p
-          wantOdd = prefix == 0x03
-          y = if (odd y0) == wantOdd then y0 else p - y0
-       in Right (Point x y)
+  | x >= p = Left "Secp256k1.decodePoint: X coordinate out of range"
+  | (y0 * y0) `mod` p /= rhs = Left "Secp256k1.decodePoint: point is not on the curve"
+  | otherwise = Right (Point x y)
   where
     prefix = BS.head bs
+    (p, a, b) = curveParams
+    x = os2ip (BS.drop 1 bs)
+    rhs = (x * x * x + a * x + b) `mod` p
+    -- p = 3 (mod 4), so a square root of rhs (if one exists) is
+    -- rhs^((p+1)/4) mod p.
+    y0 = expFast rhs ((p + 1) `div` 4) p
+    wantOdd = prefix == 0x03
+    y = if odd y0 == wantOdd then y0 else p - y0
 
 -- | Encode an ECDSA signature as DER SEQUENCE { r, s }.
 encodeSignature :: ECDSA.Signature -> ByteString

--- a/src/LibP2P/Crypto/SignedEnvelope.hs
+++ b/src/LibP2P/Crypto/SignedEnvelope.hs
@@ -40,7 +40,7 @@ data SignedEnvelope = SignedEnvelope
   , seDomain      :: !ByteString    -- ^ Domain separation string
   , sePayloadType :: !ByteString    -- ^ Payload type (multicodec bytes)
   , sePayload     :: !ByteString    -- ^ Payload bytes
-  , seSignature   :: !ByteString    -- ^ Ed25519 signature
+  , seSignature   :: !ByteString    -- ^ Signature over the signing content
   } deriving (Show, Eq)
 
 -- | Build the content that gets signed (RFC 0002).

--- a/test/LibP2P/Crypto/ECDSASpec.hs
+++ b/test/LibP2P/Crypto/ECDSASpec.hs
@@ -1,5 +1,10 @@
 module LibP2P.Crypto.ECDSASpec (spec) where
 
+import Crypto.Number.Serialize (i2ospOf_)
+import Data.ASN1.BinaryEncoding (DER (..))
+import Data.ASN1.BitArray (toBitArray)
+import Data.ASN1.Encoding (decodeASN1', encodeASN1')
+import Data.ASN1.Types (ASN1 (..), ASN1Class (..), ASN1ConstructionType (..))
 import qualified Data.ByteString as BS
 import qualified LibP2P.Crypto.ECDSA as ECDSA
 import LibP2P.Crypto.Key
@@ -32,9 +37,48 @@ spec = do
     it "signs and verifies a message" $ do
       kp <- generateECDSAKeyPair
       let msg = "libp2p ecdsa identity"
-      signed <- ECDSA.signIO (skBytes (kpPrivate kp)) msg
-      case signed of
+      case ECDSA.sign (skBytes (kpPrivate kp)) msg of
         Left err -> expectationFailure err
         Right sig -> do
           verify (kpPublic kp) msg sig `shouldBe` True
           verify (kpPublic kp) "tampered" sig `shouldBe` False
+
+    it "signs deterministically (same key and message yield identical signatures)" $ do
+      kp <- generateECDSAKeyPair
+      let msg = "deterministic nonce"
+          sk = skBytes (kpPrivate kp)
+      ECDSA.sign sk msg `shouldBe` ECDSA.sign sk msg
+
+    it "uses RFC 6979 deterministic nonces (A.2.5 P-256/SHA-256 'sample' vector)" $ do
+      -- RFC 6979 appendix A.2.5, message "sample", SHA-256.
+      let d = 0xC9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721
+          ux = 0x60FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6
+          uy = 0x7903FE1008B8BC99A41AE9E95628BC64F2F1B20C2D7E9F5177A3C294D4462299
+          rExpected = 0xEFD48B2AACB6A8FD1140DD9CD45E81D69D2C877B56AAF991C34D0EA84EAF3716
+          sExpected = 0xF7CB1C942D657C41D436C7A1B6E29F65F3E900DBB9AFF4064DC4AB2F843ACDA8
+          n = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
+      case ECDSA.sign (rfc5915Der d ux uy) "sample" of
+        Left err -> expectationFailure err
+        Right sigDer -> case decodeASN1' DER sigDer of
+          Right [Start Sequence, IntVal r, IntVal s, End Sequence] -> do
+            r `shouldBe` rExpected
+            -- crypton normalizes signatures to the low-s form.
+            (s == sExpected || s == n - sExpected) `shouldBe` True
+          other -> expectationFailure ("unexpected signature structure: " <> show other)
+
+-- | Build an RFC 5915 ECPrivateKey DER for a P-256 scalar and public point.
+rfc5915Der :: Integer -> Integer -> Integer -> BS.ByteString
+rfc5915Der d ux uy =
+  encodeASN1'
+    DER
+    [ Start Sequence
+    , IntVal 1
+    , OctetString (i2ospOf_ 32 d)
+    , Start (Container Context 0)
+    , OID [1, 2, 840, 10045, 3, 1, 7]
+    , End (Container Context 0)
+    , Start (Container Context 1)
+    , BitString (toBitArray (BS.cons 0x04 (i2ospOf_ 32 ux <> i2ospOf_ 32 uy)) 0)
+    , End (Container Context 1)
+    , End Sequence
+    ]

--- a/test/LibP2P/Crypto/KeyImportSpec.hs
+++ b/test/LibP2P/Crypto/KeyImportSpec.hs
@@ -58,8 +58,7 @@ spec = describe "private key import (peer-ids spec test vectors)" $ do
     it "signs with the imported DER private key; the spec public key verifies" $
       withImported ecdsaPrivHex $ \kp -> do
         let msg = "cross-implementation ecdsa" :: ByteString
-        signed <- ECDSA.signIO (skBytes (kpPrivate kp)) msg
-        case signed of
+        case ECDSA.sign (skBytes (kpPrivate kp)) msg of
           Left err -> expectationFailure err
           Right sig -> verifyWithSpecPub ecdsaPubHex msg sig
 
@@ -89,8 +88,7 @@ spec = describe "private key import (peer-ids spec test vectors)" $ do
     it "signs with the imported private key; the spec public key verifies" $
       withImported secp256k1PrivHex $ \kp -> do
         let msg = "cross-implementation secp256k1" :: ByteString
-        signed <- Secp256k1.signIO (skBytes (kpPrivate kp)) msg
-        case signed of
+        case Secp256k1.sign (skBytes (kpPrivate kp)) msg of
           Left err -> expectationFailure err
           Right sig -> verifyWithSpecPub secp256k1PubHex msg sig
 

--- a/test/LibP2P/Crypto/PeerIdSpec.hs
+++ b/test/LibP2P/Crypto/PeerIdSpec.hs
@@ -44,6 +44,26 @@ spec = do
       let pk = PublicKey Ed25519 rawPubKey
       decodePublicKey (encodePublicKey pk) `shouldBe` Right pk
 
+  describe "Protobuf canonical decoding" $ do
+    it "rejects trailing bytes after the PublicKey message" $ do
+      -- The peer-ids spec requires canonical serialization; accepting
+      -- trailing bytes would give one key multiple byte representations.
+      let pk = PublicKey Ed25519 (BS.replicate 32 0xCC)
+          canonical = encodePublicKey pk
+          padded = canonical <> BS.pack [0xde, 0xad, 0xbe, 0xef]
+      decodePublicKey canonical `shouldBe` Right pk
+      decodePublicKey padded `shouldSatisfy` isLeft
+
+    it "rejects trailing bytes after the PrivateKey message" $ do
+      let sk = PrivateKey Ed25519 (BS.replicate 64 0xDD)
+          padded = encodePrivateKey sk <> BS.singleton 0x00
+      isLeft (decodePrivateKey padded) `shouldBe` True
+
+    it "rejects a non-minimal varint in the key type field" $ do
+      -- 0x81 0x00 is a two-byte encoding of 1 (Ed25519); minimal is 0x01.
+      let bs = BS.pack ([0x08, 0x81, 0x00, 0x12, 0x20] <> replicate 32 0xEE)
+      decodePublicKey bs `shouldSatisfy` isLeft
+
   describe "PeerId derivation" $ do
     it "Ed25519 pubkey (36 bytes serialized) uses identity multihash" $ do
       -- From docs: 36 ≤ 42, so identity multihash:

--- a/test/LibP2P/Crypto/Secp256k1Spec.hs
+++ b/test/LibP2P/Crypto/Secp256k1Spec.hs
@@ -1,6 +1,11 @@
 module LibP2P.Crypto.Secp256k1Spec (spec) where
 
+import Crypto.Number.Serialize (i2ospOf_)
+import Data.ASN1.BinaryEncoding (DER (..))
+import Data.ASN1.Encoding (decodeASN1')
+import Data.ASN1.Types (ASN1 (..), ASN1ConstructionType (..))
 import qualified Data.ByteString as BS
+import Data.Either (isLeft)
 import LibP2P.Crypto.Key
 import LibP2P.Crypto.PeerId
 import LibP2P.Crypto.Protobuf
@@ -35,9 +40,50 @@ spec = do
     it "signs and verifies a message" $ do
       kp <- generateSecp256k1KeyPair
       let msg = "libp2p secp256k1 identity"
-      signed <- Secp256k1.signIO (skBytes (kpPrivate kp)) msg
-      case signed of
+      case Secp256k1.sign (skBytes (kpPrivate kp)) msg of
         Left err -> expectationFailure err
         Right sig -> do
           verify (kpPublic kp) msg sig `shouldBe` True
           verify (kpPublic kp) "tampered" sig `shouldBe` False
+
+    it "signs deterministically (same key and message yield identical signatures)" $ do
+      kp <- generateSecp256k1KeyPair
+      let msg = "deterministic nonce"
+          sk = skBytes (kpPrivate kp)
+      Secp256k1.sign sk msg `shouldBe` Secp256k1.sign sk msg
+
+    it "uses RFC 6979 deterministic nonces (secp256k1/SHA-256 known vector)" $ do
+      -- Well-known RFC 6979 secp256k1 vector: d = 1, message "Satoshi Nakamoto".
+      let rExpected = 0x934B1EA10A4B3C1757E2B0C017D0B6143CE3C9A7E6A4A49860D7A6AB210EE3D8
+          sExpected = 0xDBBD3162D46E9F9BEF7FEB87C16DC13B4F6568A87F4E83F728E2443BA586675C
+          n = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+      case Secp256k1.sign (i2ospOf_ 32 (1 :: Integer)) "Satoshi Nakamoto" of
+        Left err -> expectationFailure err
+        Right sigDer -> case decodeASN1' DER sigDer of
+          Right [Start Sequence, IntVal r, IntVal s, End Sequence] -> do
+            r `shouldBe` rExpected
+            -- crypton normalizes signatures to the low-s form.
+            (s == sExpected || s == n - sExpected) `shouldBe` True
+          other -> expectationFailure ("unexpected signature structure: " <> show other)
+
+  describe "secp256k1 point decompression" $ do
+    it "decodes a generated public key to a curve point" $ do
+      kp <- generateSecp256k1KeyPair
+      case Secp256k1.decodePoint (pkBytes (publicKey kp)) of
+        Left err -> expectationFailure err
+        Right _ -> pure ()
+
+    it "rejects a compressed point whose X is not on the curve" $ do
+      -- x = 5: x^3 + 7 is a quadratic non-residue mod p, so no point
+      -- with this X coordinate exists on secp256k1.
+      let bad = BS.cons 0x02 (i2ospOf_ 32 (5 :: Integer))
+      isLeft (Secp256k1.decodePoint bad) `shouldBe` True
+
+    it "rejects a compressed point with X outside the field" $ do
+      let pField = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
+          bad = BS.cons 0x02 (i2ospOf_ 32 (pField :: Integer))
+      isLeft (Secp256k1.decodePoint bad) `shouldBe` True
+
+    it "rejects a point with a bad SEC1 prefix" $ do
+      let bad = BS.cons 0x04 (BS.replicate 32 0x01)
+      isLeft (Secp256k1.decodePoint bad) `shouldBe` True


### PR DESCRIPTION
Fixes the remaining crypto-layer deviations from issue #162, verified against current main (post #193/#204).

## Per-defect status

**1. Non-canonical protobuf accepted** — fixed. `decodeKeyMessage` now rejects trailing bytes after the Data field, so each key has exactly one accepted byte representation. The non-minimal-varint half was already fixed in the shared varint decoder; a regression test pins it for the key type field. Field order and duplicate fields were already structurally rejected.

**2. Random ECDSA/secp256k1 nonces** — fixed. Both curves now sign with RFC 6979 deterministic nonces (crypton `deterministicNonce` + `signDigestWith`). Signing became pure, so `signIO` is gone and `Key.sign` handles all four key types — as a side effect, `SignedEnvelope.createEnvelope` now works with secp256k1/ECDSA keys too (issue item 4). Pinned against known-answer vectors: RFC 6979 A.2.5 P-256 "sample" and the well-known secp256k1 d=1 "Satoshi Nakamoto" vector (accepting crypton's low-s normalization).

**3. Unvalidated secp256k1 point decompression** — fixed. `decodePoint` rejects X coordinates outside the field and X values whose curve RHS is a quadratic non-residue (candidate root checked against the curve equation); it is now exported and tested. `encodePoint PointO` emits the SEC1 single-byte infinity encoding instead of 33 zero bytes. P-256 needed no change: `Data.X509.EC.unserializePoint` already runs `isPointValid` and rejects compressed input.

## Tests

TDD: new failing tests first, then the fixes. 837 examples, 0 failures with GHC 9.10.3 (`cabal test`). New coverage: trailing-byte rejection for PublicKey/PrivateKey, non-minimal key-type varint rejection, deterministic-signature equality, two RFC 6979 known-answer vectors, and four point-decompression cases.

Closes #162