### PR TITLE
fix(gossipsub): negotiate /meshsub/1.0.0, IHAVE/IWANT limits, direct peering (#157 remainder)

### DIFF
--- a/src/LibP2P/Protocol/GossipSub/Handler.hs
+++ b/src/LibP2P/Protocol/GossipSub/Handler.hs
@@ -25,6 +25,7 @@ module LibP2P.Protocol.GossipSub.Handler
   , gossipPublish
     -- * Constants
   , gossipSubProtocolId
+  , gossipSubProtocolIdV10
   ) where
 
 import Control.Concurrent.Async (Async, async, cancel)
@@ -81,9 +82,24 @@ import LibP2P.Switch.Types
   , Switch (..)
   )
 
--- | GossipSub protocol ID.
+-- | GossipSub v1.1 protocol ID (preferred).
 gossipSubProtocolId :: ProtocolId
 gossipSubProtocolId = "/meshsub/1.1.0"
+
+-- | GossipSub v1.0 protocol ID, advertised alongside v1.1 so that
+-- v1.0-only peers still get a pubsub stream (#157).
+gossipSubProtocolIdV10 :: ProtocolId
+gossipSubProtocolIdV10 = "/meshsub/1.0.0"
+
+-- | All protocol IDs we register and offer, preferred first.
+gossipSubProtocolIds :: [ProtocolId]
+gossipSubProtocolIds = [gossipSubProtocolId, gossipSubProtocolIdV10]
+
+-- | Map a negotiated protocol ID to the peer's protocol version.
+protocolFor :: ProtocolId -> PeerProtocol
+protocolFor proto
+  | proto == gossipSubProtocolIdV10 = GossipSubV10Peer
+  | otherwise                       = GossipSubPeer
 
 -- | A GossipSub node: Router + Switch integration.
 data GossipSubNode = GossipSubNode
@@ -149,15 +165,16 @@ openStreamToPeer sw pid = do
                   (\(_ :: SomeException) -> pure (Left ()))
       case result of
         Left () -> pure Nothing
-        Right mStream -> pure mStream
+        Right mStream -> pure (fst <$> mStream)
 
--- | Open a mux stream and negotiate /meshsub/1.1.0.
-openAndNegotiate :: Connection -> IO (Maybe StreamIO)
+-- | Open a mux stream and negotiate a GossipSub protocol, preferring
+-- /meshsub/1.1.0 and falling back to /meshsub/1.0.0 (#157).
+openAndNegotiate :: Connection -> IO (Maybe (StreamIO, PeerProtocol))
 openAndNegotiate conn = do
   stream <- muxOpenStream (connSession conn)
-  negResult <- negotiateInitiator stream [gossipSubProtocolId]
+  negResult <- negotiateInitiator stream gossipSubProtocolIds
   case negResult of
-    Accepted _ -> pure (Just stream)
+    Accepted proto -> pure (Just (stream, protocolFor proto))
     NoProtocol -> pure Nothing
 
 -- | Extract the remote IP bytes (4 for IPv4, 16 for IPv6) from a
@@ -179,12 +196,14 @@ trySend stream rpc =
 -- | Handle an inbound GossipSub stream.
 --
 -- Reads framed RPCs in a loop and dispatches each to the Router's handleRPC.
+-- The peer's negotiated protocol version gates v1.1 control extensions.
 -- On error or EOF, cleans up the peer's cached stream and removes the peer.
-handleGossipSubStream :: GossipSubNode -> StreamIO -> PeerId -> Maybe ByteString -> IO ()
-handleGossipSubStream node stream pid mIP = do
+handleGossipSubStream :: GossipSubNode -> StreamIO -> PeerId -> PeerProtocol
+                      -> Maybe ByteString -> IO ()
+handleGossipSubStream node stream pid proto mIP = do
   -- Register peer with router (IP feeds P6 colocation scoring)
   now <- getCurrentTime
-  addPeer (gsnRouter node) pid GossipSubPeer False now
+  addPeer (gsnRouter node) pid proto False now
   mapM_ (setPeerIP (gsnRouter node) pid) mIP
   -- Read loop
   readLoop
@@ -203,10 +222,13 @@ handleGossipSubStream node stream pid mIP = do
 -- | Start the GossipSub node: register stream handler, notifier, and start heartbeat.
 startGossipSub :: GossipSubNode -> IO ()
 startGossipSub node = do
-  -- Register inbound stream handler on Switch
-  setStreamHandler (gsnSwitch node) gossipSubProtocolId
-    (\conn stream ->
-      handleGossipSubStream node stream (connPeerId conn) (remoteIPBytes conn))
+  -- Register inbound stream handlers for both protocol versions (#157)
+  mapM_ (\protoId ->
+      setStreamHandler (gsnSwitch node) protoId
+        (\conn stream ->
+          handleGossipSubStream node stream (connPeerId conn)
+            (protocolFor protoId) (remoteIPBytes conn)))
+    gossipSubProtocolIds
   -- Register connection notifier to auto-open GossipSub streams to new peers
   atomically $ modifyTVar' (swNotifiers (gsnSwitch node))
     (onNewConnection node :)
@@ -224,12 +246,13 @@ onNewConnection node conn = do
   mStream <- openAndNegotiate conn
   case mStream of
     Nothing -> pure ()  -- Peer doesn't support GossipSub
-    Just stream -> do
+    Just (stream, proto) -> do
       -- Cache the outbound stream
       atomically $ modifyTVar' (gsnStreams node) (Map.insert pid stream)
-      -- Register peer (IP feeds P6 colocation scoring)
+      -- Register peer with its negotiated protocol version
+      -- (IP feeds P6 colocation scoring)
       now <- getCurrentTime
-      addPeer (gsnRouter node) pid GossipSubPeer True now
+      addPeer (gsnRouter node) pid proto True now
       mapM_ (setPeerIP (gsnRouter node) pid) (remoteIPBytes conn)
       -- Send current subscriptions to the new peer
       sendCurrentSubscriptions node stream
@@ -283,8 +306,8 @@ stopGossipSub node = do
   case mHb of
     Just hbAsync -> cancel hbAsync `catch` (\(_ :: SomeException) -> pure ())
     Nothing -> pure ()
-  -- Unregister stream handler
-  removeStreamHandler (gsnSwitch node) gossipSubProtocolId
+  -- Unregister stream handlers for both protocol versions
+  mapM_ (removeStreamHandler (gsnSwitch node)) gossipSubProtocolIds
 
 -- | Subscribe to a topic.
 gossipJoin :: GossipSubNode -> Topic -> IO ()

--- a/src/LibP2P/Protocol/GossipSub/Heartbeat.hs
+++ b/src/LibP2P/Protocol/GossipSub/Heartbeat.hs
@@ -26,7 +26,7 @@ import List.Shuffle (sampleIO)
 import LibP2P.Crypto.PeerId (PeerId)
 import LibP2P.Protocol.GossipSub.Types
 import LibP2P.Protocol.GossipSub.MessageCache (cacheGetGossipIds, cacheShift)
-import LibP2P.Protocol.GossipSub.Router (selectPXPeers)
+import LibP2P.Protocol.GossipSub.Router (buildPrune)
 import LibP2P.Protocol.GossipSub.Score
   ( computeScore
   , decayPeerCounters
@@ -45,6 +45,7 @@ heartbeatOnce router = do
   expireIWantPromises router
   decayAllScores router
   cleanSeenCache router
+  resetGossipBudgets router
   -- Increment heartbeat counter
   atomically $ modifyTVar' (gsHeartbeatCount router) (+ 1)
 
@@ -78,13 +79,17 @@ meshMaintenance router = do
     -- Step 3: Trim if oversubscribed (> D_hi)
     trimOversubscribed router topic filled
 
--- | Remove peers with negative score from mesh, send PRUNE.
+-- | Remove peers with negative score from mesh, send PRUNE. Direct
+-- peers are exempt: explicit peering agreements are never scored out
+-- (gossipsub-v1.1.md; they should never be mesh members to begin with).
 pruneNegativeScore :: GossipSubRouter -> Topic -> Set.Set PeerId -> UTCTime -> IO (Set.Set PeerId)
 pruneNegativeScore router topic meshPeers now = do
   let scoreParams = gsScoreParams router
+      direct = paramDirectPeers (gsParams router)
   ipMap <- readTVarIO (gsIPPeerCount router)
   peers <- readTVarIO (gsPeers router)
   let negatives = Set.filter (\pid ->
+        not (Set.member pid direct) &&
         case Map.lookup pid peers of
           Nothing -> False
           Just ps -> computeScore scoreParams pid ps ipMap now < 0
@@ -92,10 +97,9 @@ pruneNegativeScore router topic meshPeers now = do
   -- Send PRUNE to negative-score peers (no PX for negative-score peers)
   forM_ (Set.toList negatives) $ \pid -> do
     let backoffSecs = round (paramPruneBackoff (gsParams router)) :: Word64
+    prn <- buildPrune router pid topic False backoffSecs
     gsSendRPC router pid emptyRPC
-      { rpcControl = Just emptyControlMessage
-          { ctrlPrune = [Prune topic [] (Just backoffSecs)] }
-      }
+      { rpcControl = Just emptyControlMessage { ctrlPrune = [prn] } }
     -- Start backoff and stop the P1 mesh clock
     atomically $ do
       modifyTVar' (gsBackoff router) $
@@ -121,9 +125,11 @@ fillUndersubscribed router topic meshPeers now = do
       peersMap <- readTVarIO (gsPeers router)
       backoffMap <- readTVarIO (gsBackoff router)
       ipMap <- readTVarIO (gsIPPeerCount router)
-      let eligible = [ pid | (pid, ps) <- Map.toList peersMap
+      let direct = paramDirectPeers params
+          eligible = [ pid | (pid, ps) <- Map.toList peersMap
                            , Set.member topic (psTopics ps)
                            , not (Set.member pid meshPeers)
+                           , not (Set.member pid direct)  -- never graft direct peers
                            , not (isInBackoff backoffMap pid topic now)
                            , computeScore (gsScoreParams router) pid ps ipMap now >= 0
                            ]
@@ -181,11 +187,9 @@ trimOversubscribed router topic meshPeers = do
     -- Send PRUNE with peer exchange to removed peers
     forM_ (Set.toList toRemove) $ \pid -> do
       let backoffSecs = round (paramPruneBackoff params) :: Word64
-      px <- selectPXPeers router topic pid
+      prn <- buildPrune router pid topic True backoffSecs
       gsSendRPC router pid emptyRPC
-        { rpcControl = Just emptyControlMessage
-            { ctrlPrune = [Prune topic px (Just backoffSecs)] }
-        }
+        { rpcControl = Just emptyControlMessage { ctrlPrune = [prn] } }
       atomically $ do
         modifyTVar' (gsBackoff router) $
           Map.insert (pid, topic) (addUTCTime (paramPruneBackoff params) now)
@@ -215,9 +219,11 @@ fanoutMaintenance router = do
         let d = paramD (gsParams router)
         when (Set.size fanoutPeers < d) $ do
           peersMap <- readTVarIO (gsPeers router)
-          let eligible = [ pid | (pid, ps) <- Map.toList peersMap
+          let direct = paramDirectPeers (gsParams router)
+              eligible = [ pid | (pid, ps) <- Map.toList peersMap
                                , Set.member topic (psTopics ps)
                                , not (Set.member pid fanoutPeers)
+                               , not (Set.member pid direct)
                                ]
           let needed = d - Set.size fanoutPeers
           selected <- sampleIO (min needed (length eligible)) eligible
@@ -243,9 +249,10 @@ emitGossip router = do
       topics = Set.unions
         [ subs, Map.keysSet meshMap, Map.keysSet fanoutMap ]
 
-  -- For each topic in mesh+fanout, send IHAVE to non-mesh peers
+  -- For each topic in mesh+fanout, send IHAVE to non-mesh peers.
+  -- The advertised id list is capped at paramMaxIHaveLength (#157).
   forM_ (Set.toList topics) $ \topic -> do
-    let gossipIds = cacheGetGossipIds topic cache
+    let gossipIds = take (paramMaxIHaveLength params) (cacheGetGossipIds topic cache)
     unless (null gossipIds) $ do
       let meshPeers = Map.findWithDefault Set.empty topic meshMap
           -- Eligible: subscribed to topic, not in mesh, and scoring at or
@@ -287,6 +294,16 @@ expireIWantPromises router = do
     pure (map fst (Map.keys expired))
   atomically $ modifyTVar' (gsPeers router) $ \pm ->
     foldl' (\m pid -> Map.adjust addP7Penalty pid m) pm broken
+
+-- IHAVE/IWANT budget reset
+
+-- | Reset the per-peer IHAVE/IWANT flood-protection budgets; the caps in
+-- Router.handleIHave / Router.handleIWant apply per heartbeat (#157).
+resetGossipBudgets :: GossipSubRouter -> IO ()
+resetGossipBudgets router = atomically $ do
+  writeTVar (gsIHaveCounts router) Map.empty
+  writeTVar (gsIAskedCounts router) Map.empty
+  writeTVar (gsIWantServed router) Map.empty
 
 -- Score decay
 

--- a/src/LibP2P/Protocol/GossipSub/Router.hs
+++ b/src/LibP2P/Protocol/GossipSub/Router.hs
@@ -32,6 +32,8 @@ module LibP2P.Protocol.GossipSub.Router
   , peerScore
     -- * Peer exchange
   , selectPXPeers
+    -- * Version-gated PRUNE construction
+  , buildPrune
   ) where
 
 import Prelude
@@ -82,6 +84,9 @@ newRouter params localPid sendRPC getTime = do
   onMsg    <- newTVarIO (\_ _ -> pure ())
   validators <- newTVarIO Map.empty
   promises <- newTVarIO Map.empty
+  ihaveCounts <- newTVarIO Map.empty
+  iaskedCounts <- newTVarIO Map.empty
+  iwantServed <- newTVarIO Map.empty
   onPX     <- newTVarIO (\_ _ -> pure ())
   pure GossipSubRouter
     { gsParams         = params
@@ -97,6 +102,9 @@ newRouter params localPid sendRPC getTime = do
     , gsThresholds     = defaultScoreThresholds
     , gsIPPeerCount    = ipCount
     , gsIWantPromises  = promises
+    , gsIHaveCounts    = ihaveCounts
+    , gsIAskedCounts   = iaskedCounts
+    , gsIWantServed    = iwantServed
     , gsMessageCache   = mcache
     , gsHeartbeatCount = hbCount
     , gsSendRPC        = sendRPC
@@ -178,6 +186,45 @@ removeIPMember ip pid = Map.update
   (\s -> let s' = Set.delete pid s
          in if Set.null s' then Nothing else Just s') ip
 
+-- Direct peers (gossipsub-v1.1.md explicit peering agreements)
+
+-- | True when the peer is a configured direct peer.
+isDirectPeer :: GossipSubRouter -> PeerId -> Bool
+isDirectPeer router pid = Set.member pid (paramDirectPeers (gsParams router))
+
+-- | Known direct peers subscribed to the topic. They always receive
+-- published and forwarded messages although they are never in the mesh.
+directTopicPeers :: GossipSubRouter -> Map.Map PeerId PeerState -> Topic
+                 -> Set.Set PeerId
+directTopicPeers router peers topic =
+  Set.filter (\pid -> case Map.lookup pid peers of
+    Just ps -> Set.member topic (psTopics ps)
+    Nothing -> False) (paramDirectPeers (gsParams router))
+
+-- Protocol version gating
+
+-- | True when the peer negotiated /meshsub/1.1.0. Unknown peers are
+-- treated as v1.1 (the preferred protocol).
+peerSupportsV11 :: Map.Map PeerId PeerState -> PeerId -> Bool
+peerSupportsV11 peers pid = case Map.lookup pid peers of
+  Just ps -> psProtocol ps == GossipSubPeer
+  Nothing -> True
+
+-- | Build a PRUNE for a peer, gated on its negotiated protocol version:
+-- /meshsub/1.0.0 peers receive a bare PRUNE — PX records and the backoff
+-- field are v1.1 control extensions (#157).
+buildPrune :: GossipSubRouter -> PeerId -> Topic
+           -> Bool     -- ^ Include PX records (only for v1.1 peers in good standing)
+           -> Word64   -- ^ Backoff seconds (only encoded for v1.1 peers)
+           -> IO Prune
+buildPrune router pid topic withPX backoffSecs = do
+  peers <- readTVarIO (gsPeers router)
+  if peerSupportsV11 peers pid
+    then do
+      px <- if withPX then selectPXPeers router topic pid else pure []
+      pure (Prune topic px (Just backoffSecs))
+    else pure (Prune topic [] Nothing)
+
 -- Topic subscription
 
 -- | Subscribe to a topic (JOIN): announce, fanout→mesh transition, fill to D, GRAFT.
@@ -208,10 +255,13 @@ join router topic = do
     meshNow <- readTVar (gsMesh router)
     let currentMesh = Map.findWithDefault Set.empty topic meshNow
     peerMap <- readTVar (gsPeers router)
+    -- Direct peers are never mesh candidates (gossipsub-v1.1.md
+    -- explicit peering agreements)
     let eligible = Map.foldlWithKey' (\acc pid ps ->
           if Set.member topic (psTopics ps)
              && not (Set.member pid currentMesh)
              && pid /= gsLocalPeerId router
+             && not (isDirectPeer router pid)
           then Set.insert pid acc
           else acc) Set.empty peerMap
     pure (foPeers, eligible)
@@ -265,8 +315,8 @@ leave router topic = do
   mapM_ (\pid -> do
           atomically $ modifyTVar' (gsPeers router) $
             Map.adjust (unmarkPeerInMesh topic) pid
-          px <- selectPXPeers router topic pid
-          gsSendRPC router pid (pruneRPC topic px (Just backoffSecs)))
+          prn <- buildPrune router pid topic True backoffSecs
+          gsSendRPC router pid (pruneRPC prn))
     (Set.toList meshPeers)
 
 -- Publishing
@@ -300,34 +350,41 @@ publish router topic payload mKeyPair = do
   if paramFloodPublish (gsParams router)
     then do
       -- Flood publish: send to all topic peers scoring at or above the
-      -- publish threshold (gossipsub-v1.1.md flood publishing)
+      -- publish threshold (gossipsub-v1.1.md flood publishing). Direct
+      -- peers always receive our messages regardless of score.
       peers <- readTVarIO (gsPeers router)
       ipMap <- readTVarIO (gsIPPeerCount router)
       let threshold = stPublishThreshold (gsThresholds router)
           targets = Map.foldlWithKey' (\acc pid ps ->
             if Set.member topic (psTopics ps)
                && pid /= gsLocalPeerId router
-               && computeScore (gsScoreParams router) pid ps ipMap now >= threshold
+               && (isDirectPeer router pid
+                   || computeScore (gsScoreParams router) pid ps ipMap now >= threshold)
             then pid : acc
             else acc) [] peers
       mapM_ (\pid -> gsSendRPC router pid pubRPC) targets
     else do
-      -- Mesh-based publish
+      -- Mesh-based publish; subscribed direct peers are always included
+      -- although they are never mesh or fanout members
+      peers <- readTVarIO (gsPeers router)
+      let direct = directTopicPeers router peers topic
       meshPeers <- atomically $ do
         m <- readTVar (gsMesh router)
         pure (Map.findWithDefault Set.empty topic m)
       if not (Set.null meshPeers)
-        then mapM_ (\pid -> gsSendRPC router pid pubRPC) (Set.toList meshPeers)
+        then mapM_ (\pid -> gsSendRPC router pid pubRPC)
+               (Set.toList (Set.union meshPeers direct))
         else do
-          -- Fanout: use existing or create new
+          -- Fanout: use existing or create new (direct peers excluded)
           foPeers <- atomically $ do
             fo <- readTVar (gsFanout router)
             pure (Map.findWithDefault Set.empty topic fo)
           targets <- if Set.null foPeers
             then do
-              peers <- readTVarIO (gsPeers router)
               let eligible = Map.foldlWithKey' (\acc pid ps ->
-                    if Set.member topic (psTopics ps) && pid /= gsLocalPeerId router
+                    if Set.member topic (psTopics ps)
+                       && pid /= gsLocalPeerId router
+                       && not (isDirectPeer router pid)
                     then pid : acc
                     else acc) [] peers
               selected <- sampleIO (min (paramD (gsParams router)) (length eligible)) eligible
@@ -339,7 +396,8 @@ publish router topic payload mKeyPair = do
             else do
               atomically $ modifyTVar' (gsFanoutPub router) (Map.insert topic now)
               pure foPeers
-          mapM_ (\pid -> gsSendRPC router pid pubRPC) (Set.toList targets)
+          mapM_ (\pid -> gsSendRPC router pid pubRPC)
+            (Set.toList (Set.union targets direct))
 
   -- Deliver to local application
   onMsg <- readTVarIO (gsOnMessage router)
@@ -350,11 +408,13 @@ publish router topic payload mKeyPair = do
 -- | Handle an inbound RPC from a peer.
 --
 -- Graylisted peers (score below 'stGraylistThreshold') have their RPCs
--- ignored entirely (gossipsub-v1.1.md graylist).
+-- ignored entirely (gossipsub-v1.1.md graylist). Direct peers are exempt:
+-- explicit peering agreements exchange messages unconditionally.
 handleRPC :: GossipSubRouter -> PeerId -> RPC -> IO ()
 handleRPC router sender rpc = do
   score <- peerScore router sender
   if score < stGraylistThreshold (gsThresholds router)
+       && not (isDirectPeer router sender)
     then pure ()
     else handleRPC' router sender rpc
 
@@ -507,6 +567,13 @@ handleOneGraft router sender now (Graft topic) = do
       -- topics are ignored — replying with PRUNE (the v1.0 behaviour)
       -- lets an attacker elicit traffic with spam GRAFTs (#157).
       pure []
+    else if isDirectPeer router sender
+      then do
+        -- gossipsub-v1.1.md explicit peering: direct peers must never be
+        -- mesh members — answer with PRUNE and do not graft
+        prn <- buildPrune router sender topic False
+          (round (paramPruneBackoff (gsParams router)))
+        pure [prn]
     else do
       -- Check backoff
       backoffMap <- readTVarIO (gsBackoff router)
@@ -523,7 +590,8 @@ handleOneGraft router sender now (Graft topic) = do
             atomically $ modifyTVar' (gsBackoff router) $
               Map.insert (sender, topic)
                 (addUTCTime (paramPruneBackoff (gsParams router)) now)
-            pure [Prune topic [] (Just backoffSecs)]
+            prn <- buildPrune router sender topic False backoffSecs
+            pure [prn]
 
       if inBackoff
         then do
@@ -590,24 +658,46 @@ handleOnePrune router sender now prune = do
 -- (gossipsub-v1.1.md gossip threshold). One advertised-and-requested
 -- message ID is tracked as an IWANT promise: if the peer never delivers
 -- it before the follow-up deadline, it is a P7 behavioural violation.
+--
+-- IHAVE flood protection (#157): at most 'paramMaxIHaveMessages' IHAVE
+-- batches are accepted per peer per heartbeat, and at most
+-- 'paramMaxIHaveLength' message ids are requested from a peer per
+-- heartbeat (go-libp2p defaults 10 and 5000).
 handleIHave :: GossipSubRouter -> PeerId -> [IHave] -> IO ()
 handleIHave router sender ihaves = do
   score <- peerScore router sender
   unless (score < stGossipThreshold (gsThresholds router) || null ihaves) $ do
-    seenMap <- readTVarIO (gsSeen router)
-    let unseen = concatMap (\(IHave _ mids) ->
-          filter (\mid -> not (Map.member mid seenMap)) mids) ihaves
-    unless (null unseen) $ do
-      now <- gsGetTime router
-      promised <- sampleIO 1 unseen
-      let deadline = addUTCTime (paramIWantFollowupTime (gsParams router)) now
-      atomically $ modifyTVar' (gsIWantPromises router) $ \m ->
-        foldr (\mid -> Map.insert (sender, mid) deadline) m promised
-      gsSendRPC router sender emptyRPC
-        { rpcControl = Just emptyControlMessage { ctrlIWant = [IWant unseen] } }
+    let params = gsParams router
+    withinBudget <- atomically $ do
+      counts <- readTVar (gsIHaveCounts router)
+      let n = Map.findWithDefault 0 sender counts + 1
+      writeTVar (gsIHaveCounts router) (Map.insert sender n counts)
+      pure (n <= paramMaxIHaveMessages params)
+    when withinBudget $ do
+      seenMap <- readTVarIO (gsSeen router)
+      let unseen = concatMap (\(IHave _ mids) ->
+            filter (\mid -> not (Map.member mid seenMap)) mids) ihaves
+      toAsk <- atomically $ do
+        asked <- readTVar (gsIAskedCounts router)
+        let a = Map.findWithDefault 0 sender asked
+            budget = max 0 (paramMaxIHaveLength params - a)
+            capped = take budget unseen
+        writeTVar (gsIAskedCounts router)
+          (Map.insert sender (a + length capped) asked)
+        pure capped
+      unless (null toAsk) $ do
+        now <- gsGetTime router
+        promised <- sampleIO 1 toAsk
+        let deadline = addUTCTime (paramIWantFollowupTime params) now
+        atomically $ modifyTVar' (gsIWantPromises router) $ \m ->
+          foldr (\mid -> Map.insert (sender, mid) deadline) m promised
+        gsSendRPC router sender emptyRPC
+          { rpcControl = Just emptyControlMessage { ctrlIWant = [IWant toAsk] } }
 
 -- | Handle IWANT: respond with cached messages from the message cache.
--- Requests from peers below the gossip threshold are ignored.
+-- Requests from peers below the gossip threshold are ignored, and at
+-- most 'paramMaxIHaveLength' messages are served per peer per heartbeat
+-- (IWANT flood protection, #157).
 handleIWant :: GossipSubRouter -> PeerId -> [IWant] -> IO ()
 handleIWant router sender iwants = do
   score <- peerScore router sender
@@ -616,8 +706,16 @@ handleIWant router sender iwants = do
     let requestedIds = concatMap iwantMessageIds iwants
         found = [ msg | mid <- requestedIds
                        , Just msg <- [cacheGet mid cache] ]
-    unless (null found) $
-      gsSendRPC router sender emptyRPC { rpcPublish = found }
+    toServe <- atomically $ do
+      served <- readTVar (gsIWantServed router)
+      let s = Map.findWithDefault 0 sender served
+          budget = max 0 (paramMaxIHaveLength (gsParams router) - s)
+          capped = take budget found
+      writeTVar (gsIWantServed router)
+        (Map.insert sender (s + length capped) served)
+      pure capped
+    unless (null toServe) $
+      gsSendRPC router sender emptyRPC { rpcPublish = toServe }
 
 -- | Handle subscription changes from a peer.
 handleSubscriptions :: GossipSubRouter -> PeerId -> [SubOpts] -> IO ()
@@ -636,13 +734,17 @@ handleSubscriptions router sender subs = atomically $
 -- Message forwarding
 
 -- | Forward a message to mesh peers for its topic, excluding the sender.
+-- Subscribed direct peers always receive the message even though they
+-- are never mesh members (gossipsub-v1.1.md explicit peering).
 forwardMessage :: GossipSubRouter -> PeerId -> PubSubMessage -> IO ()
 forwardMessage router sender msg = do
   let topic = msgTopic msg
   meshPeers <- atomically $ do
     m <- readTVar (gsMesh router)
     pure (Map.findWithDefault Set.empty topic m)
-  let targets = Set.delete sender meshPeers
+  peers <- readTVarIO (gsPeers router)
+  let direct = directTopicPeers router peers topic
+      targets = Set.delete sender (Set.union meshPeers direct)
       fwdRPC = emptyRPC { rpcPublish = [msg] }
   mapM_ (\pid -> gsSendRPC router pid fwdRPC) (Set.toList targets)
 
@@ -683,10 +785,10 @@ graftRPC :: Topic -> RPC
 graftRPC topic = emptyRPC
   { rpcControl = Just emptyControlMessage { ctrlGraft = [Graft topic] } }
 
--- Helper: construct a PRUNE RPC
-pruneRPC :: Topic -> [PeerExchangeInfo] -> Maybe Word64 -> RPC
-pruneRPC topic peers backoff = emptyRPC
-  { rpcControl = Just emptyControlMessage { ctrlPrune = [Prune topic peers backoff] } }
+-- Helper: wrap a PRUNE in an RPC
+pruneRPC :: Prune -> RPC
+pruneRPC prn = emptyRPC
+  { rpcControl = Just emptyControlMessage { ctrlPrune = [prn] } }
 
 -- Helpers: message construction
 

--- a/src/LibP2P/Protocol/GossipSub/Types.hs
+++ b/src/LibP2P/Protocol/GossipSub/Types.hs
@@ -10,6 +10,7 @@
 module LibP2P.Protocol.GossipSub.Types
   ( -- * Protocol constants
     gossipSubProtocolId
+  , gossipSubProtocolIdV10
   , maxRPCSize
     -- * Topic and message identity
   , Topic
@@ -64,6 +65,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import Data.Set (Set)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import Data.Time (NominalDiffTime, UTCTime)
 import Data.Word (Word64)
@@ -72,6 +74,12 @@ import LibP2P.Crypto.PeerId (PeerId)
 -- | GossipSub v1.1 protocol identifier.
 gossipSubProtocolId :: Text
 gossipSubProtocolId = "/meshsub/1.1.0"
+
+-- | GossipSub v1.0 protocol identifier. Advertised alongside v1.1 for
+-- backwards compatibility (gossipsub-v1.1.md: the v1.1 extensions are
+-- fully backwards compatible with v1.0 of the protocol).
+gossipSubProtocolIdV10 :: Text
+gossipSubProtocolIdV10 = "/meshsub/1.0.0"
 
 -- | Maximum RPC message size: 1 MiB.
 maxRPCSize :: Int
@@ -196,6 +204,14 @@ data GossipSubParams = GossipSubParams
   , paramMcacheGossip       :: !Int              -- ^ Gossip windows (default 3)
   , paramPrunePeers         :: !Int              -- ^ PX peers included in PRUNE (default 16)
   , paramIWantFollowupTime  :: !NominalDiffTime  -- ^ IWANT promise deadline (default 3s)
+  , paramMaxIHaveLength     :: !Int
+    -- ^ Max message ids requested from / served to a peer per heartbeat,
+    -- and max ids advertised in an emitted IHAVE (go default 5000)
+  , paramMaxIHaveMessages   :: !Int
+    -- ^ Max IHAVE batches accepted from a peer per heartbeat (go default 10)
+  , paramDirectPeers        :: !(Set PeerId)
+    -- ^ Direct (explicit) peering agreements (gossipsub-v1.1.md): these
+    -- peers always exchange messages and are never mesh members
   }
 
 -- | Default message ID: concatenation of from and seqno fields.
@@ -227,14 +243,20 @@ defaultGossipSubParams = GossipSubParams
   , paramMcacheGossip      = 3
   , paramPrunePeers        = 16
   , paramIWantFollowupTime = 3
+  , paramMaxIHaveLength    = 5000
+  , paramMaxIHaveMessages  = 10
+  , paramDirectPeers       = Set.empty
   }
 
 -- Peer tracking
 
--- | Peer's protocol capability.
+-- | Peer's negotiated protocol capability. Peers on /meshsub/1.0.0 must
+-- not receive v1.1 control extensions (PX records or the backoff field
+-- in PRUNE).
 data PeerProtocol
-  = GossipSubPeer   -- ^ Supports GossipSub (/meshsub/1.1.0)
-  | FloodSubPeer    -- ^ Supports FloodSub only
+  = GossipSubPeer     -- ^ GossipSub v1.1 (/meshsub/1.1.0)
+  | GossipSubV10Peer  -- ^ GossipSub v1.0 (/meshsub/1.0.0)
+  | FloodSubPeer      -- ^ FloodSub only (/floodsub/1.0.0, not yet negotiated)
   deriving (Show, Eq)
 
 -- | Per-peer state tracked by the router.
@@ -418,6 +440,16 @@ data GossipSubRouter = GossipSubRouter
     -- ^ IWANT promises: message IDs a peer advertised via IHAVE and we
     -- requested, with the delivery deadline. A promise still unfulfilled
     -- past its deadline is a P7 behavioural violation (gossipsub-v1.1.md).
+  , gsIHaveCounts :: !(TVar (Map PeerId Int))
+    -- ^ IHAVE batches accepted per peer since the last heartbeat; batches
+    -- beyond 'paramMaxIHaveMessages' are ignored (gossipsub-v1.1.md
+    -- IHAVE/IWANT flood protection)
+  , gsIAskedCounts :: !(TVar (Map PeerId Int))
+    -- ^ Message ids requested via IWANT per peer since the last
+    -- heartbeat, capped at 'paramMaxIHaveLength'
+  , gsIWantServed :: !(TVar (Map PeerId Int))
+    -- ^ Messages served in response to IWANT per peer since the last
+    -- heartbeat, capped at 'paramMaxIHaveLength'
     -- Message cache (Phase 9c)
   , gsMessageCache  :: !(TVar MessageCache)
     -- ^ Sliding-window message cache for IWANT and IHAVE

--- a/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
@@ -32,6 +32,7 @@ import LibP2P.Protocol.GossipSub.Handler
   , gossipLeave
   , gossipPublish
   , gossipSubProtocolId
+  , gossipSubProtocolIdV10
   , handleGossipSubStream
   , newGossipSubNode
   , sendCurrentSubscriptions
@@ -138,7 +139,7 @@ spec = do
       -- Create memory stream pair: remote side writes, handler reads
       (remoteStream, handlerStream) <- mkMemoryStreamPair
       -- Spawn handler in background (blocks on read loop)
-      _ <- async $ handleGossipSubStream node handlerStream remotePid Nothing
+      _ <- async $ handleGossipSubStream node handlerStream remotePid GossipSubPeer Nothing
       -- Send a subscription RPC from remote
       writeRPCMessage remoteStream (subscribeRPC "test-topic")
       -- Give handler time to process
@@ -162,7 +163,7 @@ spec = do
       addPeer (gsnRouter node) remotePid GossipSubPeer False now
       (remoteStream, handlerStream) <- mkMemoryStreamPair
       -- Spawn handler
-      _ <- async $ handleGossipSubStream node handlerStream remotePid Nothing
+      _ <- async $ handleGossipSubStream node handlerStream remotePid GossipSubPeer Nothing
       -- Send a publish RPC
       let msg = signedMessage remoteKp "pub-topic" "hello gossipsub"
       writeRPCMessage remoteStream (emptyRPC { rpcPublish = [msg] })
@@ -263,6 +264,24 @@ spec = do
       -- Cleanup
       stopGossipSub node
 
+    -- Issue #157: peers speaking only /meshsub/1.0.0 must still get a
+    -- pubsub stream — both protocol versions are registered and accepted.
+    it "registers handlers for both /meshsub/1.1.0 and /meshsub/1.0.0" $ do
+      (sw, _pid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      startGossipSub node
+      h11 <- lookupStreamHandler sw gossipSubProtocolId
+      h10 <- lookupStreamHandler sw gossipSubProtocolIdV10
+      case (h11, h10) of
+        (Just _, Just _) -> pure ()
+        _ -> expectationFailure "both protocol versions should be registered"
+      stopGossipSub node
+      h11' <- lookupStreamHandler sw gossipSubProtocolId
+      h10' <- lookupStreamHandler sw gossipSubProtocolIdV10
+      case (h11', h10') of
+        (Nothing, Nothing) -> pure ()
+        _ -> expectationFailure "both protocol versions should be unregistered after stop"
+
   describe "stopGossipSub" $ do
     it "cancels heartbeat and unregisters handler" $ do
       (sw, _pid) <- mkTestSwitch
@@ -297,8 +316,8 @@ spec = do
       (streamAtoB, streamBfromA) <- mkMemoryStreamPair
       (streamBtoA, streamAfromB) <- mkMemoryStreamPair
       -- Spawn stream handlers
-      _ <- async $ handleGossipSubStream nodeB streamBfromA pidA Nothing
-      _ <- async $ handleGossipSubStream nodeA streamAfromB pidB Nothing
+      _ <- async $ handleGossipSubStream nodeB streamBfromA pidA GossipSubPeer Nothing
+      _ <- async $ handleGossipSubStream nodeA streamAfromB pidB GossipSubPeer Nothing
       -- Inject cached outbound streams for sendRPC
       atomically $ do
         writeTVar (gsnStreams nodeA) (Map.singleton pidB streamAtoB)
@@ -328,8 +347,8 @@ spec = do
       (streamAtoB, streamBfromA) <- mkMemoryStreamPair
       (streamBtoA, streamAfromB) <- mkMemoryStreamPair
       -- Spawn stream handlers (registers peers in each router)
-      _ <- async $ handleGossipSubStream nodeB streamBfromA pidA Nothing
-      _ <- async $ handleGossipSubStream nodeA streamAfromB pidB Nothing
+      _ <- async $ handleGossipSubStream nodeB streamBfromA pidA GossipSubPeer Nothing
+      _ <- async $ handleGossipSubStream nodeA streamAfromB pidB GossipSubPeer Nothing
       -- Inject cached outbound streams
       atomically $ do
         writeTVar (gsnStreams nodeA) (Map.singleton pidB streamAtoB)

--- a/test/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
@@ -467,3 +467,71 @@ spec = do
         Set.size kept `shouldBe` 6
         Set.member (mkPeerId 1) kept `shouldBe` True
         Set.member (mkPeerId 2) kept `shouldBe` True
+
+    -- Issue #157 remainder: direct peering, version-gated PRUNE, IHAVE cap
+    describe "Direct peers (#157)" $ do
+      it "mesh fill never GRAFTs a direct peer" $ do
+        let dp = mkPeerId 9
+        (logRef, sendFn) <- newSendLog
+        timeRef <- newIORef fixedTime
+        router <- newRouter
+          defaultGossipSubParams { paramDirectPeers = Set.singleton dp }
+          localPid sendFn (readIORef timeRef)
+        addSubscribedPeer router dp "t" fixedTime
+        addSubscribedPeer router (mkPeerId 1) "t" fixedTime
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "t")
+        heartbeatOnce router
+        mesh <- readTVarIO (gsMesh router)
+        Set.member dp (Map.findWithDefault Set.empty "t" mesh) `shouldBe` False
+        Set.member (mkPeerId 1) (Map.findWithDefault Set.empty "t" mesh) `shouldBe` True
+        sent <- readIORef logRef
+        let graftTo = [ pid | (pid, rpc) <- sent
+                            , Just ctrl <- [rpcControl rpc]
+                            , not (null (ctrlGraft ctrl)) ]
+        graftTo `shouldBe` [mkPeerId 1]
+
+    describe "Protocol version gating (#157)" $ do
+      it "negative-score PRUNE to a /meshsub/1.0.0 peer omits the backoff field" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        let pid = mkPeerId 1
+            routerNeg = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const (-1) } }
+        addPeer routerNeg pid GossipSubV10Peer False fixedTime
+        atomically $ do
+          modifyTVar' (gsPeers routerNeg) $
+            Map.adjust (\ps -> ps { psTopics = Set.singleton "t" }) pid
+          modifyTVar' (gsMesh routerNeg) $ Map.insert "t" (Set.singleton pid)
+        heartbeatOnce routerNeg
+        sent <- readIORef logRef
+        let prunes = [ p | (to, rpc) <- sent, to == pid
+                         , Just ctrl <- [rpcControl rpc], p <- ctrlPrune ctrl ]
+        case prunes of
+          [p] -> do
+            prunePeers p `shouldBe` []
+            pruneBackoff p `shouldBe` Nothing
+          _ -> expectationFailure "expected exactly one PRUNE"
+
+    describe "IHAVE limits (#157)" $ do
+      it "caps gossip IHAVE ids at paramMaxIHaveLength" $ do
+        (logRef, sendFn) <- newSendLog
+        timeRef <- newIORef fixedTime
+        router <- newRouter
+          defaultGossipSubParams { paramMaxIHaveLength = 2 }
+          localPid sendFn (readIORef timeRef)
+        -- Topic lives in fanout so mesh maintenance does not graft the
+        -- gossip target into the mesh before gossip emission runs.
+        addSubscribedPeer router (mkPeerId 1) "t" fixedTime
+        let mkMsg n = PubSubMessage
+              { msgFrom = Nothing, msgData = BS.pack [n], msgSeqNo = Nothing
+              , msgTopic = "t", msgSignature = Nothing, msgKey = Nothing }
+        atomically $ do
+          modifyTVar' (gsFanout router) (Map.insert "t" Set.empty)
+          modifyTVar' (gsMessageCache router) $ \c ->
+            foldl (\acc n -> cachePut (BS.pack [n]) (mkMsg n) acc) c [1, 2, 3]
+        heartbeatOnce router
+        sent <- readIORef logRef
+        let ihaveIds = concat [ ihaveMessageIds ih | (_, rpc) <- sent
+                              , Just ctrl <- [rpcControl rpc]
+                              , ih <- ctrlIHave ctrl ]
+        length ihaveIds `shouldBe` 2

--- a/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
@@ -17,6 +17,8 @@ import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Protocol.GossipSub.Types
 import LibP2P.Protocol.GossipSub.Router
+import LibP2P.Protocol.GossipSub.Heartbeat (heartbeatOnce)
+import LibP2P.Protocol.GossipSub.MessageCache (cachePut)
 import LibP2P.Protocol.GossipSub.Validation (signingBytes, validateMessage)
 
 -- Test helpers
@@ -52,6 +54,25 @@ mkTestRouter localPid = do
   (logRef, sendFn) <- newSendLog
   router <- newRouter defaultGossipSubParams localPid sendFn fixedTimeSource
   pure (router, logRef)
+
+-- | Create a test router with custom parameters and send logging.
+mkTestRouterWithParams :: GossipSubParams -> PeerId -> IO (GossipSubRouter, IORef [(PeerId, RPC)])
+mkTestRouterWithParams params pid = do
+  (logRef, sendFn) <- newSendLog
+  router <- newRouter params pid sendFn fixedTimeSource
+  pure (router, logRef)
+
+-- | All IWANT id lists sent, in order.
+iwantsSent :: [(PeerId, RPC)] -> [[MessageId]]
+iwantsSent sent =
+  [ iwantMessageIds iw
+  | (_, rpc) <- sent, Just ctrl <- [rpcControl rpc], iw <- ctrlIWant ctrl ]
+
+-- | All PRUNEs sent to a given peer.
+prunesTo :: PeerId -> [(PeerId, RPC)] -> [Prune]
+prunesTo pid sent =
+  [ p | (to, rpc) <- sent, to == pid
+      , Just ctrl <- [rpcControl rpc], p <- ctrlPrune ctrl ]
 
 -- | Create a test router with adjustable time.
 mkTestRouterWithTime :: PeerId -> UTCTime -> IO (GossipSubRouter, IORef [(PeerId, RPC)], IORef UTCTime)
@@ -1075,3 +1096,185 @@ spec = do
             Just tps -> tpsMeshFailurePenalty tps `shouldBe` 25
             Nothing -> expectationFailure "topic state not found"
           Nothing -> expectationFailure "peer not found"
+
+    -- Issue #157 remainder: peers that negotiated /meshsub/1.0.0 must not
+    -- receive v1.1 control extensions (PX records, backoff field).
+    describe "Protocol version gating (#157)" $ do
+      it "leave sends a bare PRUNE (no PX, no backoff) to a /meshsub/1.0.0 peer" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let v10Peer = mkPeerId 1
+            other   = mkPeerId 2
+        addPeer router v10Peer GossipSubV10Peer False fixedTime
+        atomically $ modifyTVar' (gsPeers router) $
+          Map.adjust (\ps -> ps { psTopics = Set.singleton "blocks" }) v10Peer
+        addSubscribedPeer router other "blocks"
+        atomically $ do
+          modifyTVar' (gsMesh router) (Map.insert "blocks" (Set.singleton v10Peer))
+          modifyTVar' (gsSubscriptions router) (Set.insert "blocks")
+        writeIORef logRef []
+        leave router "blocks"
+        sent <- readIORef logRef
+        case prunesTo v10Peer sent of
+          [p] -> do
+            prunePeers p `shouldBe` []
+            pruneBackoff p `shouldBe` Nothing
+          _ -> expectationFailure "expected exactly one PRUNE to the v1.0 peer"
+
+      it "GRAFT rejection PRUNE to a /meshsub/1.0.0 peer omits backoff and PX" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            routerNeg = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const (-1) } }
+        addPeer routerNeg sender GossipSubV10Peer False fixedTime
+        atomically $ modifyTVar' (gsSubscriptions routerNeg) (Set.insert "blocks")
+        handleGraft routerNeg sender [Graft "blocks"]
+        sent <- readIORef logRef
+        case prunesTo sender sent of
+          [p] -> do
+            prunePeers p `shouldBe` []
+            pruneBackoff p `shouldBe` Nothing
+          _ -> expectationFailure "expected exactly one PRUNE reply"
+
+      it "GRAFT rejection PRUNE to a /meshsub/1.1.0 peer carries the backoff field" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            routerNeg = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const (-1) } }
+        addPeer routerNeg sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsSubscriptions routerNeg) (Set.insert "blocks")
+        handleGraft routerNeg sender [Graft "blocks"]
+        sent <- readIORef logRef
+        case prunesTo sender sent of
+          [p] -> pruneBackoff p `shouldBe` Just 60
+          _ -> expectationFailure "expected exactly one PRUNE reply"
+
+    -- Issue #157 remainder: IHAVE/IWANT abuse limits (go-libp2p defaults:
+    -- MaxIHaveLength 5000, MaxIHaveMessages 10, reset every heartbeat).
+    describe "IHAVE/IWANT limits (#157)" $ do
+      it "ignores IHAVE batches beyond paramMaxIHaveMessages per heartbeat" $ do
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramMaxIHaveMessages = 2 } localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        handleIHave router sender [IHave "t" [BS.pack [1]]]
+        handleIHave router sender [IHave "t" [BS.pack [2]]]
+        handleIHave router sender [IHave "t" [BS.pack [3]]]
+        sent <- readIORef logRef
+        length (iwantsSent sent) `shouldBe` 2
+
+      it "caps message ids requested per peer per heartbeat at paramMaxIHaveLength" $ do
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramMaxIHaveLength = 3 } localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        handleIHave router sender [IHave "t" (map (BS.pack . pure) [1..5])]
+        handleIHave router sender [IHave "t" (map (BS.pack . pure) [6..10])]
+        sent <- readIORef logRef
+        sum (map length (iwantsSent sent)) `shouldBe` 3
+
+      it "heartbeat resets the IHAVE budget" $ do
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramMaxIHaveMessages = 1 } localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        handleIHave router sender [IHave "t" [BS.pack [1]]]
+        handleIHave router sender [IHave "t" [BS.pack [2]]]  -- over budget, ignored
+        heartbeatOnce router
+        handleIHave router sender [IHave "t" [BS.pack [3]]]
+        sent <- readIORef logRef
+        length (iwantsSent sent) `shouldBe` 2
+
+      it "serves at most paramMaxIHaveLength messages per peer per heartbeat on IWANT" $ do
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams
+            { paramMaxIHaveLength = 2
+            , paramMessageIdFn = msgData } localPid
+        let sender = mkPeerId 1
+            mkMsg n = PubSubMessage
+              { msgFrom = Nothing, msgData = BS.pack [n], msgSeqNo = Nothing
+              , msgTopic = "t", msgSignature = Nothing, msgKey = Nothing }
+            msgs = map mkMsg [1, 2, 3]
+        addPeer router sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsMessageCache router) $ \c ->
+          foldl (\acc m -> cachePut (msgData m) m acc) c msgs
+        handleIWant router sender [IWant (map msgData msgs)]
+        sent <- readIORef logRef
+        let served = concat [ rpcPublish rpc | (pid, rpc) <- sent, pid == sender ]
+        length served `shouldBe` 2
+
+    -- Issue #157 remainder: direct (explicit) peering agreements,
+    -- gossipsub-v1.1.md: direct peers always exchange messages and are
+    -- never part of the mesh.
+    describe "Direct peers (#157)" $ do
+      it "forwardMessage always includes subscribed direct peers outside the mesh" $ do
+        let dp = mkPeerId 9
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramDirectPeers = Set.singleton dp } localPid
+        let meshPeer = mkPeerId 1
+            sender   = mkPeerId 2
+        mapM_ (\pid -> addSubscribedPeer router pid "t") [meshPeer, sender, dp]
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.fromList [meshPeer, sender])
+        kp <- newKeyPair
+        forwardMessage router sender (signedMessage kp "t" (BS.pack [1]))
+        sent <- readIORef logRef
+        let recipients = Set.fromList
+              [ pid | (pid, rpc) <- sent, not (null (rpcPublish rpc)) ]
+        recipients `shouldBe` Set.fromList [meshPeer, dp]
+
+      it "join never adds a direct peer to the mesh" $ do
+        let dp = mkPeerId 9
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramDirectPeers = Set.singleton dp } localPid
+        addSubscribedPeer router dp "t"
+        join router "t"
+        mesh <- readTVarIO (gsMesh router)
+        Set.member dp (Map.findWithDefault Set.empty "t" mesh) `shouldBe` False
+        sent <- readIORef logRef
+        let graftsTo = [ pid | (pid, rpc) <- sent
+                             , Just ctrl <- [rpcControl rpc]
+                             , not (null (ctrlGraft ctrl)) ]
+        graftsTo `shouldBe` []
+
+      it "rejects GRAFT from a direct peer without adding it to the mesh" $ do
+        let dp = mkPeerId 9
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramDirectPeers = Set.singleton dp } localPid
+        addSubscribedPeer router dp "t"
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "t")
+        handleGraft router dp [Graft "t"]
+        mesh <- readTVarIO (gsMesh router)
+        Set.member dp (Map.findWithDefault Set.empty "t" mesh) `shouldBe` False
+        sent <- readIORef logRef
+        length (prunesTo dp sent) `shouldBe` 1
+
+      it "direct peers bypass the graylist" $ do
+        let dp = mkPeerId 9
+        (router, _) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramDirectPeers = Set.singleton dp } localPid
+        let routerGl = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const (-20000) } }
+        addPeer routerGl dp GossipSubPeer False fixedTime
+        handleRPC routerGl dp emptyRPC { rpcSubscriptions = [SubOpts True "t"] }
+        peers <- readTVarIO (gsPeers routerGl)
+        case Map.lookup dp peers of
+          Just ps -> psTopics ps `shouldBe` Set.singleton "t"
+          Nothing -> expectationFailure "peer not found"
+
+      it "flood publish includes direct peers regardless of score" $ do
+        let dp = mkPeerId 9
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramDirectPeers = Set.singleton dp } localPid
+        let routerTh = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore =
+                      \pid -> if pid == dp then -2000 else 0 } }
+        addSubscribedPeer routerTh dp "t"
+        kp <- newKeyPair
+        publish routerTh "t" (BS.pack [1]) (Just kp)
+        sent <- readIORef logRef
+        let publishedTo = [ pid | (pid, rpc) <- sent, not (null (rpcPublish rpc)) ]
+        publishedTo `shouldBe` [dp]


### PR DESCRIPTION
## Summary

Completes the items of #157 that were explicitly split out of #211: multi-protocol negotiation, IHAVE/IWANT count caps, and direct peering agreements.

## Protocol negotiation (/meshsub/1.0.0 fallback)

- The Handler now registers inbound stream handlers for **both** `/meshsub/1.1.0` and `/meshsub/1.0.0`, and offers both (v1.1 preferred) when initiating, so v1.0-only peers get a pubsub stream instead of `NoProtocol`.
- The negotiated version is tracked per peer (`PeerProtocol` gains `GossipSubV10Peer`; `psProtocol` is now actually read).
- v1.0 peers never receive v1.1 control extensions: all four PRUNE construction sites (leave, GRAFT rejection, negative-score prune, oversubscription trim) go through the new version-gated `buildPrune`, which sends a bare PRUNE (no PX records, no backoff field) to v1.0 peers.

## IHAVE/IWANT limits (gossipsub-v1.1.md §Flood Publishing hardening, go defaults)

Per peer, per heartbeat:

- at most `paramMaxIHaveMessages` (10) IHAVE batches are accepted; further batches are ignored,
- at most `paramMaxIHaveLength` (5000) message ids are requested via IWANT,
- at most `paramMaxIHaveLength` messages are served in response to IWANT,
- emitted IHAVE id lists are capped at `paramMaxIHaveLength`.

Budgets live in three new router TVars and reset every heartbeat. Broken IWANT promises continue to be penalised via the existing P7 tracking from #211.

## Direct peering (gossipsub-v1.1.md §Explicit Peering Agreements)

New `paramDirectPeers :: Set PeerId` config field. Configured direct peers:

- always receive published and forwarded messages for topics they subscribe to (flood, mesh, fanout and forward paths),
- bypass the graylist and the publish-threshold score gates,
- are never grafted into the mesh (join, heartbeat fill, fanout selection all exclude them) and never scored out of it,
- have their GRAFTs answered with PRUNE per spec (direct peers must not be mesh members).

**Boundary stated explicitly:** this is the minimal config-field + exemption implementation. The reciprocal reconnect loop (redialling a disconnected direct peer) is not included — connection management belongs to the application/Switch layer, and the router has no dialler.

## Tests

TDD, all green — 929 examples, 0 failures with GHC 9.10.3. New tests cover: bare PRUNE to v1.0 peers on leave/GRAFT-rejection/heartbeat-prune vs backoff-carrying PRUNE to v1.1 peers; IHAVE batch cap, id-request cap, IWANT serve cap, heartbeat budget reset, emitted IHAVE cap; direct peers in forward/flood paths, mesh-fill and join exclusion, GRAFT-from-direct rejection, graylist bypass; both protocol ids registered/unregistered on start/stop.

## Remaining out of scope

Floodsub compatibility (`/floodsub/1.0.0` negotiation and flooding to `peers.floodsub[topic]`) from item 1 of the issue is still not implemented — the `FloodSubPeer` constructor remains unconstructed. That is the only #157 item left after this PR and #211.

Refs #157