### PR TITLE
fix(noise): decode payload fields in any order and tolerate empty transport messages

### DIFF
--- a/src/LibP2P/Noise/Handshake.hs
+++ b/src/LibP2P/Noise/Handshake.hs
@@ -13,7 +13,6 @@ module LibP2P.Noise.Handshake
   , encodeNoisePayload
   , decodeNoisePayload
   , buildHandshakePayload
-  , validateHandshakePayload
     -- * Static key signing
   , signStaticKey
   , verifyStaticKey
@@ -52,10 +51,11 @@ import qualified Crypto.Noise.DH as DH
 import Crypto.Noise.DH.Curve25519 (Curve25519)
 import Crypto.Noise.HandshakePatterns (noiseXX)
 import Crypto.Noise.Hash.SHA256 (SHA256)
+import Data.Bits (shiftR, (.&.))
 import Data.ByteArray (ScrubbedBytes)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import Data.Word (Word8)
+import Data.Word (Word64)
 import LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 import LibP2P.Crypto.Key
   ( KeyPair (..)
@@ -107,18 +107,12 @@ verifyStaticKey pk noiseStaticPubKey sig =
    in verify pk payload sig
 
 -- | Build a handshake payload from an identity key pair and Noise static pubkey.
-buildHandshakePayload :: Key.KeyPair -> ByteString -> NoisePayload
-buildHandshakePayload identityKP noiseStaticPub =
-  let identKey = encodePublicKey (kpPublic identityKP)
-      identSig = case signStaticKey (kpPrivate identityKP) noiseStaticPub of
-        Right s -> s
-        Left err -> error $ "buildHandshakePayload: " <> err
-   in NoisePayload identKey identSig
-
--- | Validate a handshake payload (decode identity key and check structure).
--- Does NOT verify the signature (caller must provide the remote Noise static key).
-validateHandshakePayload :: NoisePayload -> Either String PublicKey
-validateHandshakePayload np = decodePublicKey (npIdentityKey np)
+buildHandshakePayload :: Key.KeyPair -> ByteString -> Either String NoisePayload
+buildHandshakePayload identityKP noiseStaticPub = do
+  identSig <-
+    either (Left . ("buildHandshakePayload: " <>)) Right $
+      signStaticKey (kpPrivate identityKP) noiseStaticPub
+  Right (NoisePayload (encodePublicKey (kpPublic identityKP)) identSig)
 
 -- | Encode a NoisePayload as a minimal protobuf message.
 encodeNoisePayload :: NoisePayload -> ByteString
@@ -133,24 +127,61 @@ encodeNoisePayload (NoisePayload identKey identSig) =
     <> identSig
 
 -- | Decode a NoisePayload from protobuf bytes.
+--
+-- Protobuf does not constrain field order on the wire, so fields are
+-- dispatched by number in a loop rather than matched in a fixed
+-- sequence. Unknown fields are skipped according to their wire type
+-- (go-libp2p already emits an extensions message as field 4, and other
+-- implementations may add more). Both identity_key (field 1) and
+-- identity_sig (field 2) must be present; on duplicates the last
+-- occurrence wins, per protobuf merge semantics.
 decodeNoisePayload :: ByteString -> Either String NoisePayload
-decodeNoisePayload bs = do
-  (identKey, rest1) <- decodeField 0x0a bs
-  (identSig, _rest2) <- decodeField 0x12 rest1
+decodeNoisePayload bs0 = do
+  (mKey, mSig) <- go (Nothing, Nothing) bs0
+  identKey <- maybe (Left "decodeNoisePayload: missing identity_key (field 1)") Right mKey
+  identSig <- maybe (Left "decodeNoisePayload: missing identity_sig (field 2)") Right mSig
   Right (NoisePayload identKey identSig)
   where
-    decodeField :: Word8 -> ByteString -> Either String (ByteString, ByteString)
-    decodeField expectedTag input
-      | BS.null input = Left "decodeNoisePayload: unexpected end of input"
-      | BS.head input /= expectedTag =
-          Left $ "decodeNoisePayload: expected tag " <> show expectedTag <> " got " <> show (BS.head input)
+    go
+      :: (Maybe ByteString, Maybe ByteString)
+      -> ByteString
+      -> Either String (Maybe ByteString, Maybe ByteString)
+    go acc@(mKey, mSig) input
+      | BS.null input = Right acc
       | otherwise = do
-          let rest = BS.tail input
-          (len, rest2) <- decodeUvarint rest
-          let fieldLen = fromIntegral len :: Int
-          if BS.length rest2 < fieldLen
-            then Left "decodeNoisePayload: not enough bytes for field"
-            else Right (BS.take fieldLen rest2, BS.drop fieldLen rest2)
+          (tag, rest) <- decodeUvarint input
+          let fieldNum = tag `shiftR` 3
+              wireType = tag .&. 0x7
+          case (fieldNum, wireType) of
+            (1, 2) -> do
+              (v, rest') <- lengthDelimited rest
+              go (Just v, mSig) rest'
+            (2, 2) -> do
+              (v, rest') <- lengthDelimited rest
+              go (mKey, Just v) rest'
+            (_, wt) -> do
+              rest' <- skipField wt rest
+              go acc rest'
+
+    lengthDelimited :: ByteString -> Either String (ByteString, ByteString)
+    lengthDelimited input = do
+      (len, rest) <- decodeUvarint input
+      let fieldLen = fromIntegral len :: Int
+      if BS.length rest < fieldLen
+        then Left "decodeNoisePayload: not enough bytes for field"
+        else Right (BS.take fieldLen rest, BS.drop fieldLen rest)
+
+    skipField :: Word64 -> ByteString -> Either String ByteString
+    skipField 0 input = snd <$> decodeUvarint input
+    skipField 1 input = skipFixed 8 input
+    skipField 2 input = snd <$> lengthDelimited input
+    skipField 5 input = skipFixed 4 input
+    skipField wt _ = Left $ "decodeNoisePayload: unsupported wire type " <> show wt
+
+    skipFixed :: Int -> ByteString -> Either String ByteString
+    skipFixed n input
+      | BS.length input < n = Left "decodeNoisePayload: not enough bytes for field"
+      | otherwise = Right (BS.drop n input)
 
 -- | Initialize a handshake state for the initiator role.
 -- Returns (HandshakeState, noiseStaticPublicKey).
@@ -227,7 +258,7 @@ performFullHandshake aliceIdentity bobIdentity = do
     (_payload1, bobState1) <- readHandshakeMsg bobInit msg1
 
     -- Message 2: Bob → Alice (Bob's identity payload)
-    let bobPayload = encodeNoisePayload $ buildHandshakePayload bobIdentity bobNoiseStaticPub
+    bobPayload <- encodeNoisePayload <$> buildHandshakePayload bobIdentity bobNoiseStaticPub
     (msg2, bobState2) <- writeHandshakeMsg bobState1 bobPayload
     (payload2, aliceState2) <- readHandshakeMsg aliceState1 msg2
 
@@ -245,7 +276,7 @@ performFullHandshake aliceIdentity bobIdentity = do
           else Right ()
 
     -- Message 3: Alice → Bob (Alice's identity payload)
-    let alicePayload = encodeNoisePayload $ buildHandshakePayload aliceIdentity aliceNoiseStaticPub
+    alicePayload <- encodeNoisePayload <$> buildHandshakePayload aliceIdentity aliceNoiseStaticPub
     (msg3, _aliceFinal) <- writeHandshakeMsg aliceState2 alicePayload
     (payload3, bobFinal) <- readHandshakeMsg bobState2 msg3
 
@@ -275,7 +306,7 @@ performFullHandshakeWithSessions aliceIdentity bobIdentity = do
     (_payload1, bobState1) <- readHandshakeMsg bobInit msg1
 
     -- Message 2: Bob → Alice (Bob's identity payload)
-    let bobPayload = encodeNoisePayload $ buildHandshakePayload bobIdentity bobNoiseStaticPub
+    bobPayload <- encodeNoisePayload <$> buildHandshakePayload bobIdentity bobNoiseStaticPub
     (msg2, bobState2) <- writeHandshakeMsg bobState1 bobPayload
     (payload2, aliceState2) <- readHandshakeMsg aliceState1 msg2
 
@@ -290,7 +321,7 @@ performFullHandshakeWithSessions aliceIdentity bobIdentity = do
           else Right ()
 
     -- Message 3: Alice → Bob (Alice's identity payload)
-    let alicePayload = encodeNoisePayload $ buildHandshakePayload aliceIdentity aliceNoiseStaticPub
+    alicePayload <- encodeNoisePayload <$> buildHandshakePayload aliceIdentity aliceNoiseStaticPub
     (msg3, aliceFinal) <- writeHandshakeMsg aliceState2 alicePayload
     (payload3, bobFinal) <- readHandshakeMsg bobState2 msg3
 

--- a/src/LibP2P/Switch/Upgrade.hs
+++ b/src/LibP2P/Switch/Upgrade.hs
@@ -158,7 +158,8 @@ performInitiatorHandshake identityKP stream = do
         else pure ()
 
   -- Message 3: → (initiator's identity payload)
-  let identPayload = encodeNoisePayload $ buildHandshakePayload identityKP noiseStaticPub
+  identPayload <- either (fail . ("initiator payload build: " <>)) pure $
+    encodeNoisePayload <$> buildHandshakePayload identityKP noiseStaticPub
   (msg3, hsStateFinal) <- either (fail . ("initiator msg3 write: " <>)) pure $
     writeHandshakeMsg hsState2 identPayload
   writeFramedMessage stream msg3
@@ -177,7 +178,8 @@ performResponderHandshake identityKP stream = do
     readHandshakeMsg hsState0 msg1
 
   -- Message 2: → (responder's identity payload)
-  let identPayload = encodeNoisePayload $ buildHandshakePayload identityKP noiseStaticPub
+  identPayload <- either (fail . ("responder payload build: " <>)) pure $
+    encodeNoisePayload <$> buildHandshakePayload identityKP noiseStaticPub
   (msg2, hsState2) <- either (fail . ("responder msg2 write: " <>)) pure $
     writeHandshakeMsg hsState1 identPayload
   writeFramedMessage stream msg2
@@ -239,28 +241,36 @@ encryptAndWrite sendRef rawIO plaintext =
           writeFramedMessage rawIO ct
 
 -- | Read and decrypt a byte from the Noise channel.
--- If the buffer has bytes, return the first. Otherwise, read a full Noise
--- frame from the raw stream, decrypt it, and buffer the result.
+-- If the buffer has bytes, return the first. Otherwise, read Noise
+-- frames from the raw stream until one decrypts to a non-empty
+-- plaintext, and buffer the result. A transport message with an empty
+-- plaintext (a frame carrying only the AEAD tag) is legal — some
+-- implementations send it as a keepalive — and a zero-length frame
+-- carries no Noise message at all; both yield zero application bytes,
+-- so reading continues at the next frame.
 decryptAndReadByte :: IORef NoiseSession -> IORef ByteString -> StreamIO -> IO Word8
 decryptAndReadByte recvRef bufRef rawIO = do
   buf <- readIORef bufRef
   if BS.null buf
-    then do
-      -- Read a full framed Noise message
+    then fillFromNextFrame
+    else popByte buf
+  where
+    popByte bs = do
+      writeIORef bufRef (BS.tail bs)
+      pure (BS.head bs)
+    fillFromNextFrame = do
       ct <- readFramedMessage rawIO
-      sess <- readIORef recvRef
-      case decryptMessage sess ct of
-        Left err -> fail $ "decryptAndReadByte: " <> err
-        Right (pt, sess') -> do
-          writeIORef recvRef sess'
-          if BS.null pt
-            then fail "decryptAndReadByte: empty plaintext"
-            else do
-              writeIORef bufRef (BS.tail pt)
-              pure (BS.head pt)
-    else do
-      writeIORef bufRef (BS.tail buf)
-      pure (BS.head buf)
+      if BS.null ct
+        then fillFromNextFrame -- zero-length frame: no message to decrypt
+        else do
+          sess <- readIORef recvRef
+          case decryptMessage sess ct of
+            Left err -> fail $ "decryptAndReadByte: " <> err
+            Right (pt, sess') -> do
+              writeIORef recvRef sess'
+              if BS.null pt
+                then fillFromNextFrame -- empty transport message (keepalive)
+                else popByte pt
 
 -- | Bounded window given to the send loop to flush the GoAway frame
 -- before the transport is closed underneath it.

--- a/test/LibP2P/Noise/ForeignPeerSpec.hs
+++ b/test/LibP2P/Noise/ForeignPeerSpec.hs
@@ -23,6 +23,7 @@ import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), mkMemoryStreamPair)
 import LibP2P.Noise.Handshake
   ( HandshakeResult (..)
+  , HandshakeState (..)
   , NoisePayload (..)
   , buildHandshakePayload
   , decodeNoisePayload
@@ -33,12 +34,16 @@ import LibP2P.Noise.Handshake
   , readHandshakeMsg
   , writeHandshakeMsg
   )
+import LibP2P.Noise.Session (NoiseSession, encryptMessage, mkNoiseSession)
 import LibP2P.Switch.Types (Direction (..))
 import LibP2P.Switch.Upgrade
-  ( performStreamHandshake
+  ( noiseSessionToStreamIO
+  , performStreamHandshake
+  , readExact
   , readFramedMessage
   , writeFramedMessage
   )
+import Data.IORef (newIORef)
 import Test.Hspec
 
 -- | Generate a test identity (PeerId, KeyPair).
@@ -62,7 +67,8 @@ runForeignResponder identityKP sigTarget stream = do
   (_p1, st1) <- either fail pure $ readHandshakeMsg st0 msg1
 
   -- Message 2: -> e, ee, s, es (identity payload, signature over sigTarget)
-  let payload = encodeNoisePayload $ buildHandshakePayload identityKP (sigTarget staticPub)
+  payload <- either fail pure $
+    encodeNoisePayload <$> buildHandshakePayload identityKP (sigTarget staticPub)
   (msg2, st2) <- either fail pure $ writeHandshakeMsg st1 payload
   writeFramedMessage stream msg2
 
@@ -91,7 +97,8 @@ runForeignInitiator identityKP sigTarget stream = do
   pk <- either fail pure $ decodePublicKey (npIdentityKey np)
 
   -- Message 3: -> s, se (identity payload, signature over sigTarget)
-  let payload = encodeNoisePayload $ buildHandshakePayload identityKP (sigTarget staticPub)
+  payload <- either fail pure $
+    encodeNoisePayload <$> buildHandshakePayload identityKP (sigTarget staticPub)
   (msg3, _stFinal) <- either fail pure $ writeHandshakeMsg st2 payload
   writeFramedMessage stream msg3
   pure (fromPublicKey pk, pk)
@@ -106,6 +113,22 @@ isSignatureRejection e = "identity signature verification failed" `isInfixOf` sh
 -- or a forged one (attacker without the identity private key).
 foreignStaticKey :: ByteString
 foreignStaticKey = BS.replicate 32 0x5A
+
+-- | An honest hand-rolled responder that completes the handshake and
+-- returns its transport-mode Noise session, so the test can craft
+-- arbitrary post-handshake transport messages on the foreign side.
+runForeignResponderSession :: KeyPair -> StreamIO -> IO NoiseSession
+runForeignResponderSession identityKP stream = do
+  (st0, staticPub) <- initHandshakeResponder identityKP
+  msg1 <- readFramedMessage stream
+  (_p1, st1) <- either fail pure $ readHandshakeMsg st0 msg1
+  payload <- either fail pure $
+    encodeNoisePayload <$> buildHandshakePayload identityKP staticPub
+  (msg2, st2) <- either fail pure $ writeHandshakeMsg st1 payload
+  writeFramedMessage stream msg2
+  msg3 <- readFramedMessage stream
+  (_p3, stFinal) <- either fail pure $ readHandshakeMsg st2 msg3
+  pure (mkNoiseSession (hsNoiseState stFinal))
 
 spec :: Spec
 spec = do
@@ -158,6 +181,36 @@ spec = do
         performStreamHandshake kpA Inbound streamA
           `shouldThrow` isSignatureRejection
 
+    it "empty transport messages between data frames do not kill the connection" $ do
+      -- A Noise transport message with an empty plaintext (frame carrying
+      -- only the 16-byte AEAD tag) is legal and used as a keepalive by
+      -- some implementations; a zero-length frame carries no message at
+      -- all. Both must yield zero application bytes, with reading
+      -- continuing at the next frame.
+      (_pidA, kpA) <- mkTestIdentity
+      (_pidB, kpB) <- mkTestIdentity
+      (streamA, streamB) <- mkMemoryStreamPair
+      ((prodSess, _result), foreignSess) <-
+        concurrently
+          (performStreamHandshake kpA Outbound streamA)
+          (runForeignResponderSession kpB streamB)
+      -- Foreign peer sends: data, zero-length frame, tag-only frame, data.
+      (ct1, fs1) <- either fail pure $ encryptMessage foreignSess "hello"
+      (ctEmpty, fs2) <- either fail pure $ encryptMessage fs1 BS.empty
+      (ct2, _fs3) <- either fail pure $ encryptMessage fs2 "world"
+      BS.length ctEmpty `shouldBe` 16 -- AEAD tag only
+      writeFramedMessage streamB ct1
+      streamWrite streamB (BS.pack [0x00, 0x00]) -- zero-length frame
+      writeFramedMessage streamB ctEmpty
+      writeFramedMessage streamB ct2
+      -- Production side reads through the Noise-encrypted StreamIO.
+      sendRef <- newIORef prodSess
+      recvRef <- newIORef prodSess
+      bufRef <- newIORef BS.empty
+      let encryptedIO = noiseSessionToStreamIO sendRef recvRef bufRef streamA
+      got <- readExact encryptedIO 10
+      got `shouldBe` "helloworld"
+
     it "initiator rejects a responder that advertises another peer's identity key" $ do
       -- Eve presents Bob's public key but cannot produce Bob's signature
       -- over her own session's static key: she signs with her own key.
@@ -165,15 +218,15 @@ spec = do
       (_pidBob, kpBob) <- mkTestIdentity
       (_pidEve, kpEve) <- mkTestIdentity
       (streamA, streamB) <- mkMemoryStreamPair
-      let impersonate staticPub =
-            let honest = buildHandshakePayload kpEve staticPub
-                bobKey = npIdentityKey (buildHandshakePayload kpBob staticPub)
-             in honest { npIdentityKey = bobKey }
+      let impersonate staticPub = do
+            honest <- buildHandshakePayload kpEve staticPub
+            bobPayload <- buildHandshakePayload kpBob staticPub
+            Right honest {npIdentityKey = npIdentityKey bobPayload}
           eveResponder stream = do
             (st0, staticPub) <- initHandshakeResponder kpEve
             msg1 <- readFramedMessage stream
             (_p1, st1) <- either fail pure $ readHandshakeMsg st0 msg1
-            let payload = encodeNoisePayload (impersonate staticPub)
+            payload <- either fail pure $ encodeNoisePayload <$> impersonate staticPub
             (msg2, _st2) <- either fail pure $ writeHandshakeMsg st1 payload
             writeFramedMessage stream msg2
       withAsync (eveResponder streamB) $ \_ ->

--- a/test/LibP2P/Noise/HandshakeSpec.hs
+++ b/test/LibP2P/Noise/HandshakeSpec.hs
@@ -4,6 +4,7 @@ import qualified Data.ByteString as BS
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key
 import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.Core.Varint (encodeUvarint)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Noise.Framing
 import LibP2P.Noise.Handshake
@@ -150,6 +151,62 @@ spec = do
       let payload = NoisePayload key sig
       decodeNoisePayload (encodeNoisePayload payload) `shouldBe` Right payload
 
+    it "decodes fields in reversed order (identity_sig before identity_key)" $ do
+      -- Protobuf does not constrain field order on the wire: a payload
+      -- serialized with field 2 before field 1 must decode identically.
+      let key = BS.replicate 36 0x11
+          sig = BS.replicate 64 0x22
+          reversed =
+            BS.singleton 0x12 <> encodeUvarint (fromIntegral (BS.length sig)) <> sig
+              <> BS.singleton 0x0a <> encodeUvarint (fromIntegral (BS.length key)) <> key
+      decodeNoisePayload reversed `shouldBe` Right (NoisePayload key sig)
+
+    it "skips an unknown trailing length-delimited field (extensions, field 4)" $ do
+      -- go-libp2p appends a NoiseExtensions message as field 4.
+      let key = BS.replicate 36 0x11
+          sig = BS.replicate 64 0x22
+          ext = BS.pack [0xDE, 0xAD, 0xBE, 0xEF]
+          encoded =
+            encodeNoisePayload (NoisePayload key sig)
+              <> BS.singleton 0x22 <> encodeUvarint (fromIntegral (BS.length ext)) <> ext
+      decodeNoisePayload encoded `shouldBe` Right (NoisePayload key sig)
+
+    it "skips an unknown high-numbered varint field between known fields" $ do
+      -- Field 2047, wire type 0: tag = 2047 << 3 = 16376 (multi-byte tag).
+      let key = BS.replicate 36 0x11
+          sig = BS.replicate 64 0x22
+          field1 = BS.singleton 0x0a <> encodeUvarint (fromIntegral (BS.length key)) <> key
+          field2 = BS.singleton 0x12 <> encodeUvarint (fromIntegral (BS.length sig)) <> sig
+          unknown = encodeUvarint 16376 <> encodeUvarint 300
+      decodeNoisePayload (field1 <> unknown <> field2)
+        `shouldBe` Right (NoisePayload key sig)
+
+    it "skips unknown fixed32 and fixed64 fields" $ do
+      let key = BS.replicate 36 0x11
+          sig = BS.replicate 64 0x22
+          field1 = BS.singleton 0x0a <> encodeUvarint (fromIntegral (BS.length key)) <> key
+          field2 = BS.singleton 0x12 <> encodeUvarint (fromIntegral (BS.length sig)) <> sig
+          -- Field 5, wire type 5 (fixed32): tag = 5 << 3 | 5 = 0x2D.
+          fixed32 = BS.singleton 0x2D <> BS.replicate 4 0xAB
+          -- Field 6, wire type 1 (fixed64): tag = 6 << 3 | 1 = 0x31.
+          fixed64 = BS.singleton 0x31 <> BS.replicate 8 0xCD
+      decodeNoisePayload (fixed32 <> field1 <> fixed64 <> field2)
+        `shouldBe` Right (NoisePayload key sig)
+
+    it "fails when identity_key (field 1) is missing" $ do
+      let sig = BS.replicate 64 0x22
+          onlySig = BS.singleton 0x12 <> encodeUvarint (fromIntegral (BS.length sig)) <> sig
+      decodeNoisePayload onlySig `shouldSatisfy` isLeft
+
+    it "fails when identity_sig (field 2) is missing" $ do
+      let key = BS.replicate 36 0x11
+          onlyKey = BS.singleton 0x0a <> encodeUvarint (fromIntegral (BS.length key)) <> key
+      decodeNoisePayload onlyKey `shouldSatisfy` isLeft
+
+    it "fails on a truncated length-delimited field" $ do
+      let truncated = BS.singleton 0x0a <> encodeUvarint 36 <> BS.replicate 10 0x11
+      decodeNoisePayload truncated `shouldSatisfy` isLeft
+
     it "fails on empty input" $
       decodeNoisePayload BS.empty `shouldSatisfy` isLeft
 
@@ -171,7 +228,8 @@ spec = do
       payload1 `shouldBe` BS.empty
 
       -- Message 2: Bob -> Alice (ephemeral + static key, identity payload)
-      let bobPayload = encodeNoisePayload $ buildHandshakePayload bobIdentity bobNoiseStaticPub
+      bobPayload <- either fail pure $
+        encodeNoisePayload <$> buildHandshakePayload bobIdentity bobNoiseStaticPub
       (msg2, bobState2) <- either fail pure $ writeHandshakeMsg bobState1 bobPayload
       (payload2, aliceState2) <- either fail pure $ readHandshakeMsg aliceState1 msg2
 
@@ -183,7 +241,8 @@ spec = do
           remotePubKey `shouldSatisfy` isRight
 
       -- Message 3: Alice -> Bob (static key, identity payload)
-      let alicePayload = encodeNoisePayload $ buildHandshakePayload aliceIdentity aliceNoiseStaticPub
+      alicePayload <- either fail pure $
+        encodeNoisePayload <$> buildHandshakePayload aliceIdentity aliceNoiseStaticPub
       (msg3, aliceSession) <- either fail pure $ writeHandshakeMsg aliceState2 alicePayload
       (payload3, bobSession) <- either fail pure $ readHandshakeMsg bobState2 msg3
 
@@ -228,7 +287,8 @@ spec = do
       -- Bob's payload signed over a DIFFERENT Noise static key (not the one in this session)
       -- Simulate: Bob pre-signed his identity for a different Noise session
       let bobOtherNoiseKey = BS.replicate 32 0xBB  -- arbitrary, not the actual session key
-      let replayedPayload = encodeNoisePayload $ buildHandshakePayload bobIdentity bobOtherNoiseKey
+      replayedPayload <- either fail pure $
+        encodeNoisePayload <$> buildHandshakePayload bobIdentity bobOtherNoiseKey
 
       -- Message 1 (normal)
       (msg1, aliceState1) <- either fail pure $ writeHandshakeMsg aliceInit BS.empty
@@ -262,7 +322,8 @@ spec = do
       (msg1, aliceState1) <- either fail pure $ writeHandshakeMsg aliceInit BS.empty
       (_payload1, bobState1) <- either fail pure $ readHandshakeMsg bobInit msg1
 
-      let bobPayload = encodeNoisePayload $ buildHandshakePayload bobIdentity bobNoiseStaticPub
+      bobPayload <- either fail pure $
+        encodeNoisePayload <$> buildHandshakePayload bobIdentity bobNoiseStaticPub
       (msg2, _bobState2) <- either fail pure $ writeHandshakeMsg bobState1 bobPayload
       (payload2, aliceState2) <- either fail pure $ readHandshakeMsg aliceState1 msg2
 


### PR DESCRIPTION
## Summary

Fixes the two decoder-strictness deviations from #166:

- **Lenient protobuf decoding**: `decodeNoisePayload` matched tags 1 and 2 in a fixed sequence, rejecting any peer that reorders fields (protobuf does not constrain wire order). It now dispatches on field number in a loop and skips unknown fields per wire type (varint, fixed64, length-delimited, fixed32), so extensions such as go-libp2p's field 4 — trailing or not — are tolerated. Duplicate fields follow last-wins merge semantics; both required fields must still be present.
- **Empty transport messages**: a Noise transport message with an empty plaintext (frame carrying only the 16-byte AEAD tag, used as a keepalive by some implementations) and a zero-length frame both killed the connection in `decryptAndReadByte`. Both now yield zero application bytes and reading continues at the next frame.
- `buildHandshakePayload` now returns `Either String` instead of calling `error` in pure code when signing fails (issue item 3), and the unreferenced `validateHandshakePayload` (which despite its name did not verify the signature) is removed.

## Tests (TDD, failing first)

- Payload with `identity_sig` serialized before `identity_key` decodes identically
- Unknown trailing length-delimited field (extensions, field 4), unknown high-numbered varint field (2047) between known fields, and unknown fixed32/fixed64 fields are all skipped
- Missing field 1 / field 2 and truncated fields still rejected
- ForeignPeerSpec: a zero-length frame and a tag-only (empty-plaintext) frame injected between two data frames over the production `noiseSessionToStreamIO` path still deliver the surrounding data

857 tests pass (`cabal test` with GHC 9.10.3).

Closes #166