### PR TITLE
fix: content-address anonymous gossipsub message ids

### DIFF
--- a/src/LibP2P/Protocol/GossipSub/Types.hs
+++ b/src/LibP2P/Protocol/GossipSub/Types.hs
@@ -59,14 +59,18 @@ module LibP2P.Protocol.GossipSub.Types
 
 import Control.Concurrent.STM (TVar)
 import Control.Exception (Exception)
+import qualified Crypto.Hash as Hash
+import qualified Data.ByteArray as BA
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import Data.Maybe (fromMaybe)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
+import qualified Data.Text.Encoding as TE
 import Data.Time (NominalDiffTime, UTCTime)
 import Data.Word (Word64)
 import LibP2P.Crypto.PeerId (PeerId)
@@ -214,12 +218,17 @@ data GossipSubParams = GossipSubParams
     -- peers always exchange messages and are never mesh members
   }
 
--- | Default message ID: concatenation of from and seqno fields.
+-- | Default message ID: concatenation of from and seqno fields. Anonymous
+-- messages (StrictNoSign) carry neither field, and a shared empty id would
+-- collapse seen-cache dedup, the mcache and IHAVE/IWANT tracking, so those
+-- fall back to a content-addressed id of @SHA-256(topic <> data)@ (#217).
 defaultMessageId :: PubSubMessage -> MessageId
 defaultMessageId msg =
-  let from = maybe BS.empty id (msgFrom msg)
-      seqno = maybe BS.empty id (msgSeqNo msg)
-  in from <> seqno
+  case (msgFrom msg, msgSeqNo msg) of
+    (Nothing, Nothing) ->
+      BA.convert (Hash.hash (TE.encodeUtf8 (msgTopic msg) <> msgData msg) :: Hash.Digest Hash.SHA256)
+    (from, seqno) ->
+      fromMaybe BS.empty from <> fromMaybe BS.empty seqno
 
 -- | Default GossipSub parameters per spec.
 defaultGossipSubParams :: GossipSubParams

--- a/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
@@ -552,6 +552,20 @@ spec = do
         seen <- readTVarIO (gsSeen router)
         Map.size seen `shouldBe` 1
 
+      -- #217: anonymous messages carry neither from nor seqno; if their ids
+      -- collapsed to one value, the second publish would be deduplicated away
+      -- and the mcache entry overwritten.
+      it "keeps distinct anonymous publishes distinct under StrictNoSign" $ do
+        let params = defaultGossipSubParams { paramSignaturePolicy = StrictNoSign }
+        (router, _) <- mkTestRouterWithParams params localPid
+        addSubscribedPeer router (mkPeerId 1) "blocks"
+        publish router "blocks" (BS.pack [1]) Nothing
+        publish router "blocks" (BS.pack [2]) Nothing
+        seen <- readTVarIO (gsSeen router)
+        Map.size seen `shouldBe` 2
+        cache <- readTVarIO (gsMessageCache router)
+        Map.size (mcIndex cache) `shouldBe` 2
+
       it "signs the message and the result verifies under StrictSign" $ do
         kp <- newKeyPair
         (router, logRef) <- mkTestRouter (fromPublicKey (kpPublic kp))

--- a/test/LibP2P/Protocol/GossipSub/TypesSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/TypesSpec.hs
@@ -49,16 +49,40 @@ spec = do
               }
         defaultMessageId msg `shouldBe` BS.pack [1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 42]
 
-      it "returns empty when both from and seqno are absent" $ do
+      -- Anonymous (StrictNoSign) messages carry neither from nor seqno; a
+      -- shared empty id would collapse seen-cache dedup, the mcache and
+      -- IHAVE/IWANT tracking (#217), so the id must be content-addressed.
+      it "falls back to SHA-256 of topic and data when from and seqno are absent" $ do
         let msg = PubSubMessage
               { msgFrom      = Nothing
-              , msgData      = BS.empty
+              , msgData      = BS.pack [1, 2, 3]
               , msgSeqNo     = Nothing
               , msgTopic     = "test"
               , msgSignature = Nothing
               , msgKey       = Nothing
               }
-        defaultMessageId msg `shouldBe` BS.empty
+        -- sha256(0x74657374 <> 0x010203), digest computed independently
+        defaultMessageId msg `shouldBe` BS.pack
+          [ 0xce, 0xd4, 0x9a, 0x0a, 0x8c, 0x5c, 0x38, 0xa2
+          , 0x38, 0xb6, 0x0b, 0xf3, 0x35, 0x87, 0xcf, 0x58
+          , 0x73, 0x8f, 0x16, 0xdc, 0x6c, 0x4f, 0xf9, 0xbd
+          , 0x2b, 0x75, 0x95, 0x51, 0xe9, 0xfa, 0xe3, 0x47 ]
+
+      it "derives distinct ids for distinct anonymous messages" $ do
+        let anon topic payload = PubSubMessage
+              { msgFrom      = Nothing
+              , msgData      = payload
+              , msgSeqNo     = Nothing
+              , msgTopic     = topic
+              , msgSignature = Nothing
+              , msgKey       = Nothing
+              }
+        defaultMessageId (anon "t" (BS.pack [1]))
+          `shouldNotBe` defaultMessageId (anon "t" (BS.pack [2]))
+        defaultMessageId (anon "t1" (BS.pack [1]))
+          `shouldNotBe` defaultMessageId (anon "t2" (BS.pack [1]))
+        defaultMessageId (anon "t" (BS.pack [1]))
+          `shouldBe` defaultMessageId (anon "t" (BS.pack [1]))
 
     describe "emptyRPC" $ do
       it "has no subscriptions, messages, or control" $ do


### PR DESCRIPTION
An anonymous (StrictNoSign) message carries neither `from` nor `seqno`, so the default `from <> seqno` message id was the empty string for every message. Since message ids key the seen-cache, mcache and IHAVE/IWANT tracking, only the first anonymous message ever propagated: everything after it was dropped as a duplicate, and cache entries overwrote each other.

`defaultMessageId` now falls back to `SHA-256(topic <> data)` when both fields are absent — the content-addressing approach go-libp2p and rust-libp2p require for anonymous mode. Signed messages keep the spec-default `from <> seqno` id.

Tests: the TypesSpec case that pinned the empty id as correct is rewritten to pin the exact SHA-256 digest (computed independently) plus distinctness properties, and a RouterSpec regression publishes two anonymous messages and asserts both survive dedup and both land in the mcache. Both confirmed failing before the fix; full suite 962 examples, 0 failures.

Closes #217