### PR TITLE
fix(identify): merge push updates into peer entry and add push sender

### DIFF
--- a/src/LibP2P.hs
+++ b/src/LibP2P.hs
@@ -68,6 +68,7 @@ module LibP2P
     -- * Identify protocol
   , registerIdentifyHandlers
   , requestIdentify
+  , pushIdentify
 
     -- * Ping protocol
   , registerPingHandler
@@ -126,7 +127,7 @@ import LibP2P.Protocol.GossipSub.Handler
   , stopGossipSub
   )
 import LibP2P.Protocol.GossipSub.Types (GossipSubParams (..), defaultGossipSubParams)
-import LibP2P.Protocol.Identify (registerIdentifyHandlers, requestIdentify)
+import LibP2P.Protocol.Identify (pushIdentify, registerIdentifyHandlers, requestIdentify)
 import LibP2P.Protocol.Ping (PingError (..), PingResult (..), registerPingHandler, sendPing)
 import LibP2P.Switch.Connection (closeConnection, newStream)
 import LibP2P.Switch.Dial (dial)

--- a/src/LibP2P/Protocol/Identify.hs
+++ b/src/LibP2P/Protocol/Identify.hs
@@ -19,6 +19,8 @@ module LibP2P.Protocol.Identify
   , handleIdentify
   , requestIdentify
   , handleIdentifyPush
+  , pushIdentify
+  , mergeIdentify
     -- * Building local info
   , buildLocalIdentify
     -- * Registration
@@ -28,6 +30,7 @@ module LibP2P.Protocol.Identify
   , readFramedIdentify
   ) where
 
+import Control.Applicative ((<|>))
 import Control.Concurrent.STM (atomically, readTVar, writeTVar)
 import Control.Exception (SomeException, catch)
 import qualified Data.ByteString as BS
@@ -49,6 +52,7 @@ import LibP2P.Protocol.Identify.Message
   , encodeIdentify
   , maxIdentifySize
   )
+import LibP2P.Switch.ConnPool (allConns)
 import LibP2P.Switch.Types
   ( ActiveListener (..)
   , Connection (..)
@@ -92,6 +96,10 @@ requestIdentify conn = do
 -- Reads the pushed varint-length-prefixed IdentifyInfo from the remote
 -- peer. The length prefix is the message boundary — identify push has
 -- no stream-close boundary to fall back on.
+--
+-- The pushed info is merged into the existing peer entry via
+-- 'mergeIdentify': pushes may be partial updates, so fields absent
+-- from the message must not erase what we already know.
 handleIdentifyPush :: Switch -> Connection -> StreamIO -> IO ()
 handleIdentifyPush sw conn stream = do
   infoOrErr <- readFramedIdentify stream maxIdentifySize
@@ -99,7 +107,54 @@ handleIdentifyPush sw conn stream = do
     Left _ -> pure ()
     Right info -> atomically $ do
       store <- readTVar (swPeerStore sw)
-      writeTVar (swPeerStore sw) (Map.insert (connPeerId conn) info store)
+      let merged = maybe info (`mergeIdentify` info)
+                     (Map.lookup (connPeerId conn) store)
+      writeTVar (swPeerStore sw) (Map.insert (connPeerId conn) merged store)
+
+-- | Merge a received (possibly partial) Identify update into the
+-- previously known info for a peer.
+--
+-- Per specs/identify: "missing fields should be ignored, as peers may
+-- choose to send partial updates containing only the fields whose
+-- values have changed." Optional fields keep the known value when the
+-- update omits them; repeated fields (protobuf cannot distinguish
+-- absent from empty) keep the known list when the update's is empty
+-- and are replaced wholesale otherwise, matching go-libp2p.
+mergeIdentify :: IdentifyInfo -> IdentifyInfo -> IdentifyInfo
+mergeIdentify known update = IdentifyInfo
+  { idProtocolVersion = idProtocolVersion update <|> idProtocolVersion known
+  , idAgentVersion    = idAgentVersion update <|> idAgentVersion known
+  , idPublicKey       = idPublicKey update <|> idPublicKey known
+  , idListenAddrs     = replaceUnlessEmpty (idListenAddrs known) (idListenAddrs update)
+  , idObservedAddr    = idObservedAddr update <|> idObservedAddr known
+  , idProtocols       = replaceUnlessEmpty (idProtocols known) (idProtocols update)
+  }
+  where
+    replaceUnlessEmpty old [] = old
+    replaceUnlessEmpty _ new  = new
+
+-- | Push our current IdentifyInfo to every connected peer (sender side
+-- of /ipfs/id/push/1.0.0).
+--
+-- Per specs/identify: open a stream to each remote peer, negotiate the
+-- push protocol id, send one Identify message and close the stream.
+-- Call this whenever local state advertised via identify changes
+-- (listen addresses, registered protocols). Failures on individual
+-- peers (e.g. push protocol not supported) are ignored.
+pushIdentify :: Switch -> IO ()
+pushIdentify sw = do
+  conns <- atomically $ allConns (swConnPool sw)
+  mapM_ (\conn -> pushToConn conn `catch` \(_ :: SomeException) -> pure ()) conns
+  where
+    pushToConn conn = do
+      stream <- muxOpenStream (connSession conn)
+      result <- negotiateInitiator stream [identifyPushProtocolId]
+      case result of
+        Accepted _ -> do
+          info <- buildLocalIdentify sw (Just conn)
+          streamWrite stream (encodeFramedIdentify info)
+          streamClose stream
+        NoProtocol -> streamClose stream
 
 -- | Build our local IdentifyInfo from Switch state.
 buildLocalIdentify :: Switch -> Maybe Connection -> IO IdentifyInfo

--- a/src/LibP2P/Switch.hs
+++ b/src/LibP2P/Switch.hs
@@ -13,15 +13,17 @@ module LibP2P.Switch
   , switchClose
   ) where
 
-import Control.Concurrent.Async (cancel)
+import Control.Concurrent.Async (async, cancel)
 import Control.Concurrent.STM (atomically, newBroadcastTChanIO, newTVarIO, readTVar, writeTVar)
 import Control.Exception (SomeException, catch)
+import Control.Monad (void)
 import Data.List (find)
 import qualified Data.Map.Strict as Map
 import LibP2P.Crypto.Key (KeyPair)
 import LibP2P.Crypto.PeerId (PeerId)
 import LibP2P.Multiaddr (Multiaddr)
 import LibP2P.MultistreamSelect.Negotiation (ProtocolId)
+import LibP2P.Protocol.Identify (pushIdentify)
 import LibP2P.Switch.Connection (closeAllConnections)
 import LibP2P.Switch.ResourceManager (DefaultLimits (..), defaultPeerLimits, defaultSystemLimits, newResourceManager)
 import LibP2P.Switch.Types (ActiveListener (..), StreamHandler, Switch (..))
@@ -76,16 +78,24 @@ selectTransport sw addr = atomically $ do
 
 -- | Register a protocol stream handler.
 -- Overwrites any existing handler for the same protocol ID.
+-- The changed protocol set is pushed to connected peers via
+-- identify push (specs/identify) in the background.
 setStreamHandler :: Switch -> ProtocolId -> StreamHandler -> IO ()
-setStreamHandler sw proto handler = atomically $
-  do protos <- readTVar (swProtocols sw)
-     writeTVar (swProtocols sw) (Map.insert proto handler protos)
+setStreamHandler sw proto handler = do
+  atomically $ do
+    protos <- readTVar (swProtocols sw)
+    writeTVar (swProtocols sw) (Map.insert proto handler protos)
+  void $ async (pushIdentify sw)
 
 -- | Remove a protocol stream handler.
+-- The changed protocol set is pushed to connected peers via
+-- identify push (specs/identify) in the background.
 removeStreamHandler :: Switch -> ProtocolId -> IO ()
-removeStreamHandler sw proto = atomically $
-  do protos <- readTVar (swProtocols sw)
-     writeTVar (swProtocols sw) (Map.delete proto protos)
+removeStreamHandler sw proto = do
+  atomically $ do
+    protos <- readTVar (swProtocols sw)
+    writeTVar (swProtocols sw) (Map.delete proto protos)
+  void $ async (pushIdentify sw)
 
 -- | Look up a registered stream handler by protocol ID.
 lookupStreamHandler :: Switch -> ProtocolId -> IO (Maybe StreamHandler)

--- a/src/LibP2P/Switch/Listen.hs
+++ b/src/LibP2P/Switch/Listen.hs
@@ -30,6 +30,7 @@ import LibP2P.MultistreamSelect.Negotiation
   , StreamIO (..)
   , negotiateResponder
   )
+import LibP2P.Protocol.Identify (pushIdentify)
 import LibP2P.Switch.ConnPool (addConn)
 import LibP2P.Switch.Connection (closeConnection)
 import LibP2P.Switch.ResourceManager
@@ -174,6 +175,9 @@ switchListen sw gater addrs = do
       atomically $ do
         existing <- readTVar (swListeners sw)
         writeTVar (swListeners sw) (existing ++ newListeners)
+      -- Listen addresses changed: push updated identify info to
+      -- connected peers in the background (specs/identify push).
+      _ <- async (pushIdentify sw)
       pure (map alAddress newListeners)
   where
     -- Find a transport for the address, bind, and spawn accept loop

--- a/test/LibP2P/Protocol/Identify/IdentifySpec.hs
+++ b/test/LibP2P/Protocol/Identify/IdentifySpec.hs
@@ -13,10 +13,11 @@ import Control.Concurrent.STM
   , readTVar
   , tryReadTMVar
   , writeTQueue
+  , writeTVar
   )
 import Control.Exception (SomeException, catch, throwIO)
 import qualified Data.ByteString as BS
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef, writeIORef)
 import Data.List (sort)
 import qualified Data.Map.Strict as Map
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
@@ -27,7 +28,11 @@ import LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 import LibP2P.Multiaddr (Multiaddr (..))
 import LibP2P.Multiaddr.Codec (encodeProtocols)
 import LibP2P.Multiaddr.Protocol (Protocol (..))
-import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.MultistreamSelect.Negotiation
+  ( NegotiationResult (..)
+  , StreamIO (..)
+  , negotiateResponder
+  )
 import LibP2P.Protocol.Identify
 import LibP2P.Protocol.Identify.Message (IdentifyInfo (..), decodeIdentify, encodeIdentify, maxIdentifySize)
 import LibP2P.Switch (newSwitch, setStreamHandler)
@@ -256,6 +261,51 @@ spec = do
           idProtocolVersion storedInfo `shouldBe` Just "test/1.0"
           idAgentVersion storedInfo `shouldBe` Just "test-agent/0.1"
 
+    it "handleIdentifyPush merges a partial update instead of replacing the entry" $ do
+      -- specs/identify: "missing fields should be ignored, as peers may
+      -- choose to send partial updates". go-libp2p sends address-only
+      -- pushes; they must not wipe the publicKey/protocols/agentVersion
+      -- we already know.
+      sw <- mkTestSwitch
+      let remotePeerId = PeerId "merge-peer"
+          knownInfo = IdentifyInfo
+            { idProtocolVersion = Just "ipfs/0.1.0"
+            , idAgentVersion    = Just "go-libp2p/0.36.0"
+            , idPublicKey       = Just (BS.pack [1, 2, 3])
+            , idListenAddrs     = [encodeProtocols [IP4 0x7f000001, TCP 4001]]
+            , idObservedAddr    = Nothing
+            , idProtocols       = ["/ipfs/id/1.0.0", "/ipfs/ping/1.0.0"]
+            }
+      atomically $ do
+        store <- readTVar (swPeerStore sw)
+        writeTVar (swPeerStore sw) (Map.insert remotePeerId knownInfo store)
+      -- Address-only push: every other field is absent
+      let newAddrs = [encodeProtocols [IP4 0x7f000001, TCP 9999]]
+          partialPush = IdentifyInfo
+            { idProtocolVersion = Nothing
+            , idAgentVersion    = Nothing
+            , idPublicKey       = Nothing
+            , idListenAddrs     = newAddrs
+            , idObservedAddr    = Nothing
+            , idProtocols       = []
+            }
+      (streamA, streamB) <- mkClosableStreamPair
+      streamWrite streamA (frame (encodeIdentify partialPush))
+      streamClose streamA
+      conn <- mkTestConnection remotePeerId (Multiaddr [IP4 0x7f000001, TCP 4001])
+      handleIdentifyPush sw conn streamB
+      store <- atomically $ readTVar (swPeerStore sw)
+      case Map.lookup remotePeerId store of
+        Nothing -> expectationFailure "Expected peer in store"
+        Just merged -> do
+          -- Fields carried by the push are updated
+          idListenAddrs merged `shouldBe` newAddrs
+          -- Fields absent from the push keep their known values
+          idPublicKey merged `shouldBe` Just (BS.pack [1, 2, 3])
+          idProtocols merged `shouldBe` ["/ipfs/id/1.0.0", "/ipfs/ping/1.0.0"]
+          idAgentVersion merged `shouldBe` Just "go-libp2p/0.36.0"
+          idProtocolVersion merged `shouldBe` Just "ipfs/0.1.0"
+
     it "readFramedIdentify parses a varint-length-prefixed message" $ do
       (streamA, streamB) <- mkClosableStreamPair
       let testInfo = IdentifyInfo
@@ -304,6 +354,65 @@ spec = do
       case result of
         Left err -> err `shouldSatisfy` (not . null)
         Right _  -> expectationFailure "expected oversized message to be rejected"
+
+    it "pushIdentify sends a framed identify message on the push protocol to connected peers" $ do
+      -- specs/identify: the push variant opens a stream to each remote
+      -- peer using /ipfs/id/push/1.0.0, sends one Identify message and
+      -- closes the stream.
+      --
+      -- The switch is built without setStreamHandler: that API itself
+      -- fires a background push, which would race with this test's
+      -- single mock stream. Protocols are registered directly instead.
+      Right kp <- generateKeyPair
+      sw <- newSwitch (fromPublicKey (kpPublic kp)) kp
+      let noopHandler _ _ = pure ()
+      atomically $ do
+        protos <- readTVar (swProtocols sw)
+        writeTVar (swProtocols sw)
+          (Map.insert "/test/1.0.0" noopHandler
+            (Map.insert "/test/2.0.0" noopHandler protos))
+      (streamA, streamB) <- mkClosableStreamPair
+      openCountRef <- newIORef (0 :: Int)
+      stateVar <- newTVarIO ConnOpen
+      let remotePid  = PeerId "push-target"
+          remoteAddr = Multiaddr [IP4 0x7f000001, TCP 45678]
+          conn = Connection
+            { connPeerId     = remotePid
+            , connDirection  = Outbound
+            , connLocalAddr  = Multiaddr [IP4 0x7f000001, TCP 0]
+            , connRemoteAddr = remoteAddr
+            , connSecurity   = "/noise"
+            , connMuxer      = "/yamux/1.0.0"
+            , connSession    = MuxerSession
+                { muxOpenStream   = do
+                    modifyIORef' openCountRef (+ 1)
+                    pure streamA
+                , muxAcceptStream = fail "not used in this test"
+                , muxClose        = pure ()
+                }
+            , connState      = stateVar
+            }
+      atomically $ do
+        pool <- readTVar (swConnPool sw)
+        writeTVar (swConnPool sw) (Map.insert remotePid [conn] pool)
+      -- Remote side: accept the push protocol negotiation, then read
+      -- one varint-length-prefixed identify message.
+      remote <- async $ do
+        negResult <- negotiateResponder streamB [identifyPushProtocolId]
+        infoOrErr <- readFramedIdentify streamB maxIdentifySize
+        pure (negResult, infoOrErr)
+      pushIdentify sw
+      (negResult, infoOrErr) <- wait remote
+      negResult `shouldBe` Accepted identifyPushProtocolId
+      case infoOrErr of
+        Left err -> expectationFailure $ "push message decode failed: " ++ err
+        Right info -> do
+          sort (idProtocols info) `shouldBe` ["/test/1.0.0", "/test/2.0.0"]
+          idObservedAddr info `shouldBe` Just (encodeProtocols [IP4 0x7f000001, TCP 45678])
+          idPublicKey info `shouldBe` Just (encodePublicKey (kpPublic (swIdentityKey sw)))
+      -- Exactly one push stream was opened on the connection
+      opens <- readIORef openCountRef
+      opens `shouldBe` 1
 
     it "registerIdentifyHandlers registers both protocol handlers" $ do
       sw <- mkTestSwitch


### PR DESCRIPTION
## Summary

Fixes the two identify-push gaps from #165 (points 1 and 2):

- **Push receive now merges instead of replacing.** `handleIdentifyPush` merges the pushed message into the existing peerstore entry via a new `mergeIdentify`. Per specs/identify, missing fields are ignored: absent optional fields keep their known values, and empty repeated fields (protobuf cannot distinguish absent from empty) keep the known list, matching go-libp2p. An address-only push from go-libp2p no longer wipes the peer's `publicKey`, `protocols`, and `agentVersion`.
- **Push sender implemented.** New `pushIdentify` (exported from the `LibP2P` facade) opens a `/ipfs/id/push/1.0.0` stream to every connected peer, sends one varint-framed Identify message with a per-connection `observedAddr`, and closes the stream. Per-peer failures are ignored. It is fired in the background from the local state-change points: `setStreamHandler` / `removeStreamHandler` (protocol set changed) and `switchListen` (listen addresses changed).

## Tests (TDD)

- `handleIdentifyPush merges a partial update instead of replacing the entry` — address-only push updates addrs but keeps known publicKey/protocols/agentVersion (red before the fix).
- `pushIdentify sends a framed identify message on the push protocol to connected peers` — a mock connection records the opened stream; the remote side runs the real multistream-select responder, accepts `/ipfs/id/push/1.0.0`, and decodes the framed message (protocols, observedAddr, publicKey).

`cabal build` clean, `cabal test`: 851 examples, 0 failures (GHC 9.10.3).

Closes #165