### PR TITLE
refactor: replace copy-pasted byte-at-a-time readExact with shared bounded helper

### DIFF
--- a/src/LibP2P/DHT/Message.hs
+++ b/src/LibP2P/DHT/Message.hs
@@ -41,7 +41,7 @@ import qualified Proto3.Wire.Encode as Encode
 import Proto3.Wire.Types (FieldNumber (..))
 import LibP2P.Core.Varint (encodeUvarint, decodeUvarint)
 import LibP2P.DHT.Types (ConnectionType (..))
-import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), readExactBounded)
 
 -- | Maximum DHT message size: 64 KiB.
 maxDHTMessageSize :: Int
@@ -238,14 +238,12 @@ readFramedMessage stream maxSize = do
       if msgLen > maxSize
         then pure (Left $ "DHT message too large: " ++ show msgLen ++ " > " ++ show maxSize)
         else do
-          payload <- readExact stream msgLen
-          case decodeDHTMessage payload of
-            Left err -> pure (Left $ "DHT protobuf decode error: " ++ show err)
-            Right msg -> pure (Right msg)
-
--- | Read exactly n bytes from a stream.
-readExact :: StreamIO -> Int -> IO ByteString
-readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]
+          payloadOrErr <- readExactBounded stream maxSize msgLen
+          case payloadOrErr of
+            Left err -> pure (Left $ "DHT read error: " ++ err)
+            Right payload -> case decodeDHTMessage payload of
+              Left err -> pure (Left $ "DHT protobuf decode error: " ++ show err)
+              Right msg -> pure (Right msg)
 
 -- | Read unsigned varint bytes from a stream (up to 10 bytes).
 readVarintBytes :: StreamIO -> IO ByteString

--- a/src/LibP2P/MultistreamSelect/Negotiation.hs
+++ b/src/LibP2P/MultistreamSelect/Negotiation.hs
@@ -9,9 +9,12 @@ module LibP2P.MultistreamSelect.Negotiation
   , negotiateInitiator
   , negotiateResponder
   , mkMemoryStreamPair
+  , readExactBounded
   ) where
 
 import Control.Concurrent.STM
+import Control.Exception (IOException, catch)
+import Control.Monad (replicateM)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Text (Text)
@@ -56,9 +59,44 @@ mkMemoryStreamPair = do
     , StreamIO (writeToQueue queueBtoA) (readFromQueue queueAtoB) (pure ())
     )
 
--- | Read exactly n bytes from a stream.
-readExact :: StreamIO -> Int -> IO ByteString
-readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]
+-- | Chunk size for 'readExactBounded'. Bounds the transient boxed-list
+-- allocation per read step regardless of the requested length.
+readChunkSize :: Int
+readChunkSize = 32768
+
+-- | Read exactly @n@ bytes from a stream, bounded by @maxLen@.
+--
+-- Shared by every length-delimited protocol in the stack (see issue
+-- #169): the declared length is validated against the caller's
+-- protocol-defined cap before a single byte is read or allocated, so a
+-- hostile length prefix cannot trigger an unbounded allocation. Bytes
+-- are accumulated in chunks of at most 'readChunkSize', keeping
+-- transient memory use proportional to the chunk size, not to @n@.
+--
+-- I/O failures during the read (stream reset, EOF) are returned as
+-- 'Left' instead of propagating as 'IOException's.
+readExactBounded
+  :: StreamIO
+  -> Int  -- ^ Maximum acceptable length (protocol-defined cap)
+  -> Int  -- ^ Number of bytes to read
+  -> IO (Either String ByteString)
+readExactBounded stream maxLen n
+  | n < 0 =
+      pure (Left ("readExactBounded: negative length: " <> show n))
+  | n > maxLen =
+      pure (Left ("readExactBounded: requested " <> show n
+                  <> " bytes exceeds maximum " <> show maxLen))
+  | n == 0 = pure (Right BS.empty)
+  | otherwise =
+      (Right . BS.concat <$> go n) `catch` \(e :: IOException) ->
+        pure (Left ("readExactBounded: read failed: " <> show e))
+  where
+    go :: Int -> IO [ByteString]
+    go 0 = pure []
+    go remaining = do
+      let m = min readChunkSize remaining
+      chunk <- BS.pack <$> replicateM m (streamReadByte stream)
+      (chunk :) <$> go (remaining - m)
 
 -- | Read a complete multistream-select message from a stream.
 -- Reads varint length byte-by-byte, then reads the full payload.
@@ -76,10 +114,14 @@ readMessage stream = do
           | len > maxMessageLength ->
               pure (Left "readMessage: incoming message too large (max 1024 bytes)")
           | otherwise -> do
-              payload <- readExact stream (fromIntegral len)
-              case decodeMessage (varintBytes <> payload) of
+              payloadOrErr <-
+                readExactBounded stream (fromIntegral maxMessageLength) (fromIntegral len)
+              case payloadOrErr of
                 Left err -> pure (Left err)
-                Right (msg, _) -> pure (Right msg)
+                Right payload ->
+                  case decodeMessage (varintBytes <> payload) of
+                    Left err -> pure (Left err)
+                    Right (msg, _) -> pure (Right msg)
 
 -- | Read a varint one byte at a time from the stream.
 -- The read loop is bounded at 'maxVarintBytes' (9 bytes per the

--- a/src/LibP2P/NAT/AutoNAT/Message.hs
+++ b/src/LibP2P/NAT/AutoNAT/Message.hs
@@ -45,7 +45,7 @@ import Proto3.Wire.Encode (MessageBuilder)
 import qualified Proto3.Wire.Encode as Encode
 import Proto3.Wire.Types (FieldNumber (..))
 import LibP2P.Core.Varint (encodeUvarint, decodeUvarint)
-import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), readExactBounded)
 
 -- | AutoNAT protocol identifier.
 autoNATProtocolId :: Text
@@ -253,14 +253,12 @@ readAutoNATMessage stream maxSize = do
       if msgLen > maxSize
         then pure (Left $ "AutoNAT message too large: " ++ show msgLen ++ " > " ++ show maxSize)
         else do
-          payload <- readExact stream msgLen
-          case decodeAutoNATMessage payload of
-            Left err -> pure (Left $ "AutoNAT protobuf decode error: " ++ show err)
-            Right msg -> pure (Right msg)
-
--- | Read exactly n bytes from a stream.
-readExact :: StreamIO -> Int -> IO ByteString
-readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]
+          payloadOrErr <- readExactBounded stream maxSize msgLen
+          case payloadOrErr of
+            Left err -> pure (Left $ "AutoNAT read error: " ++ err)
+            Right payload -> case decodeAutoNATMessage payload of
+              Left err -> pure (Left $ "AutoNAT protobuf decode error: " ++ show err)
+              Right msg -> pure (Right msg)
 
 -- | Read unsigned varint bytes from a stream (up to 10 bytes).
 readVarintBytes :: StreamIO -> IO ByteString

--- a/src/LibP2P/NAT/DCUtR/Message.hs
+++ b/src/LibP2P/NAT/DCUtR/Message.hs
@@ -38,7 +38,7 @@ import qualified Proto3.Wire.Decode as Decode
 import qualified Proto3.Wire.Encode as Encode
 import Proto3.Wire.Types (FieldNumber (..))
 import LibP2P.Core.Varint (encodeUvarint, decodeUvarint)
-import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), readExactBounded)
 
 -- | DCUtR protocol identifier.
 dcutrProtocolId :: Text
@@ -133,13 +133,12 @@ readHolePunchMessage stream maxSize = do
       if msgLen > maxSize
         then pure (Left $ "DCUtR message too large: " ++ show msgLen)
         else do
-          payload <- readExact stream msgLen
-          case decodeHolePunchMessage payload of
-            Left err -> pure (Left $ "DCUtR protobuf decode error: " ++ show err)
-            Right msg -> pure (Right msg)
-
-readExact :: StreamIO -> Int -> IO ByteString
-readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]
+          payloadOrErr <- readExactBounded stream maxSize msgLen
+          case payloadOrErr of
+            Left err -> pure (Left $ "DCUtR read error: " ++ err)
+            Right payload -> case decodeHolePunchMessage payload of
+              Left err -> pure (Left $ "DCUtR protobuf decode error: " ++ show err)
+              Right msg -> pure (Right msg)
 
 readVarintBytes :: StreamIO -> IO ByteString
 readVarintBytes stream = go [] (0 :: Int)

--- a/src/LibP2P/NAT/Relay/Message.hs
+++ b/src/LibP2P/NAT/Relay/Message.hs
@@ -55,7 +55,7 @@ import qualified Proto3.Wire.Encode as Encode
 import Proto3.Wire.Encode (MessageBuilder)
 import Proto3.Wire.Types (FieldNumber (..))
 import LibP2P.Core.Varint (encodeUvarint, decodeUvarint)
-import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), readExactBounded)
 
 -- | Hop protocol identifier.
 hopProtocolId :: Text
@@ -336,13 +336,12 @@ readFramedWith decoder label stream maxSize = do
       if msgLen > maxSize
         then pure (Left $ label ++ " message too large: " ++ show msgLen)
         else do
-          payload <- readExact stream msgLen
-          case decoder payload of
-            Left err -> pure (Left $ label ++ " protobuf decode error: " ++ show err)
-            Right msg -> pure (Right msg)
-
-readExact :: StreamIO -> Int -> IO ByteString
-readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]
+          payloadOrErr <- readExactBounded stream maxSize msgLen
+          case payloadOrErr of
+            Left err -> pure (Left $ label ++ " read error: " ++ err)
+            Right payload -> case decoder payload of
+              Left err -> pure (Left $ label ++ " protobuf decode error: " ++ show err)
+              Right msg -> pure (Right msg)
 
 readVarintBytes :: StreamIO -> IO ByteString
 readVarintBytes stream = go [] (0 :: Int)

--- a/src/LibP2P/Protocol/GossipSub/Message.hs
+++ b/src/LibP2P/Protocol/GossipSub/Message.hs
@@ -44,7 +44,7 @@ import Proto3.Wire.Encode (MessageBuilder)
 import qualified Proto3.Wire.Encode as Encode
 import Proto3.Wire.Types (FieldNumber (..))
 import LibP2P.Core.Varint (encodeUvarint, decodeUvarint)
-import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), readExactBounded)
 import LibP2P.Protocol.GossipSub.Types
 
 -- Encoding helpers
@@ -257,14 +257,12 @@ readRPCMessage stream maxSize = do
       if msgLen > maxSize
         then pure (Left $ "GossipSub RPC too large: " ++ show msgLen ++ " > " ++ show maxSize)
         else do
-          payload <- readExact stream msgLen
-          case decodeRPC payload of
-            Left err -> pure (Left $ "GossipSub protobuf decode error: " ++ show err)
-            Right rpc -> pure (Right rpc)
-
--- | Read exactly n bytes from a stream.
-readExact :: StreamIO -> Int -> IO ByteString
-readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]
+          payloadOrErr <- readExactBounded stream maxSize msgLen
+          case payloadOrErr of
+            Left err -> pure (Left $ "GossipSub read error: " ++ err)
+            Right payload -> case decodeRPC payload of
+              Left err -> pure (Left $ "GossipSub protobuf decode error: " ++ show err)
+              Right rpc -> pure (Right rpc)
 
 -- | Read unsigned varint bytes (up to 10).
 readVarintBytes :: StreamIO -> IO ByteString

--- a/src/LibP2P/Protocol/Identify.hs
+++ b/src/LibP2P/Protocol/Identify.hs
@@ -45,6 +45,7 @@ import LibP2P.MultistreamSelect.Negotiation
   , StreamIO (..)
   , negotiateInitiator
   , NegotiationResult (..)
+  , readExactBounded
   )
 import LibP2P.Protocol.Identify.Message
   ( IdentifyInfo (..)
@@ -213,11 +214,13 @@ readFramedIdentify stream maxSize = readFramed `catch` onError
             then pure (Left ("identify message too large: "
                              ++ show msgLen ++ " > " ++ show maxSize))
             else do
-              payload <- readExact stream msgLen
-              case decodeIdentify payload of
-                Left parseErr ->
-                  pure (Left ("identify protobuf decode error: " ++ show parseErr))
-                Right info -> pure (Right info)
+              payloadOrErr <- readExactBounded stream maxSize msgLen
+              case payloadOrErr of
+                Left err -> pure (Left ("identify read error: " ++ err))
+                Right payload -> case decodeIdentify payload of
+                  Left parseErr ->
+                    pure (Left ("identify protobuf decode error: " ++ show parseErr))
+                  Right info -> pure (Right info)
 
 -- | Read the bytes of one unsigned varint from a stream (up to 10 bytes).
 readVarintBytes :: StreamIO -> IO BS.ByteString
@@ -230,7 +233,3 @@ readVarintBytes stream = go [] (0 :: Int)
           if b < 0x80
             then pure (BS.pack (reverse (b : acc)))
             else go (b : acc) (n + 1)
-
--- | Read exactly n bytes from a stream.
-readExact :: StreamIO -> Int -> IO BS.ByteString
-readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]

--- a/src/LibP2P/Protocol/Ping.hs
+++ b/src/LibP2P/Protocol/Ping.hs
@@ -52,6 +52,7 @@ import LibP2P.MultistreamSelect.Negotiation
   ( StreamIO (..)
   , negotiateInitiator
   , NegotiationResult (..)
+  , readExactBounded
   )
 import LibP2P.Switch.Connection (newStream)
 import LibP2P.Switch.Types
@@ -94,10 +95,10 @@ handlePing :: StreamIO -> PeerId -> IO ()
 handlePing stream _remotePeerId = echoLoop `finally` closeQuietly stream
   where
     echoLoop = do
-      result <- (Right <$> readExact stream pingSize) `catch`
-                (\(_ :: SomeException) -> pure (Left ()))
+      result <- readExactBounded stream pingSize pingSize `catch`
+                (\(_ :: SomeException) -> pure (Left "stream closed"))
       case result of
-        Left () -> pure ()  -- Stream closed, exit loop
+        Left _ -> pure ()  -- Stream closed, exit loop
         Right payload -> do
           streamWrite stream payload
           echoLoop
@@ -169,7 +170,7 @@ pingOnce timeoutUs stream = do
   -- the Timeout exception itself and misreport it as a stream error.
   outcome <- try $ timeout timeoutUs $ do
     streamWrite stream payload
-    readExact stream pingSize
+    either fail pure =<< readExactBounded stream pingSize pingSize
   case outcome of
     Left (e :: SomeException) ->
       pure (Left (PingStreamError ("ping I/O failed: " ++ show e)))
@@ -218,7 +219,3 @@ registerPingHandler sw = atomically $ do
 -- | Close a stream, swallowing any exception (best-effort EOF signal).
 closeQuietly :: StreamIO -> IO ()
 closeQuietly stream = streamClose stream `catch` \(_ :: SomeException) -> pure ()
-
--- | Read exactly n bytes from a StreamIO.
-readExact :: StreamIO -> Int -> IO ByteString
-readExact stream n = BS.pack <$> mapM (const (streamReadByte stream)) [1 .. n]

--- a/src/LibP2P/Switch/Upgrade.hs
+++ b/src/LibP2P/Switch/Upgrade.hs
@@ -27,7 +27,7 @@ module LibP2P.Switch.Upgrade
 import Control.Concurrent.Async (async, cancel, race, waitCatch)
 import Control.Concurrent.STM (atomically, isEmptyTQueue, newTVarIO, retry)
 import Control.Exception (SomeException, catch)
-import Control.Monad (replicateM, unless)
+import Control.Monad (unless)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -46,6 +46,7 @@ import LibP2P.MultistreamSelect.Negotiation
   , StreamIO (..)
   , negotiateInitiator
   , negotiateResponder
+  , readExactBounded
   )
 import LibP2P.Noise.Framing (chunkPlaintext, encodeFrame)
 import LibP2P.Noise.Handshake
@@ -79,24 +80,15 @@ import qualified LibP2P.Noise.Handshake as HS
 
 -- | Read exactly n bytes from a StreamIO.
 --
--- Defence in depth against remote memory exhaustion: the request size is
--- bounded by maxStreamWindowSize (callers must validate lengths against
--- flow control before reading), and bytes are packed in fixed-size chunks
--- so memory use is proportional to the chunk size, not to n.
+-- Exception-style wrapper over 'readExactBounded' for the Noise frame
+-- reader and the yamux read callback, which expect failures as
+-- exceptions. Defence in depth against remote memory exhaustion: the
+-- request size is bounded by maxStreamWindowSize (callers must validate
+-- lengths against flow control before reading).
 readExact :: StreamIO -> Int -> IO ByteString
-readExact stream n
-  | n <= 0 = pure BS.empty
-  | n > fromIntegral maxStreamWindowSize =
-      fail ("readExact: requested size exceeds bound: " <> show n)
-  | otherwise = BS.concat <$> go n
-  where
-    chunkSize = 32768 :: Int
-    go 0 = pure []
-    go remaining = do
-      let m = min chunkSize remaining
-      chunk <- BS.pack <$> replicateM m (streamReadByte stream)
-      rest <- go (remaining - m)
-      pure (chunk : rest)
+readExact stream n =
+  either fail pure
+    =<< readExactBounded stream (fromIntegral maxStreamWindowSize) n
 
 -- | Read a 2-byte-BE-length-prefixed Noise frame from a StreamIO.
 readFramedMessage :: StreamIO -> IO ByteString

--- a/test/LibP2P/MultistreamSelect/NegotiationSpec.hs
+++ b/test/LibP2P/MultistreamSelect/NegotiationSpec.hs
@@ -4,6 +4,8 @@ import Control.Concurrent.Async (concurrently, withAsync)
 import Control.Monad (replicateM)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import Data.IORef (atomicModifyIORef', newIORef)
+import Data.Word (Word8)
 import LibP2P.MultistreamSelect.Negotiation
 import LibP2P.MultistreamSelect.Wire
 import System.Timeout (timeout)
@@ -164,6 +166,68 @@ spec = do
       streamWrite streamA (BS.pack (replicate 64 0x80))
       result <- timeout 1000000 (negotiateResponder streamB ["/noise"])
       result `shouldBe` Just NoProtocol
+
+  describe "readExactBounded" $ do
+    it "reads exactly n bytes when n is within the bound" $ do
+      (streamA, streamB) <- mkMemoryStreamPair
+      let payload = BS.pack [1 .. 10]
+      streamWrite streamA payload
+      result <- readExactBounded streamB 1024 10
+      result `shouldBe` Right payload
+
+    it "reads zero bytes as the empty string without touching the stream" $ do
+      (_, streamB) <- mkMemoryStreamPair
+      result <- readExactBounded streamB 1024 0
+      result `shouldBe` Right BS.empty
+
+    it "accepts n equal to the maximum" $ do
+      (streamA, streamB) <- mkMemoryStreamPair
+      let payload = BS.replicate 16 0xab
+      streamWrite streamA payload
+      result <- readExactBounded streamB 16 16
+      result `shouldBe` Right payload
+
+    it "rejects n above the maximum before reading any byte" $ do
+      (streamA, streamB) <- mkMemoryStreamPair
+      streamWrite streamA (BS.pack [1, 2, 3])
+      result <- readExactBounded streamB 16 17
+      result `shouldSatisfy` isLeft
+      -- No byte was consumed: the buffered bytes are still readable.
+      after' <- readExactBounded streamB 16 3
+      after' `shouldBe` Right (BS.pack [1, 2, 3])
+
+    it "rejects a negative length" $ do
+      (_, streamB) <- mkMemoryStreamPair
+      result <- readExactBounded streamB 16 (-1)
+      result `shouldSatisfy` isLeft
+
+    it "returns Left instead of throwing when the stream fails mid-read" $ do
+      -- A stream that yields 5 bytes and then fails (EOF).
+      remaining <- newIORef (5 :: Int)
+      let failingStream = StreamIO
+            { streamWrite = \_ -> pure ()
+            , streamReadByte = do
+                left <- atomicModifyIORef' remaining (\k -> (k - 1, k))
+                if left > 0
+                  then pure (0x2a :: Word8)
+                  else fail "connection reset"
+            , streamClose = pure ()
+            }
+      result <- readExactBounded failingStream 1024 10
+      case result of
+        Left err -> err `shouldContain` "read failed"
+        Right bs -> expectationFailure ("expected Left, got " ++ show bs)
+
+    it "assembles reads larger than one chunk correctly" $ do
+      -- 70000 bytes spans three 32 KiB chunks; the reassembled bytes
+      -- must be identical and in order.
+      (streamA, streamB) <- mkMemoryStreamPair
+      let payload = BS.pack (map fromIntegral [(0 :: Int) .. 69999])
+      -- The in-memory pair is backed by an unbounded queue, so the
+      -- whole payload can be written before reading it back.
+      streamWrite streamA payload
+      result <- readExactBounded streamB 131072 70000
+      result `shouldBe` Right payload
 
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True


### PR DESCRIPTION
## Summary

Issue #169: the same unbounded, byte-at-a-time `readExact` was copy-pasted into eight modules. This PR replaces every copy with a single shared helper, `readExactBounded`, defined next to `StreamIO` in `LibP2P.MultistreamSelect.Negotiation` (a `Core` location would create an import cycle, since `Negotiation` owns `StreamIO` and needs the helper itself).

```haskell
readExactBounded :: StreamIO -> Int {-max-} -> Int {-n-} -> IO (Either String ByteString)
```

The helper:

- validates `n` against the caller-supplied maximum **before** reading or allocating anything
- accumulates bytes in 32 KiB chunks (matching the #185 yamux rewrite) instead of building one boxed `[Word8]` of size `n`
- returns `Left` on overrun and on `IOException` during the read, instead of throwing into `Either`-based call sites

## Call sites migrated

| Call site | Cap passed | Semantics change |
|---|---|---|
| `MultistreamSelect/Negotiation.hs` `readMessage` | 1024 (`maxMessageLength`, go-multistream limit) | EOF mid-payload now yields `Left`/`NoProtocol` instead of an escaped exception |
| `Switch/Upgrade.hs` `readExact` (Noise frames, yamux read callback) | `maxStreamWindowSize` (16 MiB) | none — kept as a thin exception-style wrapper (exported for tests, unchanged signature) |
| `DHT/Message.hs` `readFramedMessage` | `maxSize` (`maxDHTMessageSize`, 64 KiB) | **gains defence-in-depth bound**; EOF now `Left "DHT read error: ..."` instead of exception |
| `Protocol/GossipSub/Message.hs` `readRPCMessage` | `maxSize` | same as DHT |
| `Protocol/Identify.hs` `readFramedIdentify` | `maxSize` (`maxIdentifySize`, 64 KiB) | none observable — already wrapped in a `SomeException` catch returning `Left` |
| `Protocol/Ping.hs` `handlePing` / `pingOnce` | `pingSize` (32) | **gains a hard 32-byte bound**; error categories preserved (`PingStreamError` / echo-loop exit) |
| `NAT/AutoNAT/Message.hs` `readAutoNATMessage` | `maxSize` | same as DHT |
| `NAT/DCUtR/Message.hs` `readHolePunchMessage` | `maxSize` | same as DHT |
| `NAT/Relay/Message.hs` `readFramedWith` (Hop/Stop) | `maxSize` | same as DHT |

Notes on the "gains a bound" rows: every framed reader already checked `msgLen > maxSize` before calling the old `readExact`, so the helper's bound is defence in depth there rather than a behaviour change; the byte-at-a-time boxed-list allocation is what actually goes away. Ping previously had no cap at all on the read path (fixed `n = 32`, so not exploitable, but now enforced).

## Tests

- 7 new unit tests for `readExactBounded` in `test/LibP2P/MultistreamSelect/NegotiationSpec.hs`: exact read, zero-length, `n == max` boundary, `n > max` rejected before consuming bytes, negative length, mid-read I/O failure returned as `Left`, and multi-chunk (70 000 byte) reassembly.
- Full suite: **920 examples, 0 failures** (GHC 9.10.3).

Closes #169
