### PR TITLE
fix(ping): reuse one outbound stream per peer and close it when done

### DIFF
--- a/interop/Main.hs
+++ b/interop/Main.hs
@@ -224,7 +224,7 @@ runDialer sw _pid redisConn timeoutS = do
               Right conn -> do
                 -- A single ping (README steps 5-6): its round-trip time is
                 -- pingRTT, and the total elapsed since t0 is handshakePlusOneRTT.
-                pingResult <- sendPing conn
+                pingResult <- sendPing sw conn
                 t1 <- getCurrentTime
 
                 case pingResult of

--- a/src/LibP2P.hs
+++ b/src/LibP2P.hs
@@ -72,6 +72,12 @@ module LibP2P
     -- * Ping protocol
   , registerPingHandler
   , sendPing
+  , PingSession
+  , openPingSession
+  , ping
+  , pingWithTimeout
+  , closePingSession
+  , withPingSession
   , PingResult (..)
   , PingError (..)
 
@@ -127,7 +133,18 @@ import LibP2P.Protocol.GossipSub.Handler
   )
 import LibP2P.Protocol.GossipSub.Types (GossipSubParams (..), defaultGossipSubParams)
 import LibP2P.Protocol.Identify (registerIdentifyHandlers, requestIdentify)
-import LibP2P.Protocol.Ping (PingError (..), PingResult (..), registerPingHandler, sendPing)
+import LibP2P.Protocol.Ping
+  ( PingError (..)
+  , PingResult (..)
+  , PingSession
+  , closePingSession
+  , openPingSession
+  , ping
+  , pingWithTimeout
+  , registerPingHandler
+  , sendPing
+  , withPingSession
+  )
 import LibP2P.Switch.Connection (closeConnection, newStream)
 import LibP2P.Switch.Dial (dial)
 import LibP2P.Switch.Listen (ConnectionGater (..), defaultConnectionGater, switchListen, switchListenAddrs)

--- a/src/LibP2P/Protocol/Ping.hs
+++ b/src/LibP2P/Protocol/Ping.hs
@@ -3,28 +3,46 @@
 -- Protocol ID: /ipfs/ping/1.0.0
 --
 -- Wire format: 32 bytes random → 32 bytes echo. No framing, no protobuf.
--- The handler runs an echo loop: reads 32 bytes, writes them back,
--- until the stream closes. The initiator sends 32 random bytes,
--- measures round-trip time, and verifies the echo matches.
+-- The responder runs an echo loop: reads 32 bytes, writes them back,
+-- until the initiator closes the stream, then closes its own side.
+--
+-- The initiator keeps at most one outbound ping stream per peer
+-- (ping.md: "The dialing peer MUST NOT keep more than one outbound
+-- stream for the ping protocol per peer"). A 'PingSession' holds that
+-- single stream and reuses it for successive pings (ping.md: the peer
+-- "MAY send further payloads on the same stream"); the stream is closed
+-- when the session ends or on the first failed ping. Streams are opened
+-- through the Switch ('newStream'), so each session holds exactly one
+-- stream reservation, released on close.
 module LibP2P.Protocol.Ping
   ( -- * Protocol ID
     pingProtocolId
     -- * Types
   , PingError (..)
   , PingResult (..)
-    -- * Protocol logic
+  , PingSession
+    -- * Responder
   , handlePing
+    -- * Initiator
   , sendPing
+  , openPingSession
+  , ping
+  , pingWithTimeout
+  , closePingSession
+  , withPingSession
     -- * Registration
   , registerPingHandler
     -- * Constants
   , pingSize
+  , pingTimeoutMicros
   ) where
 
 import Control.Concurrent.STM (atomically, readTVar, writeTVar)
-import Control.Exception (SomeException, catch)
+import Control.Exception (SomeException, catch, finally, try)
+import Control.Monad (unless)
 import qualified Data.ByteString as BS
 import Data.ByteString (ByteString)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Data.Time.Clock (NominalDiffTime, diffUTCTime, getCurrentTime)
@@ -35,11 +53,12 @@ import LibP2P.MultistreamSelect.Negotiation
   , negotiateInitiator
   , NegotiationResult (..)
   )
+import LibP2P.Switch.Connection (newStream)
 import LibP2P.Switch.Types
   ( Connection (..)
-  , MuxerSession (..)
   , Switch (..)
   )
+import System.Timeout (timeout)
 
 -- | Ping protocol ID.
 pingProtocolId :: Text
@@ -49,11 +68,16 @@ pingProtocolId = "/ipfs/ping/1.0.0"
 pingSize :: Int
 pingSize = 32
 
+-- | Time to wait for an echo before giving up, in microseconds.
+-- 10 seconds, mirroring go-libp2p's ping timeout.
+pingTimeoutMicros :: Int
+pingTimeoutMicros = 10000000
+
 -- | Ping error types.
 data PingError
-  = PingTimeout          -- ^ No response within timeout
+  = PingTimeout          -- ^ No echo within the timeout
   | PingMismatch         -- ^ Response doesn't match sent bytes
-  | PingStreamError !String  -- ^ Stream I/O error
+  | PingStreamError !String  -- ^ Stream open, negotiation, or I/O error
   deriving (Show, Eq)
 
 -- | Successful ping result.
@@ -63,9 +87,11 @@ data PingResult = PingResult
 
 -- | Handle an inbound Ping request (responder / echo loop).
 --
--- Reads 32 bytes, writes them back. Repeats until stream closes.
+-- Reads 32 bytes, writes them back. Repeats until the initiator closes
+-- its write side (EOF), then closes this side of the stream (ping.md:
+-- the listening peer SHOULD exit the loop and close the stream).
 handlePing :: StreamIO -> PeerId -> IO ()
-handlePing stream _remotePeerId = echoLoop
+handlePing stream _remotePeerId = echoLoop `finally` closeQuietly stream
   where
     echoLoop = do
       result <- (Right <$> readExact stream pingSize) `catch`
@@ -76,29 +102,111 @@ handlePing stream _remotePeerId = echoLoop
           streamWrite stream payload
           echoLoop
 
--- | Send a Ping to a remote peer (initiator side).
+-- | The single outbound ping stream to a peer, negotiated and ready.
 --
--- Opens a new stream, negotiates /ipfs/ping/1.0.0, sends 32 random
--- bytes, reads 32 bytes back, verifies match, measures RTT.
-sendPing :: Connection -> IO (Either PingError PingResult)
-sendPing conn = do
-  stream <- muxOpenStream (connSession conn)
-  result <- negotiateInitiator stream [pingProtocolId]
-  case result of
-    NoProtocol -> pure (Left (PingStreamError "remote does not support ping"))
-    Accepted _ -> do
-      payload <- getRandomBytes pingSize :: IO ByteString
-      t0 <- getCurrentTime
-      streamWrite stream payload
-      response <- (Right <$> readExact stream pingSize) `catch`
-                  (\(_ :: SomeException) -> pure (Left (PingStreamError "read failed")))
-      case response of
-        Left err -> pure (Left err)
-        Right echo
-          | echo /= payload -> pure (Left PingMismatch)
-          | otherwise -> do
-              t1 <- getCurrentTime
-              pure (Right (PingResult (diffUTCTime t1 t0)))
+-- Obtain with 'openPingSession' (or scoped via 'withPingSession'), send
+-- pings with 'ping', and always release with 'closePingSession'. A
+-- session whose ping failed (timeout, mismatch, I/O error) closes its
+-- stream immediately and rejects further pings.
+data PingSession = PingSession
+  { psStream :: !StreamIO
+  , psClosed :: !(IORef Bool)
+  }
+
+-- | Open a ping stream on the connection and negotiate the protocol.
+--
+-- The stream is opened through the Switch so it is counted against the
+-- peer's stream limits; the reservation is released when the session is
+-- closed. On any failure the stream (if opened) is closed before
+-- returning.
+openPingSession :: Switch -> Connection -> IO (Either PingError PingSession)
+openPingSession sw conn = do
+  streamOrErr <- newStream sw conn
+  case streamOrErr of
+    Left err ->
+      pure (Left (PingStreamError ("stream reservation failed: " ++ show err)))
+    Right stream -> do
+      negotiated <- try (negotiateInitiator stream [pingProtocolId])
+      case negotiated of
+        Right (Accepted _) -> do
+          closedRef <- newIORef False
+          pure (Right (PingSession stream closedRef))
+        Right NoProtocol -> do
+          closeQuietly stream
+          pure (Left (PingStreamError "remote does not support ping"))
+        Left (e :: SomeException) -> do
+          closeQuietly stream
+          pure (Left (PingStreamError ("ping negotiation failed: " ++ show e)))
+
+-- | Send one ping on the session with the default timeout
+-- ('pingTimeoutMicros'). The session's stream is reused across calls.
+ping :: PingSession -> IO (Either PingError PingResult)
+ping = pingWithTimeout pingTimeoutMicros
+
+-- | Send one ping on the session, waiting at most the given number of
+-- microseconds for the echo. On failure the session is closed: a stream
+-- whose echo timed out or went wrong cannot be reused, because a late
+-- echo would corrupt the next ping.
+pingWithTimeout :: Int -> PingSession -> IO (Either PingError PingResult)
+pingWithTimeout timeoutUs sess = do
+  closed <- readIORef (psClosed sess)
+  if closed
+    then pure (Left (PingStreamError "ping session is closed"))
+    else do
+      result <- pingOnce timeoutUs (psStream sess)
+      case result of
+        Left err -> do
+          closePingSession sess
+          pure (Left err)
+        ok -> pure ok
+
+-- | One ping exchange on an already-negotiated stream.
+pingOnce :: Int -> StreamIO -> IO (Either PingError PingResult)
+pingOnce timeoutUs stream = do
+  payload <- getRandomBytes pingSize :: IO ByteString
+  t0 <- getCurrentTime
+  -- try must wrap timeout (not the reverse): an inner try would catch
+  -- the Timeout exception itself and misreport it as a stream error.
+  outcome <- try $ timeout timeoutUs $ do
+    streamWrite stream payload
+    readExact stream pingSize
+  case outcome of
+    Left (e :: SomeException) ->
+      pure (Left (PingStreamError ("ping I/O failed: " ++ show e)))
+    Right Nothing -> pure (Left PingTimeout)
+    Right (Just echo)
+      | echo /= payload -> pure (Left PingMismatch)
+      | otherwise -> do
+          t1 <- getCurrentTime
+          pure (Right (PingResult (diffUTCTime t1 t0)))
+
+-- | Close the session's stream (signalling EOF to the responder's echo
+-- loop) and release its stream reservation. Idempotent.
+closePingSession :: PingSession -> IO ()
+closePingSession sess = do
+  alreadyClosed <- atomicModifyIORef' (psClosed sess) (\c -> (True, c))
+  unless alreadyClosed $ closeQuietly (psStream sess)
+
+-- | Run an action with a ping session, closing it afterwards even if
+-- the action throws. Returns Left if the session could not be opened.
+withPingSession
+  :: Switch
+  -> Connection
+  -> (PingSession -> IO a)
+  -> IO (Either PingError a)
+withPingSession sw conn action = do
+  opened <- openPingSession sw conn
+  case opened of
+    Left err -> pure (Left err)
+    Right sess -> (Right <$> action sess) `finally` closePingSession sess
+
+-- | Send a single Ping to a remote peer (initiator side).
+--
+-- Convenience wrapper: opens a ping session, pings once, and closes the
+-- stream. For repeated pings to the same peer, use 'withPingSession'
+-- to reuse one stream instead of opening one per call.
+sendPing :: Switch -> Connection -> IO (Either PingError PingResult)
+sendPing sw conn = either Left id <$> withPingSession sw conn ping
 
 -- | Register the Ping handler on the Switch.
 registerPingHandler :: Switch -> IO ()
@@ -106,6 +214,10 @@ registerPingHandler sw = atomically $ do
   protos <- readTVar (swProtocols sw)
   let handler conn stream = handlePing stream (connPeerId conn)
   writeTVar (swProtocols sw) (Map.insert pingProtocolId handler protos)
+
+-- | Close a stream, swallowing any exception (best-effort EOF signal).
+closeQuietly :: StreamIO -> IO ()
+closeQuietly stream = streamClose stream `catch` \(_ :: SomeException) -> pure ()
 
 -- | Read exactly n bytes from a StreamIO.
 readExact :: StreamIO -> Int -> IO ByteString

--- a/test/LibP2P/FaultInjectionSpec.hs
+++ b/test/LibP2P/FaultInjectionSpec.hs
@@ -77,7 +77,7 @@ expectHealthyListener pid listenAddr =
     dialResult <- timeout 10000000 $ dial sw pid [listenAddr]
     case dialResult of
       Just (Right conn) -> do
-        pingResult <- timeout 5000000 $ sendPing conn
+        pingResult <- timeout 5000000 $ sendPing sw conn
         case pingResult of
           Just (Right (PingResult rtt)) -> rtt `shouldSatisfy` (> 0)
           other ->

--- a/test/LibP2P/IntegrationSpec.hs
+++ b/test/LibP2P/IntegrationSpec.hs
@@ -17,6 +17,7 @@ import Control.Concurrent.STM
 import Control.Exception (SomeException, bracket, try)
 import Control.Monad (replicateM)
 import qualified Data.ByteString as BS
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import qualified Data.Map.Strict as Map
 import Data.Time.Clock (getCurrentTime)
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
@@ -62,8 +63,10 @@ import LibP2P.Protocol.Identify
 import LibP2P.Protocol.Identify.Message (IdentifyInfo (..))
 import LibP2P.Protocol.Ping
   ( PingResult (..)
+  , ping
   , registerPingHandler
   , sendPing
+  , withPingSession
   )
 import LibP2P.Switch.ConnPool (lookupConn)
 import LibP2P.Switch.Dial (dial)
@@ -185,8 +188,8 @@ spec = do
 
   describe "Ping over real TCP" $ do
     it "sendPing returns valid RTT (>0, <1s for loopback)" $ do
-      withConnectedPair $ \_nodeA _nodeB conn -> do
-        result <- timeout 5000000 $ sendPing conn
+      withConnectedPair $ \(swA, _pidA) _nodeB conn -> do
+        result <- timeout 5000000 $ sendPing swA conn
         case result of
           Nothing -> expectationFailure "ping timed out"
           Just (Left err) -> expectationFailure $ "ping failed: " ++ show err
@@ -228,32 +231,45 @@ spec = do
             idObservedAddr info `shouldBe` Just (toBytes (connLocalAddr conn))
 
   describe "Multi-protocol" $ do
-    -- WARNING(#163): this test certifies behaviour the spec forbids.
-    -- specs/ping/ping.md: "The dialing peer MUST NOT keep more than one
-    -- outbound stream for the ping protocol per peer." It passes only
-    -- because sendPing opens a new stream per call. When #163 is fixed
-    -- (stream reuse + close), this test must be inverted — assert a
-    -- single outbound stream across both pings — not extended.
-    it "multiple Ping requests on different streams over same connection" $ do
-      withConnectedPair $ \_nodeA _nodeB conn -> do
-        -- Send two Pings on separate streams over the same muxed connection
-        pingResult1 <- sendPing conn
-        case pingResult1 of
-          Left err -> expectationFailure $ "ping 1 failed: " ++ show err
-          Right (PingResult rtt1) -> rtt1 `shouldSatisfy` (> 0)
-        pingResult2 <- sendPing conn
-        case pingResult2 of
-          Left err -> expectationFailure $ "ping 2 failed: " ++ show err
-          Right (PingResult rtt2) -> rtt2 `shouldSatisfy` (> 0)
+    it "successive pings reuse a single outbound stream over the same connection" $ do
+      -- Regression for #163. specs/ping/ping.md: "The dialing peer MUST
+      -- NOT keep more than one outbound stream for the ping protocol per
+      -- peer." Both pings must run on one stream, opened exactly once.
+      withConnectedPair $ \(swA, _pidA) _nodeB conn -> do
+        opensRef <- newIORef (0 :: Int)
+        let realSession = connSession conn
+            countingSession = realSession
+              { muxOpenStream = do
+                  modifyIORef' opensRef (+ 1)
+                  muxOpenStream realSession
+              }
+            countingConn = conn { connSession = countingSession }
+        result <- timeout 10000000 $ withPingSession swA countingConn $ \sess -> do
+          r1 <- ping sess
+          r2 <- ping sess
+          pure (r1, r2)
+        case result of
+          Nothing -> expectationFailure "ping session timed out"
+          Just (Left err) ->
+            expectationFailure $ "ping session failed to open: " ++ show err
+          Just (Right (r1, r2)) -> do
+            case r1 of
+              Left err -> expectationFailure $ "ping 1 failed: " ++ show err
+              Right (PingResult rtt1) -> rtt1 `shouldSatisfy` (> 0)
+            case r2 of
+              Left err -> expectationFailure $ "ping 2 failed: " ++ show err
+              Right (PingResult rtt2) -> rtt2 `shouldSatisfy` (> 0)
+        opens <- readIORef opensRef
+        opens `shouldBe` 1
 
     it "unknown protocol gets na over real TCP and the connection stays usable" $ do
-      withConnectedPair $ \_nodeA _nodeB conn -> do
+      withConnectedPair $ \(swA, _pidA) _nodeB conn -> do
         stream <- muxOpenStream (connSession conn)
         result <- timeout 5000000 $
           negotiateInitiator stream ["/test/does-not-exist/1.0.0"]
         result `shouldBe` Just NoProtocol
         -- The failed negotiation must not poison the muxed connection.
-        pingAfter <- timeout 5000000 $ sendPing conn
+        pingAfter <- timeout 5000000 $ sendPing swA conn
         case pingAfter of
           Just (Right (PingResult rtt)) -> rtt `shouldSatisfy` (> 0)
           Just (Left err) ->
@@ -319,7 +335,7 @@ spec = do
               dialResult <- timeout 10000000 $ dial swA pidC learnedAddrs
               case dialResult of
                 Just (Right connC) -> do
-                  pingResult <- timeout 5000000 $ sendPing connC
+                  pingResult <- timeout 5000000 $ sendPing swA connC
                   case pingResult of
                     Just (Right (PingResult rtt)) -> rtt `shouldSatisfy` (> 0)
                     other -> expectationFailure $

--- a/test/LibP2P/Protocol/Ping/PingSpec.hs
+++ b/test/LibP2P/Protocol/Ping/PingSpec.hs
@@ -14,10 +14,10 @@ import Control.Concurrent.STM
   , tryReadTMVar
   , writeTQueue
   )
-import Control.Exception (throwIO)
+import Control.Exception (throwIO, try)
 import Data.Bits (xor)
 import qualified Data.ByteString as BS
-import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
 import Data.Word (Word8)
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
@@ -72,10 +72,26 @@ recordWrites :: IORef [BS.ByteString] -> StreamIO -> StreamIO
 recordWrites ref s = s
   { streamWrite = \bs -> modifyIORef' ref (bs :) >> streamWrite s bs }
 
--- | Build an outbound Connection whose muxer hands out the given stream.
+-- | Wrap a StreamIO so closing it flips the flag (before delegating).
+recordClose :: IORef Bool -> StreamIO -> StreamIO
+recordClose ref s = s { streamClose = writeIORef ref True >> streamClose s }
+
+-- | Stream opener that counts how many streams have been handed out.
+countingOpen :: IORef Int -> StreamIO -> IO StreamIO
+countingOpen ref stream = modifyIORef' ref (+ 1) >> pure stream
+
+-- | A Switch whose only role here is stream resource accounting for
+-- the ping initiator ('sendPing' reserves stream slots through it).
+mkTestSwitch :: IO Switch
+mkTestSwitch = do
+  Right kp <- generateKeyPair
+  let pid = fromPublicKey (kpPublic kp)
+  newSwitch pid kp
+
+-- | Build an outbound Connection whose muxer runs the given stream opener.
 -- This is what lets tests drive the real 'sendPing' initiator path.
-mkPingConnection :: StreamIO -> IO Connection
-mkPingConnection stream = do
+mkPingConnection :: IO StreamIO -> IO Connection
+mkPingConnection openStream = do
   stateVar <- newTVarIO ConnOpen
   pure Connection
     { connPeerId     = PeerId "ping-remote"
@@ -85,7 +101,7 @@ mkPingConnection stream = do
     , connSecurity   = "/noise"
     , connMuxer      = "/yamux/1.0.0"
     , connSession    = MuxerSession
-        { muxOpenStream   = pure stream
+        { muxOpenStream   = openStream
         , muxAcceptStream = fail "test connection: no inbound streams"
         , muxClose        = pure ()
         }
@@ -95,6 +111,13 @@ mkPingConnection stream = do
 -- | Read exactly n bytes from a stream.
 readNBytes :: StreamIO -> Int -> IO BS.ByteString
 readNBytes stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1..n]
+
+-- | Responder that accepts the ping protocol and runs the echo loop.
+pingResponder :: StreamIO -> IO ()
+pingResponder stream = do
+  negResult <- negotiateResponder stream [pingProtocolId]
+  negResult `shouldBe` Accepted pingProtocolId
+  handlePing stream (PeerId "initiator")
 
 spec :: Spec
 spec = do
@@ -132,6 +155,17 @@ spec = do
       -- Handler should exit gracefully (not hang or crash)
       wait handler
 
+    it "handlePing closes its side of the stream after the loop exits" $ do
+      -- ping.md: the listening peer SHOULD exit the loop and close the
+      -- stream once the dialing peer closes its write side.
+      (_streamA, closeA, streamB) <- mkClosableStreamPair
+      closedRef <- newIORef False
+      handler <- async $ handlePing (recordClose closedRef streamB) (PeerId "test-peer")
+      closeA
+      wait handler
+      closed <- readIORef closedRef
+      closed `shouldBe` True
+
     it "handlePing exits without echoing when the final read is short" $ do
       (streamA, closeA, streamB) <- mkClosableStreamPair
       handler <- async $ handlePing streamB (PeerId "test-peer")
@@ -140,31 +174,120 @@ spec = do
       streamWrite streamA (BS.pack [1..31])
       closeA
       wait handler
-      -- The responder must not have written anything back.
-      echoed <- timeout 100000 (streamReadByte streamA)
-      echoed `shouldBe` Nothing
+      -- The responder must not have written anything back: reading from
+      -- its side either blocks (timeout) or hits the EOF it signalled by
+      -- closing the stream — never an echoed byte.
+      echoed <- timeout 100000 (try (streamReadByte streamA))
+      case echoed of
+        Nothing            -> pure ()  -- no data, read blocked
+        Just (Left (_ :: IOError)) -> pure ()  -- EOF from responder close
+        Just (Right b)     -> expectationFailure $
+          "responder echoed a byte from a short read: " ++ show b
 
   describe "Ping initiator (sendPing)" $ do
     it "sendPing round-trips against handlePing and returns a non-negative RTT" $ do
-      (streamA, closeA, streamB) <- mkClosableStreamPair
-      conn <- mkPingConnection streamA
-      responder <- async $ do
-        negResult <- negotiateResponder streamB [pingProtocolId]
-        negResult `shouldBe` Accepted pingProtocolId
-        handlePing streamB (PeerId "initiator")
-      result <- sendPing conn
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (pure streamA)
+      responder <- async $ pingResponder streamB
+      result <- sendPing sw conn
       case result of
         Left err -> expectationFailure $ "sendPing failed: " ++ show err
         Right (PingResult rtt) -> rtt `shouldSatisfy` (>= 0)
-      -- NOTE(#163): sendPing does not close the stream after the echo, so
-      -- the responder's echo loop never sees EOF on its own. Close from
-      -- the test to let it exit; do not assert responder termination here.
-      closeA
+      -- Regression for #163: sendPing must close the stream, so the
+      -- responder's echo loop sees EOF and exits on its own.
+      done <- timeout 1000000 (wait responder)
+      done `shouldBe` Just ()
+
+    it "sendPing closes the ping stream after the ping completes" $ do
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      closedRef <- newIORef False
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (pure (recordClose closedRef streamA))
+      responder <- async $ pingResponder streamB
+      result <- sendPing sw conn
+      case result of
+        Left err -> expectationFailure $ "sendPing failed: " ++ show err
+        Right _  -> pure ()
+      closed <- readIORef closedRef
+      closed `shouldBe` True
+      done <- timeout 1000000 (wait responder)
+      done `shouldBe` Just ()
+
+    it "two pings on one session reuse a single stream and close it at the end" $ do
+      -- ping.md: the dialing peer MUST NOT keep more than one outbound
+      -- ping stream per peer, and MAY send further payloads on the same
+      -- stream.
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      opensRef <- newIORef (0 :: Int)
+      closedRef <- newIORef False
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (countingOpen opensRef (recordClose closedRef streamA))
+      responder <- async $ pingResponder streamB
+      result <- withPingSession sw conn $ \sess -> do
+        r1 <- ping sess
+        r2 <- ping sess
+        pure (r1, r2)
+      case result of
+        Left err -> expectationFailure $ "ping session failed to open: " ++ show err
+        Right (r1, r2) -> do
+          case r1 of
+            Left err -> expectationFailure $ "ping 1 failed: " ++ show err
+            Right (PingResult rtt1) -> rtt1 `shouldSatisfy` (>= 0)
+          case r2 of
+            Left err -> expectationFailure $ "ping 2 failed: " ++ show err
+            Right (PingResult rtt2) -> rtt2 `shouldSatisfy` (>= 0)
+      opens <- readIORef opensRef
+      opens `shouldBe` 1
+      closed <- readIORef closedRef
+      closed `shouldBe` True
+      done <- timeout 1000000 (wait responder)
+      done `shouldBe` Just ()
+
+    it "ping fails on a session that has been closed" $ do
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (pure streamA)
+      responder <- async $ pingResponder streamB
+      opened <- openPingSession sw conn
+      case opened of
+        Left err -> expectationFailure $ "ping session failed to open: " ++ show err
+        Right sess -> do
+          closePingSession sess
+          result <- ping sess
+          case result of
+            Left (PingStreamError _) -> pure ()
+            other -> expectationFailure $
+              "expected Left PingStreamError, got: " ++ show other
+      done <- timeout 1000000 (wait responder)
+      done `shouldBe` Just ()
+
+    it "pingWithTimeout returns Left PingTimeout and closes the stream when no echo arrives" $ do
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      closedRef <- newIORef False
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (pure (recordClose closedRef streamA))
+      responder <- async $ do
+        negResult <- negotiateResponder streamB [pingProtocolId]
+        negResult `shouldBe` Accepted pingProtocolId
+        -- Swallow the payload and never echo.
+        _ <- readNBytes streamB pingSize
+        pure ()
+      opened <- openPingSession sw conn
+      case opened of
+        Left err -> expectationFailure $ "ping session failed to open: " ++ show err
+        Right sess -> do
+          result <- pingWithTimeout 200000 sess
+          result `shouldBe` Left PingTimeout
+          closed <- readIORef closedRef
+          closed `shouldBe` True
       wait responder
 
-    it "sendPing returns Left PingMismatch when the echo is corrupted" $ do
+    it "sendPing returns Left PingMismatch and closes the stream when the echo is corrupted" $ do
       (streamA, _closeA, streamB) <- mkClosableStreamPair
-      conn <- mkPingConnection streamA
+      closedRef <- newIORef False
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (pure (recordClose closedRef streamA))
       responder <- async $ do
         negResult <- negotiateResponder streamB [pingProtocolId]
         negResult `shouldBe` Accepted pingProtocolId
@@ -173,13 +296,16 @@ spec = do
         -- match the sent payload).
         let corrupted = BS.cons (BS.head payload `xor` 0xFF) (BS.tail payload)
         streamWrite streamB corrupted
-      result <- sendPing conn
+      result <- sendPing sw conn
       wait responder
       result `shouldBe` Left PingMismatch
+      closed <- readIORef closedRef
+      closed `shouldBe` True
 
     it "sendPing returns Left PingStreamError on mid-payload EOF" $ do
       (streamA, _closeA, streamB) <- mkClosableStreamPair
-      conn <- mkPingConnection streamA
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (pure streamA)
       responder <- async $ do
         negResult <- negotiateResponder streamB [pingProtocolId]
         negResult `shouldBe` Accepted pingProtocolId
@@ -188,41 +314,43 @@ spec = do
         -- surface a stream error instead of hanging or succeeding.
         streamWrite streamB (BS.take 16 payload)
         streamClose streamB
-      result <- sendPing conn
+      result <- sendPing sw conn
       wait responder
       case result of
         Left (PingStreamError _) -> pure ()
         other -> expectationFailure $
           "expected Left PingStreamError, got: " ++ show other
 
-    it "sendPing returns Left PingStreamError when the responder rejects the protocol" $ do
+    it "sendPing returns Left PingStreamError and closes the stream when the responder rejects the protocol" $ do
       (streamA, _closeA, streamB) <- mkClosableStreamPair
-      conn <- mkPingConnection streamA
+      closedRef <- newIORef False
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (pure (recordClose closedRef streamA))
       -- Responder speaks multistream-select but supports no protocols, so
       -- it answers "na" to /ipfs/ping/1.0.0 and keeps waiting for further
       -- proposals (which never come) — hence cancel, not wait.
       responder <- async $ negotiateResponder streamB []
-      result <- sendPing conn
+      result <- sendPing sw conn
       cancel responder
       case result of
         Left (PingStreamError _) -> pure ()
         other -> expectationFailure $
           "expected Left PingStreamError, got: " ++ show other
+      closed <- readIORef closedRef
+      closed `shouldBe` True
 
     it "sendPing writes a fresh random 32-byte payload per ping, unframed" $ do
       let runRecordedPing = do
-            (streamA, closeA, streamB) <- mkClosableStreamPair
+            (streamA, _closeA, streamB) <- mkClosableStreamPair
             writesRef <- newIORef ([] :: [BS.ByteString])
-            conn <- mkPingConnection (recordWrites writesRef streamA)
-            responder <- async $ do
-              negResult <- negotiateResponder streamB [pingProtocolId]
-              negResult `shouldBe` Accepted pingProtocolId
-              handlePing streamB (PeerId "initiator")
-            result <- sendPing conn
+            sw <- mkTestSwitch
+            conn <- mkPingConnection (pure (recordWrites writesRef streamA))
+            responder <- async $ pingResponder streamB
+            result <- sendPing sw conn
             case result of
               Left err -> expectationFailure $ "sendPing failed: " ++ show err
               Right _  -> pure ()
-            closeA  -- see NOTE(#163) above
+            -- sendPing closed the stream, so the responder exits on EOF.
             wait responder
             readIORef writesRef
       chunks1 <- runRecordedPing


### PR DESCRIPTION
## Summary

`sendPing` opened a fresh stream per call and never closed it, so the responder's echo loop never saw EOF — leaking a stream and a handler thread on both sides per ping, and violating `ping.md` ("The dialing peer MUST NOT keep more than one outbound stream for the ping protocol per peer").

## Changes

- New `PingSession` initiator API: `openPingSession` / `ping` / `pingWithTimeout` / `closePingSession` / `withPingSession`. One stream per peer, negotiated once, reused for successive pings, closed when the session ends and on the first failed ping (timeout / mismatch / I/O error).
- Streams are opened through the Switch's `newStream`, so each session holds exactly one tracked stream reservation, released on close.
- `sendPing` is now a one-shot wrapper (open, ping once, close) and takes the `Switch`; interop dialer and tests updated to the new signature.
- `PingTimeout` is now reachable: the echo wait is bounded (default 10s, mirroring go-libp2p).
- `handlePing` closes its side of the stream after the echo loop exits (`ping.md` SHOULD).
- Inverted the `WARNING(#163)` IntegrationSpec test: it now asserts both pings run on a single outbound stream (open-count via a wrapping muxer session).

## Tests

TDD: new failing tests first, then the fix. 854 examples, 0 failures (GHC 9.10.3). New coverage: single-stream reuse across pings, stream closed on completion/error/timeout, closed-session rejection, responder-side close.

Closes #163