### PR TITLE
fix(gossipsub): wire peer scoring (P1-P7), PRUNE peer exchange and GRAFT flood protection

### DIFF
--- a/src/LibP2P/Protocol/GossipSub/Handler.hs
+++ b/src/LibP2P/Protocol/GossipSub/Handler.hs
@@ -49,6 +49,9 @@ import LibP2P.MultistreamSelect.Negotiation
   )
 import LibP2P.Protocol.GossipSub.Heartbeat (runHeartbeat)
 import LibP2P.Protocol.GossipSub.Message (readRPCMessage, writeRPCMessage)
+import LibP2P.Core.Binary (word32BE)
+import LibP2P.Multiaddr (protocols)
+import LibP2P.Multiaddr.Protocol (Protocol (..))
 import LibP2P.Protocol.GossipSub.Router
   ( addPeer
   , handleRPC
@@ -57,6 +60,7 @@ import LibP2P.Protocol.GossipSub.Router
   , newRouter
   , publish
   , removePeer
+  , setPeerIP
   )
 import qualified Data.Set as Set
 import LibP2P.Protocol.GossipSub.Types
@@ -156,6 +160,16 @@ openAndNegotiate conn = do
     Accepted _ -> pure (Just stream)
     NoProtocol -> pure Nothing
 
+-- | Extract the remote IP bytes (4 for IPv4, 16 for IPv6) from a
+-- connection's multiaddr, for P6 IP colocation scoring.
+remoteIPBytes :: Connection -> Maybe ByteString
+remoteIPBytes conn = go (protocols (connRemoteAddr conn))
+  where
+    go (IP4 w  : _)   = Just (word32BE w)
+    go (IP6 bs : _)   = Just bs
+    go (_      : ps)  = go ps
+    go []             = Nothing
+
 -- | Try to send an RPC on a stream, catching exceptions.
 trySend :: StreamIO -> RPC -> IO (Either () ())
 trySend stream rpc =
@@ -166,11 +180,12 @@ trySend stream rpc =
 --
 -- Reads framed RPCs in a loop and dispatches each to the Router's handleRPC.
 -- On error or EOF, cleans up the peer's cached stream and removes the peer.
-handleGossipSubStream :: GossipSubNode -> StreamIO -> PeerId -> IO ()
-handleGossipSubStream node stream pid = do
-  -- Register peer with router
+handleGossipSubStream :: GossipSubNode -> StreamIO -> PeerId -> Maybe ByteString -> IO ()
+handleGossipSubStream node stream pid mIP = do
+  -- Register peer with router (IP feeds P6 colocation scoring)
   now <- getCurrentTime
   addPeer (gsnRouter node) pid GossipSubPeer False now
+  mapM_ (setPeerIP (gsnRouter node) pid) mIP
   -- Read loop
   readLoop
   -- Cleanup on disconnect
@@ -190,7 +205,8 @@ startGossipSub :: GossipSubNode -> IO ()
 startGossipSub node = do
   -- Register inbound stream handler on Switch
   setStreamHandler (gsnSwitch node) gossipSubProtocolId
-    (\conn stream -> handleGossipSubStream node stream (connPeerId conn))
+    (\conn stream ->
+      handleGossipSubStream node stream (connPeerId conn) (remoteIPBytes conn))
   -- Register connection notifier to auto-open GossipSub streams to new peers
   atomically $ modifyTVar' (swNotifiers (gsnSwitch node))
     (onNewConnection node :)
@@ -211,9 +227,10 @@ onNewConnection node conn = do
     Just stream -> do
       -- Cache the outbound stream
       atomically $ modifyTVar' (gsnStreams node) (Map.insert pid stream)
-      -- Register peer
+      -- Register peer (IP feeds P6 colocation scoring)
       now <- getCurrentTime
       addPeer (gsnRouter node) pid GossipSubPeer True now
+      mapM_ (setPeerIP (gsnRouter node) pid) (remoteIPBytes conn)
       -- Send current subscriptions to the new peer
       sendCurrentSubscriptions node stream
       -- Start read loop on this stream to receive RPCs from the peer

--- a/src/LibP2P/Protocol/GossipSub/Heartbeat.hs
+++ b/src/LibP2P/Protocol/GossipSub/Heartbeat.hs
@@ -16,15 +16,25 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (Async, async)
 import Control.Concurrent.STM
 import Control.Monad (forM_, unless, when)
+import Data.List (sortOn)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import Data.Ord (Down (..))
 import Data.Time (UTCTime, addUTCTime, diffUTCTime)
 import Data.Word (Word64)
 import List.Shuffle (sampleIO)
 import LibP2P.Crypto.PeerId (PeerId)
 import LibP2P.Protocol.GossipSub.Types
 import LibP2P.Protocol.GossipSub.MessageCache (cacheGetGossipIds, cacheShift)
-import LibP2P.Protocol.GossipSub.Score (computeScore, decayPeerCounters)
+import LibP2P.Protocol.GossipSub.Router (selectPXPeers)
+import LibP2P.Protocol.GossipSub.Score
+  ( computeScore
+  , decayPeerCounters
+  , addP7Penalty
+  , refreshMeshTime
+  , markPeerInMesh
+  , unmarkPeerInMesh
+  )
 
 -- | Run a single heartbeat cycle. Exported for testing.
 heartbeatOnce :: GossipSubRouter -> IO ()
@@ -32,6 +42,7 @@ heartbeatOnce router = do
   meshMaintenance router
   fanoutMaintenance router
   emitGossip router
+  expireIWantPromises router
   decayAllScores router
   cleanSeenCache router
   -- Increment heartbeat counter
@@ -76,18 +87,21 @@ pruneNegativeScore router topic meshPeers now = do
   let negatives = Set.filter (\pid ->
         case Map.lookup pid peers of
           Nothing -> False
-          Just ps -> computeScore scoreParams ps ipMap now < 0
+          Just ps -> computeScore scoreParams pid ps ipMap now < 0
         ) meshPeers
-  -- Send PRUNE to negative-score peers
+  -- Send PRUNE to negative-score peers (no PX for negative-score peers)
   forM_ (Set.toList negatives) $ \pid -> do
     let backoffSecs = round (paramPruneBackoff (gsParams router)) :: Word64
     gsSendRPC router pid emptyRPC
       { rpcControl = Just emptyControlMessage
           { ctrlPrune = [Prune topic [] (Just backoffSecs)] }
       }
-    -- Start backoff
-    atomically $ modifyTVar' (gsBackoff router) $
-      Map.insert (pid, topic) (addUTCTime (paramPruneBackoff (gsParams router)) now)
+    -- Start backoff and stop the P1 mesh clock
+    atomically $ do
+      modifyTVar' (gsBackoff router) $
+        Map.insert (pid, topic) (addUTCTime (paramPruneBackoff (gsParams router)) now)
+      modifyTVar' (gsPeers router) $
+        Map.adjust (unmarkPeerInMesh topic) pid
   -- Update mesh
   let remaining = Set.difference meshPeers negatives
   atomically $ modifyTVar' (gsMesh router) $
@@ -111,7 +125,7 @@ fillUndersubscribed router topic meshPeers now = do
                            , Set.member topic (psTopics ps)
                            , not (Set.member pid meshPeers)
                            , not (isInBackoff backoffMap pid topic now)
-                           , computeScore (gsScoreParams router) ps ipMap now >= 0
+                           , computeScore (gsScoreParams router) pid ps ipMap now >= 0
                            ]
       let needed = d - Set.size meshPeers
       selected <- sampleIO (min needed (length eligible)) eligible
@@ -120,32 +134,63 @@ fillUndersubscribed router topic meshPeers now = do
         gsSendRPC router pid emptyRPC
           { rpcControl = Just emptyControlMessage { ctrlGraft = [Graft topic] } }
       let newMesh = Set.union meshPeers (Set.fromList selected)
-      atomically $ modifyTVar' (gsMesh router) $
-        Map.insert topic newMesh
+      atomically $ do
+        modifyTVar' (gsMesh router) $ Map.insert topic newMesh
+        -- Start the P1 mesh clock for the newly grafted peers
+        modifyTVar' (gsPeers router) $ \pm ->
+          foldl' (\m pid -> Map.adjust (markPeerInMesh topic now) pid m)
+            pm selected
       pure newMesh
 
--- | Trim mesh if above D_hi by randomly removing excess peers, send PRUNE.
+-- | Trim mesh if above D_hi down to D peers, send PRUNE with PX.
+--
+-- Per gossipsub-v1.1.md mesh maintenance: keep the best D_score peers by
+-- score, select the rest at random, under the constraint that at least
+-- D_out of the kept peers are outbound connections.
 trimOversubscribed :: GossipSubRouter -> Topic -> Set.Set PeerId -> IO ()
 trimOversubscribed router topic meshPeers = do
   let params = gsParams router
-      dhi = paramDhi params
-      d   = paramD params
+      dhi    = paramDhi params
+      d      = paramD params
+      dscore = paramDscore params
+      dout   = paramDout params
   when (Set.size meshPeers > dhi) $ do
     now <- gsGetTime router
-    -- Keep D peers: select D random peers to keep
-    let meshList = Set.toList meshPeers
-    kept <- sampleIO d meshList
-    let keptSet = Set.fromList kept
+    peersMap <- readTVarIO (gsPeers router)
+    ipMap <- readTVarIO (gsIPPeerCount router)
+    let scoreOf pid = case Map.lookup pid peersMap of
+          Nothing -> 0
+          Just ps -> computeScore (gsScoreParams router) pid ps ipMap now
+        isOutbound pid = maybe False psIsOutbound (Map.lookup pid peersMap)
+        ranked = sortOn (Down . scoreOf) (Set.toList meshPeers)
+        (best, rest) = splitAt (min dscore d) ranked
+    restKept <- sampleIO (max 0 (d - length best)) rest
+    -- keptList is ordered best-first: the score-retained peers, then the
+    -- random selection. D_out swaps drop from the tail first.
+    let keptList = best ++ restKept
+        kept0 = Set.fromList keptList
+        outDeficit = max 0 (dout - length (filter isOutbound keptList))
+        swapIn = take outDeficit
+          (filter (\p -> isOutbound p && not (Set.member p kept0)) ranked)
+        swapOut = take (length swapIn)
+          (filter (not . isOutbound) (reverse keptList))
+        keptSet = Set.union
+          (Set.difference kept0 (Set.fromList swapOut))
+          (Set.fromList swapIn)
         toRemove = Set.difference meshPeers keptSet
-    -- Send PRUNE to removed peers
+    -- Send PRUNE with peer exchange to removed peers
     forM_ (Set.toList toRemove) $ \pid -> do
       let backoffSecs = round (paramPruneBackoff params) :: Word64
+      px <- selectPXPeers router topic pid
       gsSendRPC router pid emptyRPC
         { rpcControl = Just emptyControlMessage
-            { ctrlPrune = [Prune topic [] (Just backoffSecs)] }
+            { ctrlPrune = [Prune topic px (Just backoffSecs)] }
         }
-      atomically $ modifyTVar' (gsBackoff router) $
-        Map.insert (pid, topic) (addUTCTime (paramPruneBackoff params) now)
+      atomically $ do
+        modifyTVar' (gsBackoff router) $
+          Map.insert (pid, topic) (addUTCTime (paramPruneBackoff params) now)
+        modifyTVar' (gsPeers router) $
+          Map.adjust (unmarkPeerInMesh topic) pid
     -- Update mesh
     atomically $ modifyTVar' (gsMesh router) $
       Map.insert topic keptSet
@@ -184,11 +229,13 @@ fanoutMaintenance router = do
 
 emitGossip :: GossipSubRouter -> IO ()
 emitGossip router = do
+  now <- gsGetTime router
   meshMap <- readTVarIO (gsMesh router)
   fanoutMap <- readTVarIO (gsFanout router)
   subs <- readTVarIO (gsSubscriptions router)
   cache <- readTVarIO (gsMessageCache router)
   peersMap <- readTVarIO (gsPeers router)
+  ipMap <- readTVarIO (gsIPPeerCount router)
   let params = gsParams router
       -- gossipsub-v1.0.md heartbeat: gossip covers "each topic in
       -- mesh+fanout", so topics we publish to without subscribing
@@ -201,10 +248,15 @@ emitGossip router = do
     let gossipIds = cacheGetGossipIds topic cache
     unless (null gossipIds) $ do
       let meshPeers = Map.findWithDefault Set.empty topic meshMap
-          -- Eligible: subscribed to topic, not in mesh
+          -- Eligible: subscribed to topic, not in mesh, and scoring at or
+          -- above the gossip threshold — no gossip is emitted towards
+          -- peers below it (gossipsub-v1.1.md gossip threshold)
+          gossipThreshold = stGossipThreshold (gsThresholds router)
           nonMeshPeers = [ pid | (pid, ps) <- Map.toList peersMap
                                , Set.member topic (psTopics ps)
                                , not (Set.member pid meshPeers)
+                               , computeScore (gsScoreParams router) pid ps ipMap now
+                                   >= gossipThreshold
                                ]
           -- Select max(D_lazy, |eligible| * gossipFactor) targets
           dlazy = paramDlazy params
@@ -220,12 +272,30 @@ emitGossip router = do
   -- Rotate cache
   atomically $ modifyTVar' (gsMessageCache router) cacheShift
 
+-- IWANT promise expiry (P7)
+
+-- | Penalise peers whose IWANT promises expired without delivery
+-- (gossipsub-v1.1.md: a peer that advertises via IHAVE but never sends
+-- the requested message commits a behavioural violation).
+expireIWantPromises :: GossipSubRouter -> IO ()
+expireIWantPromises router = do
+  now <- gsGetTime router
+  broken <- atomically $ do
+    promises <- readTVar (gsIWantPromises router)
+    let (expired, live) = Map.partition (<= now) promises
+    writeTVar (gsIWantPromises router) live
+    pure (map fst (Map.keys expired))
+  atomically $ modifyTVar' (gsPeers router) $ \pm ->
+    foldl' (\m pid -> Map.adjust addP7Penalty pid m) pm broken
+
 -- Score decay
 
+-- | Refresh accrued mesh time (P1 input) and decay all scoring counters.
 decayAllScores :: GossipSubRouter -> IO ()
-decayAllScores router = atomically $
-  modifyTVar' (gsPeers router) $
-    Map.map (decayPeerCounters (gsScoreParams router))
+decayAllScores router = do
+  now <- gsGetTime router
+  atomically $ modifyTVar' (gsPeers router) $
+    Map.map (decayPeerCounters (gsScoreParams router) . refreshMeshTime now)
 
 -- Seen cache cleanup
 

--- a/src/LibP2P/Protocol/GossipSub/Router.hs
+++ b/src/LibP2P/Protocol/GossipSub/Router.hs
@@ -9,6 +9,7 @@ module LibP2P.Protocol.GossipSub.Router
     -- * Peer management
   , addPeer
   , removePeer
+  , setPeerIP
     -- * Topic subscription
   , join
   , leave
@@ -29,16 +30,18 @@ module LibP2P.Protocol.GossipSub.Router
   , forwardMessage
     -- * Scoring
   , peerScore
+    -- * Peer exchange
+  , selectPXPeers
   ) where
 
 import Prelude
 import Control.Exception (throwIO)
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Control.Concurrent.STM
 import Data.ByteString (ByteString)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import Data.Time (UTCTime, addUTCTime)
+import Data.Time (UTCTime, addUTCTime, diffUTCTime)
 import Data.Word (Word64)
 import Crypto.Random (getRandomBytes)
 import List.Shuffle (sampleIO)
@@ -47,7 +50,16 @@ import LibP2P.Crypto.Key (KeyPair (..), sign)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Protocol.GossipSub.Types
 import LibP2P.Protocol.GossipSub.MessageCache (newMessageCache, cachePut, cacheGet)
-import LibP2P.Protocol.GossipSub.Score (computeScore, addP7Penalty, recordMeshFailure, recordInvalidMessage)
+import LibP2P.Protocol.GossipSub.Score
+  ( computeScore
+  , addP7Penalty
+  , recordMeshFailure
+  , recordInvalidMessage
+  , recordFirstDelivery
+  , recordMeshDelivery
+  , markPeerInMesh
+  , unmarkPeerInMesh
+  )
 import LibP2P.Protocol.GossipSub.Validation (validateMessage, signingBytes)
 
 -- | Create a new GossipSub router with empty state.
@@ -69,6 +81,8 @@ newRouter params localPid sendRPC getTime = do
   hbCount  <- newTVarIO 0
   onMsg    <- newTVarIO (\_ _ -> pure ())
   validators <- newTVarIO Map.empty
+  promises <- newTVarIO Map.empty
+  onPX     <- newTVarIO (\_ _ -> pure ())
   pure GossipSubRouter
     { gsParams         = params
     , gsLocalPeerId    = localPid
@@ -82,12 +96,14 @@ newRouter params localPid sendRPC getTime = do
     , gsScoreParams    = defaultPeerScoreParams
     , gsThresholds     = defaultScoreThresholds
     , gsIPPeerCount    = ipCount
+    , gsIWantPromises  = promises
     , gsMessageCache   = mcache
     , gsHeartbeatCount = hbCount
     , gsSendRPC        = sendRPC
     , gsGetTime        = getTime
     , gsOnMessage      = onMsg
     , gsValidators     = validators
+    , gsOnPeerExchange = onPX
     }
 
 -- Topic validation
@@ -123,12 +139,44 @@ addPeer router pid proto isOutbound now = atomically $
         , psCachedScore     = 0
         } m
 
--- | Remove a disconnected peer and clean up mesh/fanout membership.
+-- | Remove a disconnected peer and clean up mesh/fanout membership,
+-- IP colocation tracking (P6) and outstanding IWANT promises.
 removePeer :: GossipSubRouter -> PeerId -> IO ()
 removePeer router pid = atomically $ do
+  peers <- readTVar (gsPeers router)
+  case Map.lookup pid peers >>= psIPAddress of
+    Just ip -> modifyTVar' (gsIPPeerCount router) (removeIPMember ip pid)
+    Nothing -> pure ()
   modifyTVar' (gsPeers router) (Map.delete pid)
   modifyTVar' (gsMesh router) (Map.map (Set.delete pid))
   modifyTVar' (gsFanout router) (Map.map (Set.delete pid))
+  modifyTVar' (gsIWantPromises router) $
+    Map.filterWithKey (\(p, _) _ -> p /= pid)
+
+-- | Record a peer's IP address for P6 (IP colocation) scoring.
+-- No-op for unknown peers; replaces any previously recorded address.
+setPeerIP :: GossipSubRouter -> PeerId -> ByteString -> IO ()
+setPeerIP router pid ip = atomically $ do
+  peers <- readTVar (gsPeers router)
+  case Map.lookup pid peers of
+    Nothing -> pure ()
+    Just ps -> do
+      case psIPAddress ps of
+        Just oldIp | oldIp /= ip ->
+          modifyTVar' (gsIPPeerCount router) (removeIPMember oldIp pid)
+        _ -> pure ()
+      modifyTVar' (gsPeers router) $
+        Map.insert pid ps { psIPAddress = Just ip }
+      modifyTVar' (gsIPPeerCount router) $
+        Map.insertWith Set.union ip (Set.singleton pid)
+
+-- | Drop a peer from an IP's membership set, deleting empty sets.
+removeIPMember :: ByteString -> PeerId
+               -> Map.Map ByteString (Set.Set PeerId)
+               -> Map.Map ByteString (Set.Set PeerId)
+removeIPMember ip pid = Map.update
+  (\s -> let s' = Set.delete pid s
+         in if Set.null s' then Nothing else Just s') ip
 
 -- Topic subscription
 
@@ -186,6 +234,11 @@ join router topic = do
   -- fanoutPeers was captured before the mesh insert; currentMesh already
   -- contains the promoted peers, so it must not be subtracted here (#155).
   let allNewMeshPeers = Set.union fanoutPeers newPeers
+  -- Start the P1 mesh clock for every peer entering the mesh (#156)
+  now <- gsGetTime router
+  atomically $ modifyTVar' (gsPeers router) $ \pm ->
+    Set.foldl' (\m pid -> Map.adjust (markPeerInMesh topic now) pid m)
+      pm allNewMeshPeers
   mapM_ (\pid -> gsSendRPC router pid (graftRPC topic)) (Set.toList allNewMeshPeers)
 
 -- | Unsubscribe from a topic (LEAVE): announce, PRUNE with backoff, delete mesh.
@@ -200,14 +253,21 @@ leave router topic = do
       unsubRPC = emptyRPC { rpcSubscriptions = [SubOpts False topic] }
   mapM_ (\pid -> gsSendRPC router pid unsubRPC) allPeerIds
 
-  -- 3. Send PRUNE with unsubscribe backoff to mesh peers, then delete
+  -- 3. Send PRUNE with unsubscribe backoff and peer exchange to mesh
+  -- peers, then delete (gossipsub-v1.1.md PRUNE peer exchange: help the
+  -- pruned peer re-form its mesh without a discovery service)
   meshPeers <- atomically $ do
     m <- readTVar (gsMesh router)
     let mp = Map.findWithDefault Set.empty topic m
     modifyTVar' (gsMesh router) (Map.delete topic)
     pure mp
   let backoffSecs = round (paramUnsubBackoff (gsParams router)) :: Word64
-  mapM_ (\pid -> gsSendRPC router pid (pruneRPC topic [] (Just backoffSecs))) (Set.toList meshPeers)
+  mapM_ (\pid -> do
+          atomically $ modifyTVar' (gsPeers router) $
+            Map.adjust (unmarkPeerInMesh topic) pid
+          px <- selectPXPeers router topic pid
+          gsSendRPC router pid (pruneRPC topic px (Just backoffSecs)))
+    (Set.toList meshPeers)
 
 -- Publishing
 
@@ -239,10 +299,15 @@ publish router topic payload mKeyPair = do
 
   if paramFloodPublish (gsParams router)
     then do
-      -- Flood publish: send to ALL peers in topic
+      -- Flood publish: send to all topic peers scoring at or above the
+      -- publish threshold (gossipsub-v1.1.md flood publishing)
       peers <- readTVarIO (gsPeers router)
-      let targets = Map.foldlWithKey' (\acc pid ps ->
-            if Set.member topic (psTopics ps) && pid /= gsLocalPeerId router
+      ipMap <- readTVarIO (gsIPPeerCount router)
+      let threshold = stPublishThreshold (gsThresholds router)
+          targets = Map.foldlWithKey' (\acc pid ps ->
+            if Set.member topic (psTopics ps)
+               && pid /= gsLocalPeerId router
+               && computeScore (gsScoreParams router) pid ps ipMap now >= threshold
             then pid : acc
             else acc) [] peers
       mapM_ (\pid -> gsSendRPC router pid pubRPC) targets
@@ -283,8 +348,18 @@ publish router topic payload mKeyPair = do
 -- Inbound RPC handling
 
 -- | Handle an inbound RPC from a peer.
+--
+-- Graylisted peers (score below 'stGraylistThreshold') have their RPCs
+-- ignored entirely (gossipsub-v1.1.md graylist).
 handleRPC :: GossipSubRouter -> PeerId -> RPC -> IO ()
 handleRPC router sender rpc = do
+  score <- peerScore router sender
+  if score < stGraylistThreshold (gsThresholds router)
+    then pure ()
+    else handleRPC' router sender rpc
+
+handleRPC' :: GossipSubRouter -> PeerId -> RPC -> IO ()
+handleRPC' router sender rpc = do
   -- Process subscriptions
   handleSubscriptions router sender (rpcSubscriptions rpc)
 
@@ -311,32 +386,81 @@ handlePublishedMessage router sender msg =
     Left _err -> rejectMessage router sender msg
     Right ()  -> do
       let msgId = paramMessageIdFn (gsParams router) msg
+          topic = msgTopic msg
       now <- gsGetTime router
 
-      -- Deduplicate
-      alreadySeen <- atomically $ do
+      -- Deduplicate, keeping the first-seen time for the P3 near-first window
+      mFirstSeen <- atomically $ do
         s <- readTVar (gsSeen router)
-        if Map.member msgId s
-          then pure True
-          else do
+        case Map.lookup msgId s of
+          Just firstSeen -> pure (Just firstSeen)
+          Nothing -> do
             writeTVar (gsSeen router) (Map.insert msgId now s)
-            pure False
+            pure Nothing
 
-      unless alreadySeen $ do
-        accepted <- runTopicValidator router sender msg
-        if not accepted
-          then rejectMessage router sender msg
-          else do
-            -- Cache the message for IWANT responses
-            atomically $ modifyTVar' (gsMessageCache router) $
-              cachePut msgId msg
+      -- A signature-valid delivery fulfils any outstanding IWANT promise
+      -- for this message ID (P7 promise tracking, gossipsub-v1.1.md)
+      atomically $ modifyTVar' (gsIWantPromises router) $
+        Map.filterWithKey (\(_, mid) _ -> mid /= msgId)
 
-            -- Forward to mesh peers (excluding sender)
-            forwardMessage router sender msg
+      case mFirstSeen of
+        Just firstSeen ->
+          -- Duplicate: count as a mesh delivery (P3) when the sender is
+          -- in our mesh and delivered within the near-first window
+          creditMeshDelivery router sender topic (Just (firstSeen, now))
+        Nothing -> do
+          accepted <- runTopicValidator router sender msg
+          if not accepted
+            then rejectMessage router sender msg
+            else do
+              -- First valid delivery: P2, plus P3 for mesh senders (#156)
+              creditFirstDelivery router sender topic
+              creditMeshDelivery router sender topic Nothing
 
-            -- Deliver to application
-            onMsg <- readTVarIO (gsOnMessage router)
-            onMsg (msgTopic msg) msg
+              -- Cache the message for IWANT responses
+              atomically $ modifyTVar' (gsMessageCache router) $
+                cachePut msgId msg
+
+              -- Forward to mesh peers (excluding sender)
+              forwardMessage router sender msg
+
+              -- Deliver to application
+              onMsg <- readTVarIO (gsOnMessage router)
+              onMsg (msgTopic msg) msg
+
+-- | Record a P2 first-message delivery for the sender.
+creditFirstDelivery :: GossipSubRouter -> PeerId -> Topic -> IO ()
+creditFirstDelivery router sender topic = atomically $
+  modifyTVar' (gsPeers router) $ Map.adjust bump sender
+  where
+    tsp = Map.findWithDefault defaultTopicScoreParams topic
+      (pspTopicParams (gsScoreParams router))
+    bump ps =
+      let tps = Map.findWithDefault defaultTopicPeerState topic (psTopicState ps)
+      in ps { psTopicState =
+                Map.insert topic (recordFirstDelivery tsp tps) (psTopicState ps) }
+
+-- | Record a P3 mesh delivery for a sender in our mesh. For duplicates,
+-- the delivery only counts inside the near-first window after the first
+-- sighting (gossipsub-v1.1.md mesh message delivery rate).
+creditMeshDelivery :: GossipSubRouter -> PeerId -> Topic
+                   -> Maybe (UTCTime, UTCTime) -> IO ()
+creditMeshDelivery router sender topic mWindow = do
+  meshMap <- readTVarIO (gsMesh router)
+  let inMesh = Set.member sender (Map.findWithDefault Set.empty topic meshMap)
+      tsp = Map.findWithDefault defaultTopicScoreParams topic
+        (pspTopicParams (gsScoreParams router))
+      withinWindow = case mWindow of
+        Nothing -> True
+        Just (firstSeen, now) ->
+          diffUTCTime now firstSeen <= tspMeshMessageDeliveryWindow tsp
+  when (inMesh && withinWindow) $ atomically $
+    modifyTVar' (gsPeers router) $ Map.adjust
+      (\ps ->
+        let tps = Map.findWithDefault defaultTopicPeerState topic (psTopicState ps)
+        in ps { psTopicState =
+                  Map.insert topic (recordMeshDelivery tsp tps) (psTopicState ps) })
+      sender
 
 -- | Run the topic validator, if one is registered. No validator means accept.
 runTopicValidator :: GossipSubRouter -> PeerId -> PubSubMessage -> IO Bool
@@ -378,7 +502,11 @@ handleOneGraft router sender now (Graft topic) = do
   let subscribed = Set.member topic subs
 
   if not subscribed
-    then pure [Prune topic [] Nothing]  -- Not subscribed → PRUNE
+    then
+      -- gossipsub-v1.1.md GRAFT flood protection: GRAFTs for unknown
+      -- topics are ignored — replying with PRUNE (the v1.0 behaviour)
+      -- lets an attacker elicit traffic with spam GRAFTs (#157).
+      pure []
     else do
       -- Check backoff
       backoffMap <- readTVarIO (gsBackoff router)
@@ -386,22 +514,33 @@ handleOneGraft router sender now (Graft topic) = do
             Nothing -> False
             Just expires -> now < expires
 
-      -- Check score (stub: always >= 0 in Phase 9a)
       score <- peerScore router sender
+
+      -- Any rejection PRUNEs with a fresh backoff and never includes
+      -- peer exchange (no PX for misbehaving or negative-score peers)
+      let backoffSecs = round (paramPruneBackoff (gsParams router)) :: Word64
+          rejectWithBackoff = do
+            atomically $ modifyTVar' (gsBackoff router) $
+              Map.insert (sender, topic)
+                (addUTCTime (paramPruneBackoff (gsParams router)) now)
+            pure [Prune topic [] (Just backoffSecs)]
 
       if inBackoff
         then do
-          -- P7 penalty: GRAFT during backoff is a protocol violation
+          -- GRAFT flood protection: re-GRAFTing inside the backoff window
+          -- is a protocol violation — penalise (P7) and prune with backoff
           atomically $ modifyTVar' (gsPeers router) $
             Map.adjust addP7Penalty sender
-          let backoffSecs = round (paramPruneBackoff (gsParams router)) :: Word64
-          pure [Prune topic [] (Just backoffSecs)]
+          rejectWithBackoff
         else if score < 0
-          then pure [Prune topic [] Nothing]
+          then rejectWithBackoff
           else do
-            -- Accept: add sender to mesh
-            atomically $ modifyTVar' (gsMesh router) $
-              Map.insertWith Set.union topic (Set.singleton sender)
+            -- Accept: add sender to mesh and start its P1 mesh clock
+            atomically $ do
+              modifyTVar' (gsMesh router) $
+                Map.insertWith Set.union topic (Set.singleton sender)
+              modifyTVar' (gsPeers router) $
+                Map.adjust (markPeerInMesh topic now) sender
             pure []
 
 -- | Handle PRUNE: remove from mesh and start backoff.
@@ -423,9 +562,12 @@ handleOnePrune router sender now prune = do
         in ps { psTopicState = Map.insert topic topicSt' (psTopicState ps) }
       ) sender
     Nothing -> pure ()
-  -- Remove sender from mesh
-  atomically $ modifyTVar' (gsMesh router) $
-    Map.adjust (Set.delete sender) topic
+  -- Remove sender from mesh and stop its P1 mesh clock
+  atomically $ do
+    modifyTVar' (gsMesh router) $
+      Map.adjust (Set.delete sender) topic
+    modifyTVar' (gsPeers router) $
+      Map.adjust (unmarkPeerInMesh topic) sender
   -- Start backoff timer
   let backoffDuration = case pruneBackoff prune of
         Just secs -> fromIntegral secs
@@ -433,26 +575,49 @@ handleOnePrune router sender now prune = do
       expires = addUTCTime backoffDuration now
   atomically $ modifyTVar' (gsBackoff router) $
     Map.insert (sender, topic) expires
+  -- Honour peer exchange, but only from peers whose score clears the
+  -- PX acceptance threshold (gossipsub-v1.1.md: PX from low-scoring
+  -- peers is an eclipse-attack vector)
+  unless (null (prunePeers prune)) $ do
+    score <- peerScore router sender
+    when (score >= stAcceptPXThreshold (gsThresholds router)) $ do
+      onPX <- readTVarIO (gsOnPeerExchange router)
+      onPX topic (prunePeers prune)
 
 -- | Handle IHAVE: request unseen messages via IWANT.
+--
+-- Gossip from peers below the gossip threshold is ignored
+-- (gossipsub-v1.1.md gossip threshold). One advertised-and-requested
+-- message ID is tracked as an IWANT promise: if the peer never delivers
+-- it before the follow-up deadline, it is a P7 behavioural violation.
 handleIHave :: GossipSubRouter -> PeerId -> [IHave] -> IO ()
 handleIHave router sender ihaves = do
-  seenMap <- readTVarIO (gsSeen router)
-  let unseen = concatMap (\(IHave _ mids) ->
-        filter (\mid -> not (Map.member mid seenMap)) mids) ihaves
-  unless (null unseen) $
-    gsSendRPC router sender emptyRPC
-      { rpcControl = Just emptyControlMessage { ctrlIWant = [IWant unseen] } }
+  score <- peerScore router sender
+  unless (score < stGossipThreshold (gsThresholds router) || null ihaves) $ do
+    seenMap <- readTVarIO (gsSeen router)
+    let unseen = concatMap (\(IHave _ mids) ->
+          filter (\mid -> not (Map.member mid seenMap)) mids) ihaves
+    unless (null unseen) $ do
+      now <- gsGetTime router
+      promised <- sampleIO 1 unseen
+      let deadline = addUTCTime (paramIWantFollowupTime (gsParams router)) now
+      atomically $ modifyTVar' (gsIWantPromises router) $ \m ->
+        foldr (\mid -> Map.insert (sender, mid) deadline) m promised
+      gsSendRPC router sender emptyRPC
+        { rpcControl = Just emptyControlMessage { ctrlIWant = [IWant unseen] } }
 
 -- | Handle IWANT: respond with cached messages from the message cache.
+-- Requests from peers below the gossip threshold are ignored.
 handleIWant :: GossipSubRouter -> PeerId -> [IWant] -> IO ()
 handleIWant router sender iwants = do
-  cache <- readTVarIO (gsMessageCache router)
-  let requestedIds = concatMap iwantMessageIds iwants
-      found = [ msg | mid <- requestedIds
-                     , Just msg <- [cacheGet mid cache] ]
-  unless (null found) $
-    gsSendRPC router sender emptyRPC { rpcPublish = found }
+  score <- peerScore router sender
+  unless (score < stGossipThreshold (gsThresholds router)) $ do
+    cache <- readTVarIO (gsMessageCache router)
+    let requestedIds = concatMap iwantMessageIds iwants
+        found = [ msg | mid <- requestedIds
+                       , Just msg <- [cacheGet mid cache] ]
+    unless (null found) $
+      gsSendRPC router sender emptyRPC { rpcPublish = found }
 
 -- | Handle subscription changes from a peer.
 handleSubscriptions :: GossipSubRouter -> PeerId -> [SubOpts] -> IO ()
@@ -483,8 +648,7 @@ forwardMessage router sender msg = do
 
 -- Scoring
 
--- | Compute peer score using Score.computeScore (P1-P4, P6, P7).
--- P5 (application-specific) is not included here.
+-- | Compute peer score using Score.computeScore (P1-P7).
 peerScore :: GossipSubRouter -> PeerId -> IO Double
 peerScore router pid = do
   peers <- readTVarIO (gsPeers router)
@@ -492,7 +656,27 @@ peerScore router pid = do
   ipMap <- readTVarIO (gsIPPeerCount router)
   case Map.lookup pid peers of
     Nothing -> pure 0
-    Just ps -> pure $ computeScore (gsScoreParams router) ps ipMap now
+    Just ps -> pure $ computeScore (gsScoreParams router) pid ps ipMap now
+
+-- Peer exchange
+
+-- | Select peer-exchange records for a PRUNE: up to 'paramPrunePeers'
+-- random peers subscribed to the topic with non-negative score,
+-- excluding the pruned peer itself (gossipsub-v1.1.md peer exchange).
+selectPXPeers :: GossipSubRouter -> Topic -> PeerId -> IO [PeerExchangeInfo]
+selectPXPeers router topic excluded = do
+  now <- gsGetTime router
+  peers <- readTVarIO (gsPeers router)
+  ipMap <- readTVarIO (gsIPPeerCount router)
+  let candidates =
+        [ pid | (pid, ps) <- Map.toList peers
+              , pid /= excluded
+              , pid /= gsLocalPeerId router
+              , Set.member topic (psTopics ps)
+              , computeScore (gsScoreParams router) pid ps ipMap now >= 0 ]
+  chosen <- sampleIO
+    (min (paramPrunePeers (gsParams router)) (length candidates)) candidates
+  pure [ PeerExchangeInfo (peerIdBytes pid) Nothing | pid <- chosen ]
 
 -- Helper: construct a GRAFT RPC
 graftRPC :: Topic -> RPC

--- a/src/LibP2P/Protocol/GossipSub/Score.hs
+++ b/src/LibP2P/Protocol/GossipSub/Score.hs
@@ -28,6 +28,10 @@ module LibP2P.Protocol.GossipSub.Score
   , recordInvalidMessage
   , recordMeshFailure
   , addP7Penalty
+    -- * Mesh membership marking
+  , markPeerInMesh
+  , unmarkPeerInMesh
+  , refreshMeshTime
   ) where
 
 import Data.ByteString (ByteString)
@@ -96,8 +100,8 @@ computeP7 ps = psBehaviorPenalty ps * psBehaviorPenalty ps
 
 -- | Compute full peer score per the gossipsub v1.1 scoring formula.
 -- Takes explicit PeerId for the P5 application-specific callback.
-computeScore :: PeerScoreParams -> PeerState -> Map.Map ByteString (Set.Set PeerId) -> UTCTime -> Double
-computeScore params ps ipMap now =
+computeScore :: PeerScoreParams -> PeerId -> PeerState -> Map.Map ByteString (Set.Set PeerId) -> UTCTime -> Double
+computeScore params pid ps ipMap now =
   let -- Topic score: sum over topics
       topicScore = Map.foldlWithKey' (\acc topic tps ->
         case Map.lookup topic (pspTopicParams params) of
@@ -119,8 +123,8 @@ computeScore params ps ipMap now =
            then cap
            else topicScore
 
-      -- P5: not computed here (requires PeerId from router context).
-      -- Use computeScoreForPeer in Router for full P5 support.
+      -- P5: application-specific score
+      p5 = pspAppSpecificWeight params * pspAppSpecificScore params pid
 
       -- P6: IP colocation
       p6 = pspIPColocationFactorWeight params * computeP6 params ps ipMap
@@ -128,7 +132,7 @@ computeScore params ps ipMap now =
       -- P7: behavioral penalty
       p7 = pspBehaviorPenaltyWeight params * computeP7 ps
 
-  in cappedTopicScore + p6 + p7
+  in cappedTopicScore + p5 + p6 + p7
 
 -- Decay
 
@@ -196,3 +200,33 @@ recordMeshFailure tsp tps =
 -- | Increment P7 behavioral penalty counter by 1.
 addP7Penalty :: PeerState -> PeerState
 addP7Penalty ps = ps { psBehaviorPenalty = psBehaviorPenalty ps + 1 }
+
+-- Mesh membership marking
+
+-- | Mark a peer as being in the mesh for a topic (P1/P3 start counting).
+-- Resets the mesh clock: graft time is now, accrued mesh time is zero.
+markPeerInMesh :: Topic -> UTCTime -> PeerState -> PeerState
+markPeerInMesh topic now ps =
+  let tps = Map.findWithDefault defaultTopicPeerState topic (psTopicState ps)
+      tps' = tps { tpsInMesh = True, tpsGraftTime = Just now, tpsMeshTime = 0 }
+  in ps { psTopicState = Map.insert topic tps' (psTopicState ps) }
+
+-- | Mark a peer as no longer in the mesh for a topic. Counters are kept
+-- (they decay on heartbeat); only the mesh clock stops.
+unmarkPeerInMesh :: Topic -> PeerState -> PeerState
+unmarkPeerInMesh topic ps =
+  case Map.lookup topic (psTopicState ps) of
+    Nothing -> ps
+    Just tps ->
+      let tps' = tps { tpsInMesh = False, tpsGraftTime = Nothing }
+      in ps { psTopicState = Map.insert topic tps' (psTopicState ps) }
+
+-- | Refresh accrued mesh time (P1 input) from the graft timestamp.
+-- Run on each heartbeat before scores are consulted.
+refreshMeshTime :: UTCTime -> PeerState -> PeerState
+refreshMeshTime now ps =
+  ps { psTopicState = Map.map refresh (psTopicState ps) }
+  where
+    refresh tps = case (tpsInMesh tps, tpsGraftTime tps) of
+      (True, Just gt) -> tps { tpsMeshTime = diffUTCTime now gt }
+      _               -> tps

--- a/src/LibP2P/Protocol/GossipSub/Types.hs
+++ b/src/LibP2P/Protocol/GossipSub/Types.hs
@@ -194,6 +194,8 @@ data GossipSubParams = GossipSubParams
   , paramSignaturePolicy    :: !SignaturePolicy  -- ^ Signing policy (default StrictSign)
   , paramMcacheLen          :: !Int              -- ^ Message cache windows (default 5)
   , paramMcacheGossip       :: !Int              -- ^ Gossip windows (default 3)
+  , paramPrunePeers         :: !Int              -- ^ PX peers included in PRUNE (default 16)
+  , paramIWantFollowupTime  :: !NominalDiffTime  -- ^ IWANT promise deadline (default 3s)
   }
 
 -- | Default message ID: concatenation of from and seqno fields.
@@ -223,6 +225,8 @@ defaultGossipSubParams = GossipSubParams
   , paramSignaturePolicy   = StrictSign
   , paramMcacheLen         = 5
   , paramMcacheGossip      = 3
+  , paramPrunePeers        = 16
+  , paramIWantFollowupTime = 3
   }
 
 -- Peer tracking
@@ -403,9 +407,17 @@ data GossipSubRouter = GossipSubRouter
   , gsBackoff     :: !(TVar (Map (PeerId, Topic) UTCTime))
     -- Scoring (Phase 9b)
   , gsScoreParams :: !PeerScoreParams
+    -- ^ Scoring parameters. A plain (immutable) field: configure it via
+    -- record update right after 'newRouter' — all mutable state lives in
+    -- shared TVars, so the updated record operates on the same router.
+    -- Topics without an entry in 'pspTopicParams' contribute no topic score.
   , gsThresholds  :: !ScoreThresholds
   , gsIPPeerCount :: !(TVar (Map ByteString (Set PeerId)))
     -- ^ IP address → peers sharing that IP (for P6)
+  , gsIWantPromises :: !(TVar (Map (PeerId, MessageId) UTCTime))
+    -- ^ IWANT promises: message IDs a peer advertised via IHAVE and we
+    -- requested, with the delivery deadline. A promise still unfulfilled
+    -- past its deadline is a P7 behavioural violation (gossipsub-v1.1.md).
     -- Message cache (Phase 9c)
   , gsMessageCache  :: !(TVar MessageCache)
     -- ^ Sliding-window message cache for IWANT and IHAVE
@@ -420,6 +432,10 @@ data GossipSubRouter = GossipSubRouter
     -- ^ Application message callback
   , gsValidators  :: !(TVar (Map Topic TopicValidator))
     -- ^ Per-topic application validators, applied before propagation
+  , gsOnPeerExchange :: !(TVar (Topic -> [PeerExchangeInfo] -> IO ()))
+    -- ^ Called with PX records from a PRUNE whose sender scores at or
+    -- above 'stAcceptPXThreshold'. The application decides how to act
+    -- (e.g. resolve addresses and dial); default is a no-op.
   }
 
 -- Defaults

--- a/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
@@ -138,7 +138,7 @@ spec = do
       -- Create memory stream pair: remote side writes, handler reads
       (remoteStream, handlerStream) <- mkMemoryStreamPair
       -- Spawn handler in background (blocks on read loop)
-      _ <- async $ handleGossipSubStream node handlerStream remotePid
+      _ <- async $ handleGossipSubStream node handlerStream remotePid Nothing
       -- Send a subscription RPC from remote
       writeRPCMessage remoteStream (subscribeRPC "test-topic")
       -- Give handler time to process
@@ -162,7 +162,7 @@ spec = do
       addPeer (gsnRouter node) remotePid GossipSubPeer False now
       (remoteStream, handlerStream) <- mkMemoryStreamPair
       -- Spawn handler
-      _ <- async $ handleGossipSubStream node handlerStream remotePid
+      _ <- async $ handleGossipSubStream node handlerStream remotePid Nothing
       -- Send a publish RPC
       let msg = signedMessage remoteKp "pub-topic" "hello gossipsub"
       writeRPCMessage remoteStream (emptyRPC { rpcPublish = [msg] })
@@ -297,8 +297,8 @@ spec = do
       (streamAtoB, streamBfromA) <- mkMemoryStreamPair
       (streamBtoA, streamAfromB) <- mkMemoryStreamPair
       -- Spawn stream handlers
-      _ <- async $ handleGossipSubStream nodeB streamBfromA pidA
-      _ <- async $ handleGossipSubStream nodeA streamAfromB pidB
+      _ <- async $ handleGossipSubStream nodeB streamBfromA pidA Nothing
+      _ <- async $ handleGossipSubStream nodeA streamAfromB pidB Nothing
       -- Inject cached outbound streams for sendRPC
       atomically $ do
         writeTVar (gsnStreams nodeA) (Map.singleton pidB streamAtoB)
@@ -328,8 +328,8 @@ spec = do
       (streamAtoB, streamBfromA) <- mkMemoryStreamPair
       (streamBtoA, streamAfromB) <- mkMemoryStreamPair
       -- Spawn stream handlers (registers peers in each router)
-      _ <- async $ handleGossipSubStream nodeB streamBfromA pidA
-      _ <- async $ handleGossipSubStream nodeA streamAfromB pidB
+      _ <- async $ handleGossipSubStream nodeB streamBfromA pidA Nothing
+      _ <- async $ handleGossipSubStream nodeA streamAfromB pidB Nothing
       -- Inject cached outbound streams
       atomically $ do
         writeTVar (gsnStreams nodeA) (Map.singleton pidB streamAtoB)

--- a/test/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
@@ -13,6 +13,7 @@ import LibP2P.Crypto.PeerId (PeerId (..))
 import LibP2P.Protocol.GossipSub.Types
 import LibP2P.Protocol.GossipSub.Router (newRouter, addPeer, peerScore)
 import LibP2P.Protocol.GossipSub.MessageCache (newMessageCache, cachePut, cacheGetGossipIds)
+import LibP2P.Protocol.GossipSub.Score (markPeerInMesh)
 import LibP2P.Protocol.GossipSub.Heartbeat
 
 -- Test helpers
@@ -348,3 +349,121 @@ spec = do
         heartbeatOnce router
         count2 <- readTVarIO (gsHeartbeatCount router)
         count2 `shouldBe` 2
+
+    -- Issue #156: P1 mesh time was never accrued, so time-in-mesh never
+    -- contributed to any score.
+    describe "P1 mesh time accrual" $ do
+      it "accrues mesh time on heartbeat and yields a positive score" $ do
+        (router, _, timeRef) <- mkHeartbeatRouter localPid fixedTime
+        let tsp = defaultTopicScoreParams { tspMeshMessageDeliveriesThreshold = 0 }
+            routerP1 = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspTopicParams = Map.singleton "t" tsp } }
+            pid = mkPeerId 1
+        addMeshPeer routerP1 pid "t" fixedTime
+        atomically $ modifyTVar' (gsPeers routerP1) $
+          Map.adjust (markPeerInMesh "t" fixedTime) pid
+        writeIORef timeRef (addUTCTime 10 fixedTime)
+        heartbeatOnce routerP1
+        peers <- readTVarIO (gsPeers routerP1)
+        case Map.lookup pid peers >>= Map.lookup "t" . psTopicState of
+          Just tps -> tpsMeshTime tps `shouldBe` 10
+          Nothing -> expectationFailure "topic state not found"
+        score <- peerScore routerP1 pid
+        score `shouldSatisfy` (> 0)
+
+    -- Issue #156/#157: IWANT promises (P7) and gossip threshold.
+    describe "IWANT promise expiry (P7)" $ do
+      it "penalizes peers whose IWANT promise expired undelivered" $ do
+        (router, _, timeRef) <- mkHeartbeatRouter localPid fixedTime
+        let pid = mkPeerId 1
+        addPeer router pid GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsIWantPromises router) $
+          Map.insert (pid, BS.pack [1]) (addUTCTime 3 fixedTime)
+        writeIORef timeRef (addUTCTime 4 fixedTime)
+        heartbeatOnce router
+        peers <- readTVarIO (gsPeers router)
+        case Map.lookup pid peers of
+          Just ps -> psBehaviorPenalty ps `shouldSatisfy` (> 0)
+          Nothing -> expectationFailure "peer not found"
+        promises <- readTVarIO (gsIWantPromises router)
+        promises `shouldBe` Map.empty
+
+      it "does not penalize before the deadline" $ do
+        (router, _, _) <- mkHeartbeatRouter localPid fixedTime
+        let pid = mkPeerId 1
+        addPeer router pid GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsIWantPromises router) $
+          Map.insert (pid, BS.pack [1]) (addUTCTime 3 fixedTime)
+        heartbeatOnce router
+        peers <- readTVarIO (gsPeers router)
+        case Map.lookup pid peers of
+          Just ps -> psBehaviorPenalty ps `shouldBe` 0
+          Nothing -> expectationFailure "peer not found"
+
+    describe "Gossip threshold" $ do
+      it "emits no IHAVE to peers below the gossip threshold" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        let badPeer = mkPeerId 10
+            routerTh = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = \pid ->
+                      if pid == badPeer then -200 else 0 } }
+        mapM_ (\pid -> addMeshPeer routerTh pid "t" fixedTime) (map mkPeerId [1..6])
+        addSubscribedPeer routerTh badPeer "t" fixedTime
+        let mid = BS.pack [42]
+            msg = PubSubMessage (Just (BS.pack [1])) (BS.pack [1]) (Just mid) "t" Nothing Nothing
+        atomically $ modifyTVar' (gsMessageCache routerTh) $ cachePut mid msg
+        heartbeatOnce routerTh
+        sent <- readIORef logRef
+        let ihaveTo = [ pid | (pid, rpc) <- sent
+                            , Just ctrl <- [rpcControl rpc]
+                            , not (null (ctrlIHave ctrl)) ]
+        badPeer `shouldSatisfy` (`notElem` ihaveTo)
+
+    -- Issue #156 (score-aware trim) and #157 (PX on PRUNE).
+    describe "Score-aware mesh trim" $ do
+      it "keeps the best D_score peers and PRUNEs with peer exchange" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        let appScore pid = let PeerId bs = pid in fromIntegral (BS.head bs)
+            routerSc = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = appScore } }
+        mapM_ (\pid -> addMeshPeer routerSc pid "t" fixedTime) (map mkPeerId [1..15])
+        heartbeatOnce routerSc
+        mesh <- readTVarIO (gsMesh routerSc)
+        let kept = Map.findWithDefault Set.empty "t" mesh
+        Set.size kept `shouldBe` 6
+        -- D_score = 4: the four best-scoring peers survive the trim
+        mapM_ (\n -> Set.member (mkPeerId n) kept `shouldBe` True) [12..15 :: Int]
+        -- PRUNEs to removed peers carry PX records (#157)
+        sent <- readIORef logRef
+        let pxPrunes = [ p | (_, rpc) <- sent
+                           , Just ctrl <- [rpcControl rpc]
+                           , p <- ctrlPrune ctrl
+                           , not (null (prunePeers p)) ]
+        length pxPrunes `shouldSatisfy` (>= 1)
+
+      it "keeps at least D_out outbound peers when trimming" $ do
+        (router, _, _) <- mkHeartbeatRouter localPid fixedTime
+        let appScore pid = let PeerId bs = pid in fromIntegral (BS.head bs)
+            routerSc = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = appScore } }
+        -- Peers 1-2 are outbound with the lowest scores; 3-15 inbound
+        mapM_ (\n -> do
+                let pid = mkPeerId n
+                addPeer routerSc pid GossipSubPeer True fixedTime
+                atomically $ do
+                  modifyTVar' (gsPeers routerSc) $
+                    Map.adjust (\ps -> ps { psTopics = Set.singleton "t" }) pid
+                  modifyTVar' (gsMesh routerSc) $
+                    Map.insertWith Set.union "t" (Set.singleton pid))
+          [1, 2 :: Int]
+        mapM_ (\n -> addMeshPeer routerSc (mkPeerId n) "t" fixedTime) [3..15 :: Int]
+        heartbeatOnce routerSc
+        mesh <- readTVarIO (gsMesh routerSc)
+        let kept = Map.findWithDefault Set.empty "t" mesh
+        Set.size kept `shouldBe` 6
+        Set.member (mkPeerId 1) kept `shouldBe` True
+        Set.member (mkPeerId 2) kept `shouldBe` True

--- a/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
@@ -328,20 +328,18 @@ spec = do
                 Nothing -> False) sent
         length pruneMsgs `shouldBe` 0
 
-      it "does not add the sender to the mesh for an unsubscribed topic" $ do
-        (router, _) <- mkTestRouter localPid
+      it "ignores a GRAFT for an unsubscribed topic entirely" $ do
+        (router, logRef) <- mkTestRouter localPid
         let sender = mkPeerId 1
         addPeer router sender GossipSubPeer False fixedTime
         handleGraft router sender [Graft "unknown-topic"]
         -- The sender must never enter a mesh for a topic we are not
-        -- subscribed to. Note: the reply behaviour is deliberately NOT
-        -- asserted here. The router currently answers with PRUNE, but
-        -- gossipsub-v1.1.md requires ignoring a GRAFT for an unknown topic
-        -- entirely (the PRUNE reply is a spam amplification vector). The
-        -- previous version of this test asserted the PRUNE reply as correct;
-        -- the reply fix is tracked in #157.
+        -- subscribed to, and per gossipsub-v1.1.md the GRAFT is ignored
+        -- entirely: replying with PRUNE (the v1.0 behaviour) is a spam
+        -- amplification vector (#157).
         mesh <- readTVarIO (gsMesh router)
         Map.findWithDefault Set.empty "unknown-topic" mesh `shouldBe` Set.empty
+        readIORef logRef `shouldReturn` []
 
       it "rejects graft during backoff (sends PRUNE with backoff)" $ do
         (router, logRef, timeRef) <- mkTestRouterWithTime localPid fixedTime
@@ -354,11 +352,13 @@ spec = do
         atomically $ modifyTVar' (gsBackoff router) $
           Map.insert (sender, "blocks") backoffExpiry
         handleGraft router sender [Graft "blocks"]
-        -- Should send PRUNE
+        -- Should send PRUNE carrying a fresh backoff (GRAFT flood
+        -- protection, gossipsub-v1.1.md; #157)
         sent <- readIORef logRef
         let pruneMsgs = filter (\(pid, rpc) ->
               pid == sender && case rpcControl rpc of
-                Just ctrl -> any (\p -> pruneTopic p == "blocks") (ctrlPrune ctrl)
+                Just ctrl -> any (\p -> pruneTopic p == "blocks"
+                                     && pruneBackoff p == Just 60) (ctrlPrune ctrl)
                 Nothing -> False) sent
         length pruneMsgs `shouldBe` 1
         -- Sender should NOT be in mesh
@@ -840,6 +840,212 @@ spec = do
           Just ps -> psBehaviorPenalty ps `shouldBe` 1
           Nothing -> expectationFailure "peer not found"
 
+      -- Issue #156: every counter feeding the score formula was write-free
+      it "GRAFT acceptance starts the P1 mesh clock" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "blocks")
+        handleGraft router sender [Graft "blocks"]
+        peers <- readTVarIO (gsPeers router)
+        case Map.lookup sender peers >>= Map.lookup "blocks" . psTopicState of
+          Just tps -> do
+            tpsInMesh tps `shouldBe` True
+            tpsGraftTime tps `shouldBe` Just fixedTime
+          Nothing -> expectationFailure "topic state not created on GRAFT"
+
+      it "first valid delivery increments P2 for the sender" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        kp <- newKeyPair
+        handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
+        peers <- readTVarIO (gsPeers router)
+        case Map.lookup sender peers >>= Map.lookup "t" . psTopicState of
+          Just tps -> tpsFirstMessageDeliveries tps `shouldBe` 1
+          Nothing -> expectationFailure "no topic state recorded"
+
+      it "delivery from a mesh peer increments P3" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.singleton sender)
+        kp <- newKeyPair
+        handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
+        peers <- readTVarIO (gsPeers router)
+        case Map.lookup sender peers >>= Map.lookup "t" . psTopicState of
+          Just tps -> tpsMeshMessageDeliveries tps `shouldBe` 1
+          Nothing -> expectationFailure "no topic state recorded"
+
+      it "duplicate delivery within the window counts P3 but not P2" $ do
+        (router, _) <- mkTestRouter localPid
+        let first  = mkPeerId 1
+            second = mkPeerId 2
+        addPeer router first GossipSubPeer False fixedTime
+        addPeer router second GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.fromList [first, second])
+        kp <- newKeyPair
+        let msg = signedMessage kp "t" (BS.pack [1])
+        handleRPC router first emptyRPC { rpcPublish = [msg] }
+        handleRPC router second emptyRPC { rpcPublish = [msg] }
+        peers <- readTVarIO (gsPeers router)
+        case Map.lookup second peers >>= Map.lookup "t" . psTopicState of
+          Just tps -> do
+            tpsFirstMessageDeliveries tps `shouldBe` 0
+            tpsMeshMessageDeliveries tps `shouldBe` 1
+          Nothing -> expectationFailure "no topic state recorded"
+
+      it "peerScore includes P5 (application-specific score)" $ do
+        (router, _) <- mkTestRouter localPid
+        let pid = mkPeerId 1
+            routerP5 = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const 42 }
+              }
+        addPeer routerP5 pid GossipSubPeer False fixedTime
+        peerScore routerP5 pid `shouldReturn` 42
+
+      it "setPeerIP feeds P6 IP colocation" $ do
+        (router, _) <- mkTestRouter localPid
+        let pids = map mkPeerId [1..4]
+            ip = BS.pack [10, 0, 0, 1]
+        mapM_ (\pid -> addPeer router pid GossipSubPeer False fixedTime) pids
+        mapM_ (\pid -> setPeerIP router pid ip) pids
+        -- Threshold is 3, so 4 peers on one IP give excess 1: P6 = 1,
+        -- weight -10 => score -10
+        mapM_ (\pid -> peerScore router pid `shouldReturn` (-10)) pids
+
+      it "removePeer clears the P6 IP colocation entry" $ do
+        (router, _) <- mkTestRouter localPid
+        let pid = mkPeerId 1
+            ip = BS.pack [10, 0, 0, 1]
+        addPeer router pid GossipSubPeer False fixedTime
+        setPeerIP router pid ip
+        removePeer router pid
+        ipMap <- readTVarIO (gsIPPeerCount router)
+        Map.member ip ipMap `shouldBe` False
+
+      it "graylisted peers have their RPCs ignored" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            routerGl = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const (-20000) }
+              }
+        addPeer routerGl sender GossipSubPeer False fixedTime
+        -- Below stGraylistThreshold (-10000): the subscription is dropped
+        handleRPC routerGl sender emptyRPC { rpcSubscriptions = [SubOpts True "t"] }
+        peers <- readTVarIO (gsPeers routerGl)
+        case Map.lookup sender peers of
+          Just ps -> psTopics ps `shouldBe` Set.empty
+          Nothing -> expectationFailure "peer not found"
+
+      it "flood publish skips peers below the publish threshold" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let good = mkPeerId 1
+            bad  = mkPeerId 2
+            routerTh = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = \pid -> if pid == bad then -2000 else 0 }
+              }
+        addSubscribedPeer routerTh good "blocks"
+        addSubscribedPeer routerTh bad "blocks"
+        kp <- newKeyPair
+        publish routerTh "blocks" (BS.pack [1]) (Just kp)
+        sent <- readIORef logRef
+        let publishedTo = map fst $ filter (\(_, rpc) -> not (null (rpcPublish rpc))) sent
+        publishedTo `shouldBe` [good]
+
+    describe "PRUNE peer exchange (#157)" $ do
+      it "leave sends PRUNE with PX records for other topic peers" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let meshPeer = mkPeerId 1
+            otherA = mkPeerId 2
+            otherB = mkPeerId 3
+        mapM_ (\pid -> addSubscribedPeer router pid "blocks") [meshPeer, otherA, otherB]
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "blocks" (Set.singleton meshPeer)
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "blocks")
+        writeIORef logRef []
+        leave router "blocks"
+        sent <- readIORef logRef
+        let pxSets = [ map pxPeerId (prunePeers p)
+                     | (pid, rpc) <- sent
+                     , pid == meshPeer
+                     , Just ctrl <- [rpcControl rpc]
+                     , p <- ctrlPrune ctrl
+                     , pruneTopic p == "blocks" ]
+        case pxSets of
+          [pxIds] -> do
+            let PeerId bytesA = otherA
+                PeerId bytesB = otherB
+            Set.fromList pxIds `shouldBe` Set.fromList [bytesA, bytesB]
+          _ -> expectationFailure "expected exactly one PRUNE with PX to the mesh peer"
+
+      it "honours PX from a sender above the acceptance threshold" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            routerPx = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const 200 }  -- >= stAcceptPXThreshold (100)
+              }
+        addPeer routerPx sender GossipSubPeer False fixedTime
+        receivedRef <- newIORef ([] :: [(Topic, [PeerExchangeInfo])])
+        atomically $ writeTVar (gsOnPeerExchange routerPx) $ \t px ->
+          modifyIORef' receivedRef (++ [(t, px)])
+        let px = [PeerExchangeInfo (BS.pack [9]) Nothing]
+        handlePrune routerPx sender [Prune "t" px (Just 60)]
+        readIORef receivedRef `shouldReturn` [("t", px)]
+
+      it "ignores PX from a sender below the acceptance threshold" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        receivedRef <- newIORef ([] :: [(Topic, [PeerExchangeInfo])])
+        atomically $ writeTVar (gsOnPeerExchange router) $ \t px ->
+          modifyIORef' receivedRef (++ [(t, px)])
+        -- Default score is 0, below stAcceptPXThreshold (100)
+        handlePrune router sender [Prune "t" [PeerExchangeInfo (BS.pack [9]) Nothing] (Just 60)]
+        readIORef receivedRef `shouldReturn` []
+
+    describe "IWANT promise tracking (#157/#156 P7)" $ do
+      it "records a promise when requesting from an IHAVE" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            mid = BS.pack [1, 2, 3]
+        addPeer router sender GossipSubPeer False fixedTime
+        handleIHave router sender [IHave "t" [mid]]
+        promises <- readTVarIO (gsIWantPromises router)
+        Map.member (sender, mid) promises `shouldBe` True
+
+      it "clears the promise when the message is delivered" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        kp <- newKeyPair
+        let msg = signedMessage kp "t" (BS.pack [1])
+            mid = defaultMessageId msg
+        handleIHave router sender [IHave "t" [mid]]
+        promises0 <- readTVarIO (gsIWantPromises router)
+        Map.member (sender, mid) promises0 `shouldBe` True
+        handleRPC router sender emptyRPC { rpcPublish = [msg] }
+        promises1 <- readTVarIO (gsIWantPromises router)
+        promises1 `shouldBe` Map.empty
+
+      it "ignores IHAVE from peers below the gossip threshold" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            routerTh = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const (-200) }  -- < stGossipThreshold (-100)
+              }
+        addPeer routerTh sender GossipSubPeer False fixedTime
+        handleIHave routerTh sender [IHave "t" [BS.pack [1]]]
+        readIORef logRef `shouldReturn` []
+
+    describe "P3b mesh failure penalty" $ do
       it "handlePrune records P3b mesh failure" $ do
         (router, _) <- mkTestRouter localPid
         let sender = mkPeerId 1

--- a/test/LibP2P/Protocol/GossipSub/ScoreSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/ScoreSpec.hs
@@ -172,7 +172,7 @@ spec = do
       it "returns 0 for all-zero counters" $ do
         let ps = mkPeerState (Map.singleton "t" defaultTopicPeerState)
             params = mkScoreParams "t" defaultTopicScoreParams
-        computeScore params ps emptyIPMap fixedTime `shouldBe` 0
+        computeScore params (mkPeerId 1) ps emptyIPMap fixedTime `shouldBe` 0
 
       it "computes positive score for first deliveries" $ do
         let tps = defaultTopicPeerState
@@ -185,7 +185,7 @@ spec = do
         -- P1 = min(5/1, 100) = 5, w1=0.01 => 0.05
         -- P2 = min(10, 100) = 10, w2=1.0 => 10
         -- Topic score = 1.0 * (0.05 + 10) = 10.05
-        let score = computeScore params ps emptyIPMap fixedTime
+        let score = computeScore params (mkPeerId 1) ps emptyIPMap fixedTime
         score `shouldSatisfy` (> 0)
         abs (score - 10.05) `shouldSatisfy` (< 0.01)
 
@@ -196,7 +196,7 @@ spec = do
             params = mkScoreParams "t" tsp
         -- P4 = 2^2 = 4, w4=-100 => -400
         -- Topic score = 1.0 * (-400) = -400
-        let score = computeScore params ps emptyIPMap fixedTime
+        let score = computeScore params (mkPeerId 1) ps emptyIPMap fixedTime
         score `shouldSatisfy` (< 0)
 
       it "applies TopicScoreCap to topic portion" $ do
@@ -205,8 +205,62 @@ spec = do
             tsp = defaultTopicScoreParams
             params = (mkScoreParams "t" tsp) { pspTopicScoreCap = 10 }
         -- P2 = 100, w2=1 => 100, but TopicCap=10
-        let score = computeScore params ps emptyIPMap fixedTime
+        let score = computeScore params (mkPeerId 1) ps emptyIPMap fixedTime
         score `shouldSatisfy` (<= 10)
+
+      -- Issue #156: P5 was omitted from computeScore entirely
+      it "includes the P5 application-specific score" $ do
+        let ps = mkPeerState Map.empty
+            params = defaultPeerScoreParams
+              { pspAppSpecificScore = \pid -> if pid == mkPeerId 1 then 42 else 0
+              , pspAppSpecificWeight = 2
+              }
+        computeScore params (mkPeerId 1) ps emptyIPMap fixedTime `shouldBe` 84
+        computeScore params (mkPeerId 2) ps emptyIPMap fixedTime `shouldBe` 0
+
+    -- Mesh membership marking (issue #156: tpsInMesh/tpsGraftTime were
+    -- assigned only in defaultTopicPeerState and never updated)
+    describe "mesh membership marking" $ do
+      it "markPeerInMesh starts the mesh clock" $ do
+        let ps = mkPeerState Map.empty
+            ps' = markPeerInMesh "t" fixedTime ps
+        case Map.lookup "t" (psTopicState ps') of
+          Just tps -> do
+            tpsInMesh tps `shouldBe` True
+            tpsGraftTime tps `shouldBe` Just fixedTime
+            tpsMeshTime tps `shouldBe` 0
+          Nothing -> expectationFailure "topic state not created"
+
+      it "unmarkPeerInMesh stops the clock but keeps counters" $ do
+        let tps0 = defaultTopicPeerState
+              { tpsInMesh = True
+              , tpsGraftTime = Just fixedTime
+              , tpsFirstMessageDeliveries = 7
+              }
+            ps = mkPeerState (Map.singleton "t" tps0)
+            ps' = unmarkPeerInMesh "t" ps
+        case Map.lookup "t" (psTopicState ps') of
+          Just tps -> do
+            tpsInMesh tps `shouldBe` False
+            tpsGraftTime tps `shouldBe` Nothing
+            tpsFirstMessageDeliveries tps `shouldBe` 7
+          Nothing -> expectationFailure "topic state lost"
+
+      it "refreshMeshTime accrues time since graft for in-mesh peers" $ do
+        let tps0 = defaultTopicPeerState
+              { tpsInMesh = True, tpsGraftTime = Just fixedTime }
+            ps = mkPeerState (Map.singleton "t" tps0)
+            ps' = refreshMeshTime (addUTCTime 30 fixedTime) ps
+        case Map.lookup "t" (psTopicState ps') of
+          Just tps -> tpsMeshTime tps `shouldBe` 30
+          Nothing  -> expectationFailure "topic state lost"
+
+      it "refreshMeshTime leaves non-mesh peers untouched" $ do
+        let ps = mkPeerState (Map.singleton "t" defaultTopicPeerState)
+            ps' = refreshMeshTime (addUTCTime 30 fixedTime) ps
+        case Map.lookup "t" (psTopicState ps') of
+          Just tps -> tpsMeshTime tps `shouldBe` 0
+          Nothing  -> expectationFailure "topic state lost"
 
     -- Decay
     describe "decayScores" $ do


### PR DESCRIPTION
## Summary

Fixes the two medium gossipsub issues in one branch (same module): #156 (peer scoring structurally complete but all counters unwritten) and #157 (PRUNE peer exchange and GRAFT flood protection missing).

## Issue #156 — peer scoring is now live

Every counter feeding the v1.1 score formula is now written where the corresponding event happens, and scores are consulted where the spec requires:

- **P1 (time in mesh)**: mesh membership is marked (`tpsInMesh`/`tpsGraftTime`) on GRAFT acceptance, `join`, and heartbeat fill, and unmarked on every prune path; accrued mesh time is refreshed each heartbeat.
- **P2/P3 (first/mesh message deliveries)**: recorded in `handlePublishedMessage` — first valid delivery counts P2 (and P3 for mesh senders); duplicates count P3 only inside the near-first delivery window.
- **P3b/P4**: already wired on main (PRUNE mesh-failure snapshot, invalid-message counting); kept as-is.
- **P5**: the application-specific score was omitted from `computeScore` entirely — now included (signature takes the `PeerId`).
- **P6 (IP colocation)**: new `setPeerIP` maintains `psIPAddress` and `gsIPPeerCount`; the Switch handler feeds it from the connection's remote multiaddr. `removePeer` cleans up.
- **P7 (behavioural)**: in addition to the existing GRAFT-during-backoff penalty, IWANT promises are tracked (one random ID per IHAVE-elicited IWANT) and expired promises are penalised on heartbeat.
- **Decay** already ran on heartbeat; it now also refreshes P1 mesh time.
- **Thresholds in use**: graylist gate on `handleRPC`, publish threshold on flood publish, gossip threshold on IHAVE/IWANT handling and gossip emission, score `< 0` gates on mesh fill and GRAFT acceptance (existing), and the oversubscription trim is now score-aware: keeps the best `D_score` peers, fills the rest at random, under the `D_out` outbound constraint.

Not covered (listed in #156's "consequently missing" section but outside the agreed scope): opportunistic grafting. The scoring plumbing it needs (median mesh score, `gsHeartbeatCount`) is now in place.

## Issue #157 — PX and GRAFT flood protection (partial: `Refs`, not `Closes`)

- **PRUNE carries PX**: `leave` and the heartbeat trim attach up to `paramPrunePeers` (16) records of non-negative-score topic peers. No PX is given to negative-score or backoff-violating peers.
- **Received PX is honoured subject to score**: `handleOnePrune` invokes the new `gsOnPeerExchange` callback only when the pruning peer's score clears `stAcceptPXThreshold`. The router surfaces the records rather than dialling: PX records carry peer IDs (no addresses without signed peer records), so acting on them requires the application's peer store/discovery.
- **GRAFT flood protection**: GRAFT for an unsubscribed topic is now **ignored entirely** per gossipsub-v1.1.md (the v1.0 PRUNE reply is a spam amplification vector) — the RouterSpec test that deliberately deferred this assertion pending #157 now asserts no reply is sent. GRAFT during backoff keeps the P7 penalty and re-prunes with a fresh backoff; score-rejected GRAFTs also set a backoff.

**Explicitly split out of this PR** (remaining #157 items): multi-protocol negotiation (`/meshsub/1.0.0` fallback and `/floodsub/1.0.0`, which needs a per-peer protocol-version model and version-gated PRUNE construction), IHAVE/IWANT count caps, and direct peering agreements. This PR therefore closes #156 and refs #157.

## Tests

New tests (TDD, all green — 852 examples, 0 failures with GHC 9.10.3):
- counters move on events: GRAFT starts the P1 mesh clock; P2/P3 on deliveries; duplicate-within-window counts P3 not P2
- P5 in `peerScore`; `setPeerIP` → P6 penalty; `removePeer` cleanup
- decay on heartbeat (existing) plus P1 accrual across heartbeats
- graylist, publish threshold, gossip threshold (router and heartbeat sides)
- PRUNE carries PX on `leave` and on trim; PX honoured above / ignored below `stAcceptPXThreshold`
- unknown-topic GRAFT ignored with **no** reply (strengthened #197 test); backoff GRAFT re-pruned with backoff + P7
- IWANT promise recorded, cleared on delivery, penalised on expiry
- score-aware trim keeps best `D_score` and at least `D_out` outbound peers

Closes #156
Refs #157