### PR TITLE
feat(dht): record validation, provider TTL, routing-table growth and client mode

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -66,6 +66,7 @@ library
     LibP2P.DHT.Distance
     LibP2P.DHT.RoutingTable
     LibP2P.DHT.Message
+    LibP2P.DHT.Validator
     LibP2P.DHT
     LibP2P.DHT.Lookup
     LibP2P.NAT.AutoNAT.Message
@@ -168,6 +169,7 @@ test-suite libp2p-hs-test
     LibP2P.DHT.MessageSpec
     LibP2P.DHT.DHTSpec
     LibP2P.DHT.LookupSpec
+    LibP2P.DHT.ValidatorSpec
     LibP2P.NAT.AutoNAT.MessageSpec
     LibP2P.NAT.AutoNAT.AutoNATSpec
     LibP2P.Crypto.SignedEnvelopeSpec

--- a/src/LibP2P/DHT.hs
+++ b/src/LibP2P/DHT.hs
@@ -12,12 +12,18 @@ module LibP2P.DHT
   , DHTMode (..)
   , ProviderEntry (..)
   , Validator (..)
+    -- * Validators
+  , defaultValidator
+  , namespacedValidator
+  , pkValidator
     -- * Construction
   , newDHTNode
     -- * Handler registration
   , registerDHTHandler
     -- * Inbound RPC handler
   , handleDHTRequest
+    -- * Routing table maintenance
+  , addPeerToTable
     -- * Store operations
   , storeRecord
   , lookupRecord
@@ -27,20 +33,36 @@ module LibP2P.DHT
   , decodePeerAddrs
     -- * Constants
   , dhtProtocolId
+  , providerRecordTTL
   ) where
 
 import Control.Concurrent.STM
-import Control.Exception (SomeException, try)
+import Control.Exception (SomeException, catch, try)
 import Data.ByteString (ByteString)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
-import Data.Time (UTCTime, getCurrentTime)
+import qualified Data.Text as T
+import Data.Time (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
+import Data.Time.Format.ISO8601 (iso8601Show)
 import LibP2P.Crypto.PeerId (PeerId (..), peerIdBytes)
 import LibP2P.DHT.Distance (keyToDHTKey, peerIdToKey)
 import LibP2P.DHT.Message
-import LibP2P.DHT.RoutingTable (RoutingTable, closestPeers, newRoutingTable)
+import LibP2P.DHT.RoutingTable
+  ( RoutingTable
+  , allPeers
+  , closestPeers
+  , insertPeer
+  , newRoutingTable
+  , removePeer
+  )
 import LibP2P.DHT.Types
+import LibP2P.DHT.Validator
+  ( Validator (..)
+  , defaultValidator
+  , namespacedValidator
+  , pkValidator
+  )
 import LibP2P.Multiaddr (Multiaddr, fromBytes, toBytes)
 import LibP2P.MultistreamSelect.Negotiation
   ( NegotiationResult (..)
@@ -66,11 +88,10 @@ data ProviderEntry = ProviderEntry
   , peTimestamp :: !UTCTime
   } deriving (Show, Eq)
 
--- | Validator interface for record validation.
-data Validator = Validator
-  { valValidate :: ByteString -> ByteString -> Either String ()
-  , valSelect   :: ByteString -> [ByteString] -> Either String Int
-  }
+-- | Provider record expiration interval, per specs/kad-dht (48 hours).
+-- Expired entries are pruned on read in 'getProviders'.
+providerRecordTTL :: NominalDiffTime
+providerRecordTTL = 48 * 3600
 
 -- | Top-level DHT node state.
 data DHTNode = DHTNode
@@ -81,6 +102,10 @@ data DHTNode = DHTNode
   , dhtLocalKey      :: !DHTKey
   , dhtLocalPeerId   :: !PeerId
   , dhtMode          :: !DHTMode
+  , dhtValidator     :: !Validator
+    -- ^ Record validator applied to PUT_VALUE records before storage
+    -- (and available to GET_VALUE conflict resolution). Defaults to
+    -- 'defaultValidator' (the @/pk/@ namespace).
   , dhtStreams       :: !(TVar (Map PeerId StreamIO))
     -- ^ Cached outbound @/ipfs/kad/1.0.0@ streams, one per peer
     -- (go-libp2p reuses a single long-lived stream per peer)
@@ -105,15 +130,23 @@ newDHTNode sw mode = do
     , dhtLocalKey      = peerIdToKey localPid
     , dhtLocalPeerId   = localPid
     , dhtMode          = mode
+    , dhtValidator     = defaultValidator
     , dhtStreams       = streams
     , dhtSendRequest   = sendRequestViaSwitch sw streams
     }
 
--- | Register the DHT handler on the Switch (server mode only).
+-- | Register the DHT handler on the Switch.
+--
+-- Per specs/kad-dht (client and server mode), nodes operating in client
+-- mode do not offer the Kademlia protocol identifier for incoming
+-- streams, so this is a no-op for 'DHTClient' nodes: they keep issuing
+-- outbound queries via 'dhtSendRequest' but never serve inbound RPC.
 registerDHTHandler :: DHTNode -> IO ()
-registerDHTHandler node =
-  setStreamHandler (dhtSwitch node) dhtProtocolId
-    (\conn stream -> handleDHTRequest node stream (connPeerId conn))
+registerDHTHandler node = case dhtMode node of
+  DHTClient -> pure ()
+  DHTServer ->
+    setStreamHandler (dhtSwitch node) dhtProtocolId
+      (\conn stream -> handleDHTRequest node stream (connPeerId conn))
 
 -- | Handle an inbound DHT stream.
 --
@@ -132,6 +165,18 @@ handleDHTRequest node stream remotePeerId = loop
           Right msg -> do
             response <- processRequest node msg remotePeerId
             writeFramedMessage stream response
+            -- Routing-table growth: a peer speaking the DHT protocol to
+            -- us is a live contact; insert (or refresh) it. Note this
+            -- cannot distinguish client-mode senders (the spec would
+            -- exclude them) without identify-provided protocol lists.
+            now <- getCurrentTime
+            _ <- addPeerToTable node BucketEntry
+              { entryPeerId   = remotePeerId
+              , entryKey      = peerIdToKey remotePeerId
+              , entryAddrs    = []
+              , entryLastSeen = now
+              , entryConnType = Connected
+              }
             pure (Right ())
       case result of
         Left (_ :: SomeException) -> pure ()  -- Stream closed or reset
@@ -179,18 +224,36 @@ handleGetValue node msg = do
     , msgCloserPeers = peers
     }
 
--- | PUT_VALUE: store record and echo it back.
+-- | PUT_VALUE: validate, store with a receiver-set timestamp, and echo.
+--
+-- Per specs/kad-dht (Entry validation), incoming records are validated
+-- before being stored: the record key must match the message key and
+-- the configured 'dhtValidator' must accept the key/value binding
+-- (e.g. @/pk/@ records must carry the public key hashing to the key's
+-- multihash). Rejected records are neither stored nor echoed back.
+--
+-- The stored record's @timeReceived@ is set by the receiver (Record
+-- field 5: "Time the record was received, set by receiver"), never
+-- taken from the sender's claim.
 handlePutValue :: DHTNode -> DHTMessage -> IO DHTMessage
 handlePutValue node msg = do
   case msgRecord msg of
-    Nothing -> pure emptyDHTMessage { msgType = PutValue }
-    Just rec -> do
-      storeRecord node rec
-      pure emptyDHTMessage
-        { msgType = PutValue
-        , msgKey = msgKey msg
-        , msgRecord = Just rec
-        }
+    Nothing -> pure rejected
+    Just rec
+      | recKey rec /= msgKey msg -> pure rejected
+      | otherwise ->
+          case valValidate (dhtValidator node) (recKey rec) (recValue rec) of
+            Left _err -> pure rejected
+            Right () -> do
+              now <- getCurrentTime
+              storeRecord node rec { recTimeReceived = T.pack (iso8601Show now) }
+              pure emptyDHTMessage
+                { msgType = PutValue
+                , msgKey = msgKey msg
+                , msgRecord = Just rec
+                }
+  where
+    rejected = emptyDHTMessage { msgType = PutValue }
 
 -- | ADD_PROVIDER: verify sender and store provider record.
 handleAddProvider :: DHTNode -> DHTMessage -> PeerId -> IO DHTMessage
@@ -206,19 +269,69 @@ handleAddProvider node msg remotePeerId = do
 handleGetProviders :: DHTNode -> DHTMessage -> IO DHTMessage
 handleGetProviders node msg = do
   rt <- readTVarIO (dhtRoutingTable node)
-  providerMap <- readTVarIO (dhtProviderStore node)
   let key = msgKey msg
       -- Store lookup uses the raw key; distance uses its SHA-256.
       targetKey = keyToDHTKey key
       closest = closestPeers targetKey kValue rt
       closerPeers = map entryToDHTPeer closest
-      providers = Map.findWithDefault [] key providerMap
-      providerPeers = map providerToDHTPeer providers
+  -- getProviders prunes entries past the 48h provider TTL on read.
+  providers <- getProviders node key
+  let providerPeers = map providerToDHTPeer providers
   pure emptyDHTMessage
     { msgType = GetProviders
     , msgCloserPeers = closerPeers
     , msgProviderPeers = providerPeers
     }
+
+-- Routing table maintenance
+
+-- | Insert a peer into the routing table, applying the Kademlia
+-- full-bucket eviction policy.
+--
+-- When the target bucket is full, the least-recently-seen peer is
+-- probed with a FIND_NODE request (the DHT liveness check; our
+-- 'MessageType' has no PING, and go-libp2p likewise treats any
+-- successful RPC as proof of liveness):
+--
+-- * if the LRS peer answers, it is kept (refreshed to
+--   most-recently-seen) and the new peer is dropped ('BucketFull');
+-- * if it does not answer, it is evicted and the new peer takes its
+--   place ('Inserted').
+addPeerToTable :: DHTNode -> BucketEntry -> IO InsertResult
+addPeerToTable node entry = do
+  result <- atomically $ do
+    rt <- readTVar (dhtRoutingTable node)
+    let (rt', res) = insertPeer entry rt
+    writeTVar (dhtRoutingTable node) rt'
+    pure res
+  case result of
+    BucketFull lrs -> evictOrKeep lrs
+    other -> pure other
+  where
+    evictOrKeep lrs = do
+      let ping = emptyDHTMessage { msgType = FindNode, msgKey = peerIdBytes lrs }
+      response <- dhtSendRequest node lrs ping
+        `catch` \(e :: SomeException) -> pure (Left (show e))
+      case response of
+        Right _ -> do
+          -- LRS peer is alive: move it to most-recently-seen and drop
+          -- the newcomer.
+          now <- getCurrentTime
+          atomically $ modifyTVar' (dhtRoutingTable node) (refreshPeer lrs now)
+          pure (BucketFull lrs)
+        Left _ -> do
+          -- LRS peer is dead: evict it and insert the newcomer.
+          atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+            fst (insertPeer entry (removePeer lrs rt))
+          pure Inserted
+
+-- | Move an existing peer to the most-recently-seen position of its
+-- bucket with a fresh last-seen timestamp. No-op if the peer is gone.
+refreshPeer :: PeerId -> UTCTime -> RoutingTable -> RoutingTable
+refreshPeer pid now rt =
+  case filter ((== pid) . entryPeerId) (allPeers rt) of
+    (e : _) -> fst (insertPeer e { entryLastSeen = now } rt)
+    [] -> rt
 
 -- Outbound RPC
 
@@ -299,15 +412,30 @@ lookupRecord :: DHTNode -> ByteString -> IO (Maybe DHTRecord)
 lookupRecord node key = Map.lookup key <$> readTVarIO (dhtRecordStore node)
 
 -- | Add a provider entry for a content key.
+--
+-- A provider republishing on schedule replaces its previous entry
+-- (deduplicated by peer ID) instead of appending a duplicate, so the
+-- entry's timestamp is refreshed and GET_PROVIDERS responses stay
+-- bounded.
 addProvider :: DHTNode -> ByteString -> ProviderEntry -> IO ()
 addProvider node key entry = atomically $
   modifyTVar' (dhtProviderStore node) $ \m ->
-    Map.insertWith (++) key [entry] m
+    Map.insertWith merge key [entry] m
+  where
+    merge new old = new ++ filter (\e -> peProvider e /= peProvider entry) old
 
--- | Get providers for a content key.
+-- | Get providers for a content key, pruning entries older than
+-- 'providerRecordTTL' (48h expiration interval per specs/kad-dht).
 getProviders :: DHTNode -> ByteString -> IO [ProviderEntry]
-getProviders node key =
-  Map.findWithDefault [] key <$> readTVarIO (dhtProviderStore node)
+getProviders node key = do
+  now <- getCurrentTime
+  atomically $ do
+    m <- readTVar (dhtProviderStore node)
+    let live = filter (\e -> diffUTCTime now (peTimestamp e) < providerRecordTTL)
+                      (Map.findWithDefault [] key m)
+        m' = if null live then Map.delete key m else Map.insert key live m
+    writeTVar (dhtProviderStore node) m'
+    pure live
 
 -- Helpers
 

--- a/src/LibP2P/DHT/Lookup.hs
+++ b/src/LibP2P/DHT/Lookup.hs
@@ -27,10 +27,16 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Time (UTCTime, getCurrentTime)
 import LibP2P.Crypto.PeerId (PeerId (..), peerIdBytes)
-import LibP2P.DHT (DHTNode (..), ProviderEntry (..), Validator (..), decodePeerAddrs)
+import LibP2P.DHT
+  ( DHTNode (..)
+  , ProviderEntry (..)
+  , Validator (..)
+  , addPeerToTable
+  , decodePeerAddrs
+  )
 import LibP2P.DHT.Distance (keyToDHTKey, peerIdToKey, sortByDistance)
 import LibP2P.DHT.Message
-import LibP2P.DHT.RoutingTable (closestPeers, insertPeer, allPeers)
+import LibP2P.DHT.RoutingTable (allPeers, closestPeers)
 import LibP2P.DHT.Types
 
 -- | Result of an iterative lookup.
@@ -74,10 +80,10 @@ lookupLoop
   -> TVar [BucketEntry]   -- ^ Candidates sorted by XOR distance to target
   -> TVar (Set PeerId)    -- ^ Already queried peers
   -> TVar (Set PeerId)    -- ^ Known peers (all candidates ever seen, for dedup)
-  -> a                    -- ^ Timestamp placeholder (UTCTime)
+  -> UTCTime              -- ^ Lookup start time (last-seen for new entries)
   -> MessageType          -- ^ Query type
   -> IO [BucketEntry]
-lookupLoop node wireKey targetKey candidatesVar queriedVar knownVar _now queryType = go
+lookupLoop node wireKey targetKey candidatesVar queriedVar knownVar now queryType = go
   where
     go = do
       -- Pick up to alpha unqueried candidates closest to target
@@ -101,19 +107,27 @@ lookupLoop node wireKey targetKey candidatesVar queriedVar knownVar _now queryTy
           results <- mapConcurrently (queryPeer node wireKey queryType) toQuery
 
           -- Merge results
-          atomically $ do
+          newEntries <- atomically $ do
             known <- readTVar knownVar
             candidates <- readTVar candidatesVar
             let newPeers = concatMap (either (const []) id) results
                 -- Convert DHTPeers to BucketEntries, excluding already known
                 newEntries = filter (\e -> not (Set.member (entryPeerId e) known))
-                           $ map (dhtPeerToEntry _now) newPeers
+                           $ map (dhtPeerToEntry now) newPeers
                 -- Mark new entries as known
                 newKnown = Set.union known (Set.fromList (map entryPeerId newEntries))
                 -- Merge and re-sort by XOR distance
                 merged = sortByDistance targetKey (candidates ++ newEntries)
             writeTVar candidatesVar merged
             writeTVar knownVar newKnown
+            pure newEntries
+
+          -- Peers encountered throughout the search are inserted in the
+          -- routing table, as per usual business (specs/kad-dht,
+          -- bootstrap process); responders are refreshed as live.
+          insertLookupPeers node
+            [e | (e, Right _) <- zip toQuery results]
+            newEntries
 
           -- Check termination: have we queried top-k?
           shouldContinue <- atomically $ do
@@ -179,9 +193,9 @@ valueLoop
   -> TVar (Set PeerId)    -- ^ Peers that returned best value
   -> TVar (Set PeerId)    -- ^ Peers with outdated values
   -> Validator
-  -> a
+  -> UTCTime              -- ^ Lookup start time (last-seen for new entries)
   -> IO (Either String DHTRecord)
-valueLoop node wireKey targetKey candidatesVar queriedVar knownVar bestVar bestPeersVar outdatedVar validator _now = go
+valueLoop node wireKey targetKey candidatesVar queriedVar knownVar bestVar bestPeersVar outdatedVar validator now = go
   where
     go = do
       toQuery <- atomically $ do
@@ -199,19 +213,25 @@ valueLoop node wireKey targetKey candidatesVar queriedVar knownVar bestVar bestP
           results <- mapConcurrently (queryPeerForValue node wireKey) toQuery
 
           -- Process each result
-          mapM_ (processValueResult node targetKey bestVar bestPeersVar outdatedVar validator _now) results
+          mapM_ (processValueResult node targetKey bestVar bestPeersVar outdatedVar validator now) results
 
           -- Merge closer peers from responses
-          atomically $ do
+          newEntries <- atomically $ do
             known <- readTVar knownVar
             candidates <- readTVar candidatesVar
             let newPeers = concatMap (\(_, peers, _) -> either (const []) id peers) results
                 newEntries = filter (\e -> not (Set.member (entryPeerId e) known))
-                           $ map (dhtPeerToEntry _now) newPeers
+                           $ map (dhtPeerToEntry now) newPeers
                 newKnown = Set.union known (Set.fromList (map entryPeerId newEntries))
                 merged = sortByDistance targetKey (candidates ++ newEntries)
             writeTVar candidatesVar merged
             writeTVar knownVar newKnown
+            pure newEntries
+
+          -- Grow the routing table from peers seen this round.
+          insertLookupPeers node
+            [e | (e, (_, Right _, _)) <- zip toQuery results]
+            newEntries
 
           -- Check termination
           shouldContinue <- atomically $ do
@@ -253,16 +273,22 @@ queryPeerForValue node wireKey entry = do
     Right resp -> (entryPeerId entry, Right (msgCloserPeers resp), msgRecord resp)
 
 -- | Process a value result: update best/bestPeers/outdated.
+--
+-- Per specs/kad-dht (Entry validation), values retrieved in a GET_VALUE
+-- query are validated before being considered; records failing the
+-- validator are ignored as if the peer had returned no record.
 processValueResult
   :: DHTNode -> DHTKey
   -> TVar (Maybe DHTRecord)
   -> TVar (Set PeerId)
   -> TVar (Set PeerId)
   -> Validator
-  -> a
+  -> UTCTime
   -> (PeerId, Either String [DHTPeer], Maybe DHTRecord)
   -> IO ()
-processValueResult _ _ bestVar bestPeersVar outdatedVar validator _ (pid, _, Just rec) = do
+processValueResult _ _ bestVar bestPeersVar outdatedVar validator _ (pid, _, Just rec)
+  | Left _ <- valValidate validator (recKey rec) (recValue rec) = pure ()
+  | otherwise = do
   atomically $ do
     best <- readTVar bestVar
     case best of
@@ -310,9 +336,9 @@ providerLoop
   -> TVar (Set PeerId)
   -> TVar (Set PeerId)    -- ^ Known peers (dedup)
   -> TVar [ProviderEntry]
-  -> a
+  -> UTCTime              -- ^ Lookup start time (last-seen for new entries)
   -> IO [ProviderEntry]
-providerLoop node wireKey targetKey candidatesVar queriedVar knownVar providersVar _now = go
+providerLoop node wireKey targetKey candidatesVar queriedVar knownVar providersVar now = go
   where
     go = do
       toQuery <- atomically $ do
@@ -330,20 +356,26 @@ providerLoop node wireKey targetKey candidatesVar queriedVar knownVar providersV
           results <- mapConcurrently (queryPeerForProviders node wireKey) toQuery
 
           -- Collect providers and closer peers
-          atomically $ do
+          newEntries <- atomically $ do
             known <- readTVar knownVar
             candidates <- readTVar candidatesVar
             currentProviders <- readTVar providersVar
             let allCloser = concatMap (\(_, closer, _) -> either (const []) id closer) results
                 allProviders = concatMap (\(_, _, provs) -> provs) results
                 newEntries = filter (\e -> not (Set.member (entryPeerId e) known))
-                           $ map (dhtPeerToEntry _now) allCloser
+                           $ map (dhtPeerToEntry now) allCloser
                 newKnown = Set.union known (Set.fromList (map entryPeerId newEntries))
                 merged = sortByDistance targetKey (candidates ++ newEntries)
-                newProviderEntries = map dhtPeerToProvider allProviders
+                newProviderEntries = map (dhtPeerToProvider now) allProviders
             writeTVar candidatesVar merged
             writeTVar knownVar newKnown
             writeTVar providersVar (currentProviders ++ newProviderEntries)
+            pure newEntries
+
+          -- Grow the routing table from peers seen this round.
+          insertLookupPeers node
+            [e | (e, (_, Right _, _)) <- zip toQuery results]
+            newEntries
 
           shouldContinue <- atomically $ do
             candidates <- readTVar candidatesVar
@@ -369,11 +401,9 @@ queryPeerForProviders node wireKey entry = do
 bootstrap :: DHTNode -> [PeerId] -> IO ()
 bootstrap node seeds = do
   now <- getCurrentTime
-  -- Step 1: Add seed peers to routing table
-  rt <- readTVarIO (dhtRoutingTable node)
+  -- Step 1: Add seed peers to routing table (with eviction policy)
   let seedEntries = map (\pid -> BucketEntry pid (peerIdToKey pid) [] now NotConnected) seeds
-      rt' = foldl (\r e -> fst (insertPeer e r)) rt seedEntries
-  atomically $ writeTVar (dhtRoutingTable node) rt'
+  mapM_ (addPeerToTable node) seedEntries
 
   -- Step 2: Self-lookup (FIND_NODE for our own peer ID)
   _ <- iterativeFindNode node (dhtLocalPeerId node)
@@ -390,26 +420,32 @@ bootstrap node seeds = do
 
 -- Helpers
 
--- | Convert a DHTPeer to a BucketEntry (with current time).
+-- | Insert peers observed during a lookup round into the routing table:
+-- peers that answered our query (refreshed with a new last-seen time)
+-- and newly discovered candidates from closerPeers. Insertion applies
+-- the full-bucket eviction policy of 'addPeerToTable'.
+insertLookupPeers :: DHTNode -> [BucketEntry] -> [BucketEntry] -> IO ()
+insertLookupPeers node responders discovered = do
+  now <- getCurrentTime
+  mapM_ (\e -> addPeerToTable node e { entryLastSeen = now }) responders
+  mapM_ (addPeerToTable node) discovered
+
+-- | Convert a DHTPeer to a BucketEntry seen at the given time.
 -- Per specs/kad-dht, multiaddrs carried by Peer records are decoded and
 -- kept so the learned peers can be dialled in follow-up queries.
-dhtPeerToEntry :: a -> DHTPeer -> BucketEntry
-dhtPeerToEntry _ peer = BucketEntry
+dhtPeerToEntry :: UTCTime -> DHTPeer -> BucketEntry
+dhtPeerToEntry now peer = BucketEntry
   { entryPeerId   = PeerId (dhtPeerId peer)
   , entryKey      = peerIdToKey (PeerId (dhtPeerId peer))
   , entryAddrs    = decodePeerAddrs (dhtPeerAddrs peer)
-  , entryLastSeen = epochTime
+  , entryLastSeen = now
   , entryConnType = dhtPeerConnType peer
   }
 
--- | Convert a DHTPeer to a ProviderEntry.
-dhtPeerToProvider :: DHTPeer -> ProviderEntry
-dhtPeerToProvider peer = ProviderEntry
+-- | Convert a DHTPeer to a ProviderEntry seen at the given time.
+dhtPeerToProvider :: UTCTime -> DHTPeer -> ProviderEntry
+dhtPeerToProvider now peer = ProviderEntry
   { peProvider  = PeerId (dhtPeerId peer)
   , peAddrs     = decodePeerAddrs (dhtPeerAddrs peer)
-  , peTimestamp = epochTime
+  , peTimestamp = now
   }
-
--- | Epoch time as placeholder (0 seconds from epoch).
-epochTime :: UTCTime
-epochTime = read "2000-01-01 00:00:00 UTC"

--- a/src/LibP2P/DHT/Validator.hs
+++ b/src/LibP2P/DHT/Validator.hs
@@ -1,0 +1,96 @@
+-- | Record validation for the Kademlia DHT.
+--
+-- Per specs/kad-dht (Entry validation), records must be validated on
+-- two occasions: values retrieved in a GET_VALUE query and values
+-- received in a PUT_VALUE query before storing them locally.
+--
+-- Record keys have the form @/namespace/path@; validation dispatches on
+-- the namespace, mirroring go-libp2p's @record.NamespacedValidator@.
+-- The built-in @/pk/@ validator binds the key to the value: the path
+-- must be the multihash (Peer ID) of the serialized public key carried
+-- in the value.
+module LibP2P.DHT.Validator
+  ( -- * Validator interface
+    Validator (..)
+    -- * Built-in validators
+  , namespacedValidator
+  , pkValidator
+  , defaultValidator
+    -- * Key helpers
+  , splitRecordKey
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import LibP2P.Crypto.PeerId (fromPublicKey, peerIdBytes)
+import LibP2P.Crypto.Protobuf (decodePublicKey)
+
+-- | Validator interface for record validation.
+--
+-- 'valValidate' checks that a value is well-formed for its key and
+-- returns an error for records that must not be stored or served.
+-- 'valSelect' picks the index of the best value among conflicting
+-- candidates for the same key (used for GET_VALUE conflict resolution).
+data Validator = Validator
+  { valValidate :: ByteString -> ByteString -> Either String ()
+  , valSelect   :: ByteString -> [ByteString] -> Either String Int
+  }
+
+-- | Split a record key of the form @/namespace/path@ into
+-- (namespace, path). The path is raw bytes (for @/pk/@ it is a binary
+-- multihash), so only the two leading separators are interpreted.
+splitRecordKey :: ByteString -> Either String (ByteString, ByteString)
+splitRecordKey key = case BS.uncons key of
+  Just (0x2F, rest) ->
+    let (ns, pathWithSlash) = BS.break (== 0x2F) rest
+    in case BS.uncons pathWithSlash of
+         Just (0x2F, path) -> Right (ns, path)
+         _ -> Left "invalid record key: missing namespace separator"
+  _ -> Left "invalid record key: missing leading '/'"
+
+-- | Dispatch validation by key namespace. Keys without a registered
+-- namespace are rejected, matching go-libp2p's namespaced validator
+-- (\"invalid record keytype\").
+namespacedValidator :: Map ByteString Validator -> Validator
+namespacedValidator validators = Validator
+  { valValidate = \key value -> do
+      v <- validatorFor key
+      valValidate v key value
+  , valSelect = \key values -> do
+      v <- validatorFor key
+      valSelect v key values
+  }
+  where
+    validatorFor key = do
+      (ns, _) <- splitRecordKey key
+      case Map.lookup ns validators of
+        Nothing -> Left ("invalid record keytype: " ++ BSC.unpack ns)
+        Just v -> Right v
+
+-- | Validator for the @/pk/@ namespace: the value must be a serialized
+-- PublicKey protobuf whose derived Peer ID equals the multihash in the
+-- key path. Public keys never conflict, so 'valSelect' keeps the first
+-- candidate (go-libp2p's @record.PublicKeyValidator@ does the same).
+pkValidator :: Validator
+pkValidator = Validator
+  { valValidate = \key value -> do
+      (_, mh) <- splitRecordKey key
+      pub <- decodePublicKey value
+      let derived = peerIdBytes (fromPublicKey pub)
+      if derived == mh
+        then Right ()
+        else Left "public key does not match record key"
+  , valSelect = \_ values ->
+      if null values
+        then Left "no values to select from"
+        else Right 0
+  }
+
+-- | The default validator set: @/pk/@ records only. Additional
+-- namespaces can be registered by building a custom
+-- 'namespacedValidator' and storing it in the DHT node.
+defaultValidator :: Validator
+defaultValidator = namespacedValidator (Map.fromList [(BSC.pack "pk", pkValidator)])

--- a/test/LibP2P/DHT/DHTSpec.hs
+++ b/test/LibP2P/DHT/DHTSpec.hs
@@ -12,15 +12,19 @@ import Control.Concurrent.STM
 import Crypto.Hash (Digest, SHA256, hash)
 import Data.ByteArray (convert)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Map.Strict as Map
-import Data.Time (getCurrentTime)
+import qualified Data.Text as T
+import Data.Time (addUTCTime, getCurrentTime)
 import Data.Word (Word8)
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (KeyPair (..), PublicKey (..), PrivateKey (..), KeyType (..))
-import LibP2P.Crypto.PeerId (PeerId (..), peerIdBytes)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey, peerIdBytes)
+import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.DHT
 import LibP2P.DHT.Distance (peerIdToKey, sortByDistance)
 import LibP2P.DHT.Message
-import LibP2P.DHT.RoutingTable (insertPeer)
+import LibP2P.DHT.RoutingTable (allPeers, bucketForPeer, insertPeer, newRoutingTable)
 import LibP2P.DHT.Types
 import LibP2P.Multiaddr (Multiaddr, fromText, toBytes)
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), negotiateResponder)
@@ -100,6 +104,33 @@ dummyKeyPair = KeyPair
 -- | A test multiaddr for address propagation assertions.
 testAddr :: Multiaddr
 testAddr = either error id (fromText "/ip4/127.0.0.1/tcp/4001")
+
+-- | Build a valid /pk/ record: key is "/pk/" ++ peer ID multihash,
+-- value is the serialized PublicKey protobuf that hashes to that ID.
+mkPkRecord :: IO (BS.ByteString, BS.ByteString)
+mkPkRecord = do
+  ekp <- generateKeyPair
+  case ekp of
+    Left err -> fail ("keypair generation failed: " ++ err)
+    Right kp -> do
+      let pub = kpPublic kp
+          pid = fromPublicKey pub
+      pure (BSC.pack "/pk/" <> peerIdBytes pid, encodePublicKey pub)
+
+-- | A bucket entry with no addresses for routing-table tests.
+mkEntry :: PeerId -> IO BucketEntry
+mkEntry pid = do
+  now <- getCurrentTime
+  pure (BucketEntry pid (peerIdToKey pid) [] now NotConnected)
+
+-- | Peer IDs that all land in the same k-bucket (index 0) of localPid's
+-- routing table, used to fill a bucket to capacity.
+sameBucketPeers :: Int -> [PeerId]
+sameBucketPeers n =
+  let rt = newRoutingTable localPid
+      candidates = [mkPeerId (BS.pack [10, i]) | i <- [0 .. 255]]
+      inBucket pid = bucketForPeer (peerIdToKey pid) rt == 0
+  in take n (filter inBucket candidates)
 
 -- | Create a stream pair for testing, with close/EOF support.
 -- Closing one end makes reads on the other end fail once the in-flight
@@ -321,10 +352,10 @@ spec = do
           msgType resp `shouldBe` GetValue
         Left err -> expectationFailure $ "Failed: " ++ err
 
-    it "PUT_VALUE stores record" $ do
+    it "PUT_VALUE stores a valid /pk/ record and stamps timeReceived" $ do
       node <- mkTestNode localPid
-      let key = BS.pack [0xBE, 0xEF]
-          rec = DHTRecord key (BS.pack [1, 2, 3]) "2024-06-15T12:00:00Z"
+      (key, value) <- mkPkRecord
+      let rec = DHTRecord key value "2024-06-15T12:00:00Z"
 
       (clientStream, serverStream) <- mkStreamPair
       let request = emptyDHTMessage
@@ -338,7 +369,13 @@ spec = do
       _ <- readFramedMessage clientStream maxDHTMessageSize
 
       stored <- lookupRecord node key
-      stored `shouldBe` Just rec
+      fmap recKey stored `shouldBe` Just key
+      fmap recValue stored `shouldBe` Just value
+      -- Spec: "Time the record was received, set by receiver" — the
+      -- sender's claimed timestamp must be replaced, not echoed into
+      -- the store.
+      fmap recTimeReceived stored `shouldNotBe` Just "2024-06-15T12:00:00Z"
+      fmap (T.null . recTimeReceived) stored `shouldBe` Just False
 
     it "ADD_PROVIDER rejects mismatched sender" $ do
       node <- mkTestNode localPid
@@ -596,3 +633,173 @@ spec = do
       node <- mkTestNode localPid
       result <- getProviders node (BS.pack [0xFF])
       result `shouldBe` []
+
+  -- Issue #148 (1): PUT_VALUE must validate records before storing them.
+  describe "PUT_VALUE validation" $ do
+    it "rejects a record under an unregistered namespace" $ do
+      node <- mkTestNode localPid
+      let key = BS.pack [0xBE, 0xEF]
+          rec = DHTRecord key (BS.pack [1, 2, 3]) ""
+
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage
+            { msgType = PutValue, msgKey = key, msgRecord = Just rec }
+      writeFramedMessage clientStream request
+      streamClose clientStream
+      handleDHTRequest node serverStream remotePid
+      resp <- readFramedMessage clientStream maxDHTMessageSize
+
+      stored <- lookupRecord node key
+      stored `shouldBe` Nothing
+      -- The rejected record must not be echoed back as accepted.
+      fmap msgRecord resp `shouldBe` Right Nothing
+
+    it "rejects a /pk/ record bound to a different peer" $ do
+      node <- mkTestNode localPid
+      (_, value) <- mkPkRecord
+      (otherKey, _) <- mkPkRecord
+      let rec = DHTRecord otherKey value ""
+
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage
+            { msgType = PutValue, msgKey = otherKey, msgRecord = Just rec }
+      writeFramedMessage clientStream request
+      streamClose clientStream
+      handleDHTRequest node serverStream remotePid
+      _ <- readFramedMessage clientStream maxDHTMessageSize
+
+      stored <- lookupRecord node otherKey
+      stored `shouldBe` Nothing
+
+    it "rejects a record whose embedded key differs from the message key" $ do
+      node <- mkTestNode localPid
+      (key, value) <- mkPkRecord
+      (msgOnlyKey, _) <- mkPkRecord
+      let rec = DHTRecord key value ""
+
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage
+            { msgType = PutValue, msgKey = msgOnlyKey, msgRecord = Just rec }
+      writeFramedMessage clientStream request
+      streamClose clientStream
+      handleDHTRequest node serverStream remotePid
+      _ <- readFramedMessage clientStream maxDHTMessageSize
+
+      storedUnderMsgKey <- lookupRecord node msgOnlyKey
+      storedUnderRecKey <- lookupRecord node key
+      storedUnderMsgKey `shouldBe` Nothing
+      storedUnderRecKey `shouldBe` Nothing
+
+  -- Issue #148 (5): provider records must expire after the 48h TTL and
+  -- must not duplicate when a provider republishes.
+  describe "provider TTL" $ do
+    it "getProviders drops entries older than the provider TTL" $ do
+      node <- mkTestNode localPid
+      now <- getCurrentTime
+      let key = BS.pack [0xAA]
+          stalePid = mkPeerId (BS.pack [5])
+          freshPid = mkPeerId (BS.pack [6])
+          stale = ProviderEntry stalePid [] (addUTCTime (negate (49 * 3600)) now)
+          fresh = ProviderEntry freshPid [] now
+      addProvider node key stale
+      addProvider node key fresh
+      result <- getProviders node key
+      map peProvider result `shouldBe` [freshPid]
+
+    it "GET_PROVIDERS omits expired providers" $ do
+      node <- mkTestNode localPid
+      now <- getCurrentTime
+      let key = BS.pack [0xAB]
+          stale = ProviderEntry (mkPeerId (BS.pack [5])) []
+                    (addUTCTime (negate (49 * 3600)) now)
+      addProvider node key stale
+
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage { msgType = GetProviders, msgKey = key }
+      writeFramedMessage clientStream request
+      streamClose clientStream
+      handleDHTRequest node serverStream remotePid
+      resp <- readFramedMessage clientStream maxDHTMessageSize
+      fmap msgProviderPeers resp `shouldBe` Right []
+
+    it "addProvider replaces an existing entry for the same provider" $ do
+      node <- mkTestNode localPid
+      now <- getCurrentTime
+      let key = BS.pack [0xAC]
+          pid = mkPeerId (BS.pack [7])
+          older = ProviderEntry pid [] (addUTCTime (negate 60) now)
+          newer = ProviderEntry pid [] now
+      addProvider node key older
+      addProvider node key newer
+      result <- getProviders node key
+      result `shouldBe` [newer]
+
+  -- Issue #148 (4, 6): the routing table must grow from observed peers,
+  -- with the LRS ping-or-drop policy when a bucket is full.
+  describe "routing-table growth" $ do
+    it "an inbound request adds the sender to the routing table" $ do
+      node <- mkTestNode localPid
+      (clientStream, serverStream) <- mkStreamPair
+      let request = emptyDHTMessage { msgType = FindNode, msgKey = BS.pack [7] }
+      writeFramedMessage clientStream request
+      streamClose clientStream
+      handleDHTRequest node serverStream remotePid
+      rt <- readTVarIO (dhtRoutingTable node)
+      map entryPeerId (allPeers rt) `shouldContain` [remotePid]
+
+    it "addPeerToTable evicts an unresponsive LRS peer from a full bucket" $ do
+      node0 <- mkTestNode localPid
+      let node = node0 { dhtSendRequest = \_ _ -> pure (Left "unreachable") }
+          bucketPeers = sameBucketPeers (kValue + 1)
+          initial = take kValue bucketPeers
+          newcomer = last bucketPeers
+          lrs = head initial
+      mapM_ (\pid -> do
+               e <- mkEntry pid
+               atomically $ modifyTVar' (dhtRoutingTable node) (fst . insertPeer e))
+            initial
+      entry <- mkEntry newcomer
+      result <- addPeerToTable node entry
+      result `shouldBe` Inserted
+      rt <- readTVarIO (dhtRoutingTable node)
+      let pids = map entryPeerId (allPeers rt)
+      pids `shouldContain` [newcomer]
+      pids `shouldNotContain` [lrs]
+
+    it "addPeerToTable keeps a responsive LRS peer and drops the newcomer" $ do
+      node0 <- mkTestNode localPid
+      let node = node0
+            { dhtSendRequest = \_ _ ->
+                pure (Right (emptyDHTMessage { msgType = FindNode })) }
+          bucketPeers = sameBucketPeers (kValue + 1)
+          initial = take kValue bucketPeers
+          newcomer = last bucketPeers
+          lrs = head initial
+      mapM_ (\pid -> do
+               e <- mkEntry pid
+               atomically $ modifyTVar' (dhtRoutingTable node) (fst . insertPeer e))
+            initial
+      entry <- mkEntry newcomer
+      result <- addPeerToTable node entry
+      result `shouldBe` BucketFull lrs
+      rt <- readTVarIO (dhtRoutingTable node)
+      let pids = map entryPeerId (allPeers rt)
+      pids `shouldContain` [lrs]
+      pids `shouldNotContain` [newcomer]
+
+  -- Issue #148 (3): client-mode nodes must not offer the Kademlia
+  -- protocol for incoming streams.
+  describe "client/server mode" $ do
+    it "registerDHTHandler is a no-op for a client-mode node" $ do
+      sw <- mkMockSwitch localPid
+      node <- newDHTNode sw DHTClient
+      registerDHTHandler node
+      protos <- readTVarIO (swProtocols sw)
+      Map.member dhtProtocolId protos `shouldBe` False
+
+    it "registerDHTHandler registers the protocol for a server-mode node" $ do
+      sw <- mkMockSwitch localPid
+      node <- newDHTNode sw DHTServer
+      registerDHTHandler node
+      protos <- readTVarIO (swProtocols sw)
+      Map.member dhtProtocolId protos `shouldBe` True

--- a/test/LibP2P/DHT/LookupSpec.hs
+++ b/test/LibP2P/DHT/LookupSpec.hs
@@ -348,7 +348,76 @@ spec = do
       let entriesB = filter ((== pidB) . entryPeerId) result
       map entryAddrs entriesB `shouldBe` [[addrB]]
 
+    -- Issue #148 (4): "Peers encountered throughout the search are
+    -- inserted in the routing table, as per usual business."
+    it "inserts peers discovered during the lookup into the routing table" $ do
+      now <- getCurrentTime
+      let pidA = mkPeerId (BS.pack [10])
+          pidB = mkPeerId (BS.pack [20])
+          pidC = mkPeerId (BS.pack [30])
+          targetPid = mkPeerId (BS.pack [42, 42, 42, 42])
+          wantKey = peerIdBytes targetPid
+          network = Map.fromList
+            [ (pidA, expecting FindNode wantKey
+                (findNodeReply [DHTPeer (peerIdBytes pidB) [] NotConnected]))
+            , (pidB, expecting FindNode wantKey
+                (findNodeReply [DHTPeer (peerIdBytes pidC) [] NotConnected]))
+            , (pidC, expecting FindNode wantKey (findNodeReply []))
+            ]
+      node <- mkNodeWithMock localPid (mockSendFromNetwork network)
+      let entryA = BucketEntry pidA (peerIdToKey pidA) [] now NotConnected
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        fst (insertPeer entryA rt)
+
+      _ <- iterativeFindNode node targetPid
+      rt <- readTVarIO (dhtRoutingTable node)
+      let tablePids = map entryPeerId (allPeers rt)
+      tablePids `shouldContain` [pidB]
+      tablePids `shouldContain` [pidC]
+
   describe "iterativeGetValue" $ do
+    -- Issue #148 (1): the validator must also gate values retrieved in
+    -- GET_VALUE queries, not just PUT_VALUE storage.
+    it "ignores retrieved records that fail validation" $ do
+      now <- getCurrentTime
+      let pidA = mkPeerId (BS.pack [10])
+          pidB = mkPeerId (BS.pack [20])
+          key = BS.pack [0xCA, 0xFE]
+          badRecord = DHTRecord key (BS.pack [0xBA, 0xD0]) ""
+          goodRecord = DHTRecord key (BS.pack [0x60, 0x0D]) ""
+          network = Map.fromList
+            [ (pidA, expecting GetValue key (emptyDHTMessage
+                { msgType = GetValue
+                , msgRecord = Just badRecord
+                , msgCloserPeers = [DHTPeer (peerIdBytes pidB) [] NotConnected]
+                }))
+            , (pidB, \req -> case msgType req of
+                GetValue -> expecting GetValue key (emptyDHTMessage
+                  { msgType = GetValue
+                  , msgRecord = Just goodRecord
+                  , msgCloserPeers = []
+                  }) req
+                -- The invalid record's holder may receive a repair.
+                PutValue -> expecting PutValue key
+                  (emptyDHTMessage { msgType = PutValue, msgKey = key }) req
+                other -> Left $ "mock: unexpected request type " ++ show other)
+            ]
+          validator = Validator
+            { valValidate = \_ value ->
+                if value == recValue badRecord
+                  then Left "invalid record"
+                  else Right ()
+            , valSelect = \_ _ -> Right 0
+            }
+      node <- mkNodeWithMock localPid (mockSendFromNetwork network)
+      let entryA = BucketEntry pidA (peerIdToKey pidA) [] now NotConnected
+      atomically $ modifyTVar' (dhtRoutingTable node) $ \rt ->
+        fst (insertPeer entryA rt)
+
+      result <- iterativeGetValue node validator key
+      case result of
+        Right rec -> recValue rec `shouldBe` recValue goodRecord
+        Left err -> expectationFailure $ "Expected the valid record, got: " ++ err
     it "sends the raw record key as the wire key" $ do
       now <- getCurrentTime
       sentKeysRef <- newIORef ([] :: [BS.ByteString])

--- a/test/LibP2P/DHT/ValidatorSpec.hs
+++ b/test/LibP2P/DHT/ValidatorSpec.hs
@@ -1,0 +1,81 @@
+-- | Tests for DHT record validation (issue #148).
+--
+-- Per specs/kad-dht, PUT_VALUE records must be validated before storage
+-- and the /pk/ namespace binds the record key to the public key value:
+-- the key is "/pk/" ++ multihash where the multihash must equal the
+-- Peer ID derived from the serialized public key in the value.
+module LibP2P.DHT.ValidatorSpec (spec) where
+
+import Test.Hspec
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import Data.Either (isLeft)
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair (..))
+import LibP2P.Crypto.PeerId (fromPublicKey, peerIdBytes)
+import LibP2P.Crypto.Protobuf (encodePublicKey)
+import LibP2P.DHT.Validator
+
+-- | Generate a fresh Ed25519 identity for /pk/ record fixtures.
+mkIdentity :: IO (BS.ByteString, BS.ByteString)
+-- ^ Returns (peer ID multihash bytes, serialized PublicKey protobuf).
+mkIdentity = do
+  ekp <- generateKeyPair
+  case ekp of
+    Left err -> fail ("keypair generation failed: " ++ err)
+    Right kp -> do
+      let pub = kpPublic kp
+          pid = fromPublicKey pub
+      pure (peerIdBytes pid, encodePublicKey pub)
+
+spec :: Spec
+spec = do
+  describe "splitRecordKey" $ do
+    it "splits /pk/<mh> into namespace and path" $ do
+      splitRecordKey (BSC.pack "/pk/" <> BS.pack [1, 2, 3])
+        `shouldBe` Right (BSC.pack "pk", BS.pack [1, 2, 3])
+
+    it "rejects a key without a leading slash" $ do
+      splitRecordKey (BSC.pack "pk/abc") `shouldSatisfy` isLeft
+
+    it "rejects a key without a namespace separator" $ do
+      splitRecordKey (BSC.pack "/pk") `shouldSatisfy` isLeft
+
+  describe "pkValidator" $ do
+    it "accepts a record whose key is the peer ID of the value's public key" $ do
+      (mh, pubBytes) <- mkIdentity
+      valValidate pkValidator (BSC.pack "/pk/" <> mh) pubBytes
+        `shouldBe` Right ()
+
+    it "rejects a record whose key names a different peer" $ do
+      (_, pubBytes) <- mkIdentity
+      (otherMh, _) <- mkIdentity
+      valValidate pkValidator (BSC.pack "/pk/" <> otherMh) pubBytes
+        `shouldSatisfy` isLeft
+
+    it "rejects a value that is not a serialized public key" $ do
+      (mh, _) <- mkIdentity
+      valValidate pkValidator (BSC.pack "/pk/" <> mh) (BSC.pack "garbage")
+        `shouldSatisfy` isLeft
+
+    it "selects the first record" $ do
+      valSelect pkValidator (BSC.pack "/pk/x") [BSC.pack "a", BSC.pack "b"]
+        `shouldBe` Right 0
+
+    it "select fails on an empty candidate list" $ do
+      valSelect pkValidator (BSC.pack "/pk/x") [] `shouldSatisfy` isLeft
+
+  describe "defaultValidator (namespaced)" $ do
+    it "delegates /pk/ records to the pk validator" $ do
+      (mh, pubBytes) <- mkIdentity
+      valValidate defaultValidator (BSC.pack "/pk/" <> mh) pubBytes
+        `shouldBe` Right ()
+
+    it "rejects keys in an unregistered namespace" $ do
+      valValidate defaultValidator (BSC.pack "/unknown/key") (BSC.pack "v")
+        `shouldSatisfy` isLeft
+
+    it "rejects keys with no namespace" $ do
+      valValidate defaultValidator (BSC.pack "rawkey") (BSC.pack "v")
+        `shouldSatisfy` isLeft


### PR DESCRIPTION
## Summary

Implements the four declared-but-unimplemented DHT behaviours from #148, per [specs/kad-dht](https://github.com/libp2p/specs/tree/master/kad-dht) and go-libp2p semantics.

### 1. Record validation (issue items 1 & 2)

- New `LibP2P.DHT.Validator` module: `namespacedValidator` dispatches on the `/namespace/` prefix of the record key (mirroring go-libp2p's `record.NamespacedValidator`); keys in an unregistered namespace are rejected.
- Built-in `pkValidator` for `/pk/` records: the value must be a serialized `PublicKey` protobuf whose derived Peer ID equals the multihash in the key path; `Select` keeps the first candidate, as go's `PublicKeyValidator` does.
- `DHTNode` gains a `dhtValidator` field (default: `/pk/` only; injectable for tests/custom namespaces).
- `handlePutValue` now rejects records whose embedded key differs from the message key or that fail validation — rejected records are neither stored nor echoed. Previously any peer could store arbitrary bytes under any key.
- The stored record's `timeReceived` is stamped by the receiver (spec: "set by receiver"), never taken from the sender's claim.
- `iterativeGetValue` also validates retrieved records before `valSelect` conflict resolution, per the spec's two validation occasions.

### 2. Provider TTL (issue item 5)

- `providerRecordTTL = 48h` (spec expiration interval); `getProviders` prunes expired entries on read, so `GET_PROVIDERS` no longer serves records forever.
- `addProvider` dedups by provider peer ID: a republishing provider refreshes its entry instead of appending duplicates.

### 3. Routing-table growth (issue items 4 & 6)

- New `addPeerToTable` acts on the previously ignored `BucketFull` signal: the least-recently-seen peer is probed with a `FIND_NODE` liveness check (our `MessageType` has no PING; go-libp2p likewise treats any successful RPC as liveness proof). Responsive LRS peers are kept and refreshed to most-recently-seen; unresponsive ones are evicted for the newcomer.
- Peers discovered in lookup `closerPeers` and peers that answer our queries are now inserted/refreshed in the routing table each round; inbound RPC senders are inserted too.
- `entryLastSeen` now carries real timestamps instead of the `2000-01-01` placeholder, so LRS ordering is meaningful.

### 4. Client/server mode (issue item 3)

- `registerDHTHandler` is a no-op for `DHTClient` nodes: client-mode nodes no longer offer `/ipfs/kad/1.0.0` for inbound streams while still querying via `dhtSendRequest`.

## Known simplifications

- Inbound RPC senders are inserted into the routing table without confirming the sender operates in server mode — distinguishing client-mode senders would require identify-provided protocol lists, which the DHT node has no handle on. Peers learned from `closerPeers` are server-mode by construction (a server returned them as routing entries).
- Issue #148 also lists smaller items outside these four surfaces that are **not** covered here and may deserve follow-up issues: unknown message types decoding as `PUT_VALUE` (item 7), `GET_VALUE` quorum, bootstrap random-ID-per-bucket refresh, and the hardcoded protocol ID. Item 8 (outbound RPC wiring) was already fixed on main by #194.

## Testing

TDD: failing tests first per surface, then implementation. New coverage:

- `LibP2P.DHT.ValidatorSpec` (11 examples): key splitting, `/pk/` accept/reject, namespace dispatch.
- `DHTSpec`: PUT_VALUE rejection (unknown namespace, wrong peer binding, key mismatch), receiver-set `timeReceived`, provider TTL pruning (store + wire), provider dedup, inbound sender insertion, LRS ping-or-drop both branches, client-mode handler no-op.
- `LookupSpec`: discovered peers enter the routing table; invalid retrieved records are ignored in favour of valid ones.

`cabal build` and `cabal test` (GHC 9.10.3): **937 examples, 0 failures**.

Closes #148