### PR TITLE
test: cover ping session lifecycle and identify push semantics left open by #200

### DIFF
--- a/test/LibP2P/IntegrationSpec.hs
+++ b/test/LibP2P/IntegrationSpec.hs
@@ -230,6 +230,24 @@ spec = do
           Just (Right info) ->
             idObservedAddr info `shouldBe` Just (toBytes (connLocalAddr conn))
 
+    it "switchListen pushes the new listen address to already-connected peers" $ do
+      -- specs/identify push: when local state advertised via identify
+      -- changes (here: listen addresses), connected peers are updated
+      -- proactively over /ipfs/id/push/1.0.0 — B's peer store must gain
+      -- A's new address without B ever calling requestIdentify.
+      withConnectedPair $ \(swA, pidA) (swB, _pidB) _conn -> do
+        newAddrs <- switchListen swA defaultConnectionGater [loopbackAddr]
+        let expected = toBytes (head newAddrs)
+        seen <- timeout 5000000 $ atomically $ do
+          store <- readTVar (swPeerStore swB)
+          case Map.lookup pidA store of
+            Just info | expected `elem` idListenAddrs info -> pure ()
+            _ -> retry
+        case seen of
+          Just () -> pure ()
+          Nothing -> expectationFailure
+            "B never received A's pushed listen address"
+
   describe "Multi-protocol" $ do
     it "successive pings reuse a single outbound stream over the same connection" $ do
       -- Regression for #163. specs/ping/ping.md: "The dialing peer MUST

--- a/test/LibP2P/Protocol/Identify/IdentifySpec.hs
+++ b/test/LibP2P/Protocol/Identify/IdentifySpec.hs
@@ -109,6 +109,48 @@ mkClosableStreamPair = do
         }
   pure (streamA, streamB)
 
+-- | Wrap a StreamIO so closing it flips the flag (before delegating).
+recordClose :: IORef Bool -> StreamIO -> StreamIO
+recordClose ref s = s { streamClose = writeIORef ref True >> streamClose s }
+
+-- | An IdentifyInfo with every optional field absent and every
+-- repeated field empty (what an empty push message decodes to).
+emptyInfo :: IdentifyInfo
+emptyInfo = IdentifyInfo
+  { idProtocolVersion = Nothing
+  , idAgentVersion    = Nothing
+  , idPublicKey       = Nothing
+  , idListenAddrs     = []
+  , idObservedAddr    = Nothing
+  , idProtocols       = []
+  }
+
+-- | Build an outbound Connection whose muxer hands out the given
+-- streams (one per muxOpenStream call), for driving pushIdentify.
+mkPushConnection :: PeerId -> Multiaddr -> IO StreamIO -> IO Connection
+mkPushConnection pid remoteAddr openStream = do
+  stateVar <- newTVarIO ConnOpen
+  pure Connection
+    { connPeerId     = pid
+    , connDirection  = Outbound
+    , connLocalAddr  = Multiaddr [IP4 0x7f000001, TCP 0]
+    , connRemoteAddr = remoteAddr
+    , connSecurity   = "/noise"
+    , connMuxer      = "/yamux/1.0.0"
+    , connSession    = MuxerSession
+        { muxOpenStream   = openStream
+        , muxAcceptStream = fail "test connection: no inbound streams"
+        , muxClose        = pure ()
+        }
+    , connState      = stateVar
+    }
+
+-- | Insert a connection into the Switch's connection pool.
+addConn :: Switch -> Connection -> IO ()
+addConn sw conn = atomically $ do
+  pool <- readTVar (swConnPool sw)
+  writeTVar (swConnPool sw) (Map.insert (connPeerId conn) [conn] pool)
+
 -- | Read all raw bytes from a StreamIO until EOF (test helper).
 readAllBytes :: StreamIO -> IO (Either String BS.ByteString)
 readAllBytes stream = go []
@@ -306,6 +348,67 @@ spec = do
           idAgentVersion merged `shouldBe` Just "go-libp2p/0.36.0"
           idProtocolVersion merged `shouldBe` Just "ipfs/0.1.0"
 
+    it "mergeIdentify replaces present optional fields and non-empty repeated fields wholesale" $ do
+      -- specs/identify: only *missing* fields are ignored. A field that
+      -- is present in the update wins, and repeated fields are replaced
+      -- wholesale — never unioned or appended (matching go-libp2p).
+      let known = IdentifyInfo
+            { idProtocolVersion = Just "ipfs/0.1.0"
+            , idAgentVersion    = Just "old-agent/1.0"
+            , idPublicKey       = Just (BS.pack [1, 2, 3])
+            , idListenAddrs     = [encodeProtocols [IP4 0x7f000001, TCP 4001]]
+            , idObservedAddr    = Nothing
+            , idProtocols       = ["/old/1.0.0", "/old/2.0.0"]
+            }
+          update = IdentifyInfo
+            { idProtocolVersion = Just "ipfs/0.2.0"
+            , idAgentVersion    = Just "new-agent/2.0"
+            , idPublicKey       = Just (BS.pack [9, 9])
+            , idListenAddrs     = [encodeProtocols [IP4 0x7f000001, TCP 9999]]
+            , idObservedAddr    = Just (encodeProtocols [IP4 0x7f000001, TCP 5555])
+            , idProtocols       = ["/new/1.0.0"]
+            }
+      -- Every field of the result comes from the update; in particular
+      -- idProtocols is exactly the update's one-element list, not a
+      -- union with the two known entries.
+      mergeIdentify known update `shouldBe` update
+
+    it "mergeIdentify keeps every known field when the update is empty" $ do
+      let known = IdentifyInfo
+            { idProtocolVersion = Just "ipfs/0.1.0"
+            , idAgentVersion    = Just "go-libp2p/0.36.0"
+            , idPublicKey       = Just (BS.pack [1, 2, 3])
+            , idListenAddrs     = [encodeProtocols [IP4 0x7f000001, TCP 4001]]
+            , idObservedAddr    = Just (encodeProtocols [IP4 0x7f000001, TCP 5555])
+            , idProtocols       = ["/ipfs/id/1.0.0"]
+            }
+      mergeIdentify known emptyInfo `shouldBe` known
+
+    it "handleIdentifyPush with an empty message leaves the peer entry untouched" $ do
+      -- specs/identify: "missing fields should be ignored". An empty
+      -- push carries no information, so the stored entry must survive
+      -- byte-identical.
+      sw <- mkTestSwitch
+      let remotePeerId = PeerId "empty-push-peer"
+          knownInfo = IdentifyInfo
+            { idProtocolVersion = Just "ipfs/0.1.0"
+            , idAgentVersion    = Just "go-libp2p/0.36.0"
+            , idPublicKey       = Just (BS.pack [1, 2, 3])
+            , idListenAddrs     = [encodeProtocols [IP4 0x7f000001, TCP 4001]]
+            , idObservedAddr    = Nothing
+            , idProtocols       = ["/ipfs/id/1.0.0", "/ipfs/ping/1.0.0"]
+            }
+      atomically $ do
+        store <- readTVar (swPeerStore sw)
+        writeTVar (swPeerStore sw) (Map.insert remotePeerId knownInfo store)
+      (streamA, streamB) <- mkClosableStreamPair
+      streamWrite streamA (frame (encodeIdentify emptyInfo))
+      streamClose streamA
+      conn <- mkTestConnection remotePeerId (Multiaddr [IP4 0x7f000001, TCP 4001])
+      handleIdentifyPush sw conn streamB
+      store <- atomically $ readTVar (swPeerStore sw)
+      Map.lookup remotePeerId store `shouldBe` Just knownInfo
+
     it "readFramedIdentify parses a varint-length-prefixed message" $ do
       (streamA, streamB) <- mkClosableStreamPair
       let testInfo = IdentifyInfo
@@ -413,6 +516,63 @@ spec = do
       -- Exactly one push stream was opened on the connection
       opens <- readIORef openCountRef
       opens `shouldBe` 1
+
+    it "pushIdentify sends each connection its own observedAddr and closes every push stream" $ do
+      -- specs/identify: observedAddr is the address of the *remote*
+      -- peer as seen from this connection, so a push fan-out must build
+      -- a distinct message per connection — and close each push stream
+      -- after the single message (the length prefix is the message
+      -- boundary, the close releases the stream).
+      Right kp <- generateKeyPair
+      sw <- newSwitch (fromPublicKey (kpPublic kp)) kp
+      (streamA1, streamB1) <- mkClosableStreamPair
+      (streamA2, streamB2) <- mkClosableStreamPair
+      closed1 <- newIORef False
+      closed2 <- newIORef False
+      let addr1 = [IP4 0x7f000001, TCP 1111]
+          addr2 = [IP4 0x7f000001, TCP 2222]
+      conn1 <- mkPushConnection (PeerId "push-1") (Multiaddr addr1)
+                 (pure (recordClose closed1 streamA1))
+      conn2 <- mkPushConnection (PeerId "push-2") (Multiaddr addr2)
+                 (pure (recordClose closed2 streamA2))
+      addConn sw conn1
+      addConn sw conn2
+      let remoteSide streamB = async $ do
+            negResult <- negotiateResponder streamB [identifyPushProtocolId]
+            negResult `shouldBe` Accepted identifyPushProtocolId
+            readFramedIdentify streamB maxIdentifySize
+      remote1 <- remoteSide streamB1
+      remote2 <- remoteSide streamB2
+      pushIdentify sw
+      info1 <- wait remote1
+      info2 <- wait remote2
+      fmap idObservedAddr info1 `shouldBe` Right (Just (encodeProtocols addr1))
+      fmap idObservedAddr info2 `shouldBe` Right (Just (encodeProtocols addr2))
+      readIORef closed1 `shouldReturn` True
+      readIORef closed2 `shouldReturn` True
+
+    it "pushIdentify keeps pushing to the remaining peers when one connection fails" $ do
+      -- Per-peer failures are ignored: a dead muxer on one connection
+      -- must not prevent the push from reaching the other peers.
+      Right kp <- generateKeyPair
+      sw <- newSwitch (fromPublicKey (kpPublic kp)) kp
+      (streamA, streamB) <- mkClosableStreamPair
+      deadConn <- mkPushConnection (PeerId "push-dead") (Multiaddr [IP4 0x7f000001, TCP 1111])
+                    (throwIO (userError "muxer session is dead"))
+      liveConn <- mkPushConnection (PeerId "push-live") (Multiaddr [IP4 0x7f000001, TCP 2222])
+                    (pure streamA)
+      addConn sw deadConn
+      addConn sw liveConn
+      remote <- async $ do
+        negResult <- negotiateResponder streamB [identifyPushProtocolId]
+        negResult `shouldBe` Accepted identifyPushProtocolId
+        readFramedIdentify streamB maxIdentifySize
+      pushIdentify sw
+      infoOrErr <- wait remote
+      case infoOrErr of
+        Left err -> expectationFailure $ "push to the live peer failed: " ++ err
+        Right info ->
+          idObservedAddr info `shouldBe` Just (encodeProtocols [IP4 0x7f000001, TCP 2222])
 
     it "registerIdentifyHandlers registers both protocol handlers" $ do
       sw <- mkTestSwitch

--- a/test/LibP2P/Protocol/Ping/PingSpec.hs
+++ b/test/LibP2P/Protocol/Ping/PingSpec.hs
@@ -32,6 +32,11 @@ import LibP2P.MultistreamSelect.Negotiation
   )
 import LibP2P.Protocol.Ping
 import LibP2P.Switch (newSwitch)
+import LibP2P.Switch.ResourceManager
+  ( ResourceScope (..)
+  , ResourceUsage (..)
+  , getOrCreatePeerScope
+  )
 import LibP2P.Switch.Types
   ( ConnState (..)
   , Connection (..)
@@ -107,6 +112,13 @@ mkPingConnection openStream = do
         }
     , connState      = stateVar
     }
+
+-- | Outbound ping streams currently reserved against a peer's resource
+-- scope (a session holds exactly one while open, zero after close).
+readPeerOutboundStreams :: Switch -> PeerId -> IO Int
+readPeerOutboundStreams sw pid = atomically $ do
+  scope <- getOrCreatePeerScope (swResourceMgr sw) pid
+  ruStreamsOutbound <$> readTVar (rsUsage scope)
 
 -- | Read exactly n bytes from a stream.
 readNBytes :: StreamIO -> Int -> IO BS.ByteString
@@ -261,6 +273,78 @@ spec = do
               "expected Left PingStreamError, got: " ++ show other
       done <- timeout 1000000 (wait responder)
       done `shouldBe` Just ()
+
+    it "closePingSession closes the stream and releases its reservation exactly once" $ do
+      -- A session holds exactly one stream reservation against the
+      -- peer's resource scope; closing the session must release it, and
+      -- a double close must not close the stream (or release the
+      -- reservation) a second time.
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      closeCountRef <- newIORef (0 :: Int)
+      let countingClose s =
+            s { streamClose = modifyIORef' closeCountRef (+ 1) >> streamClose s }
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (pure (countingClose streamA))
+      responder <- async $ pingResponder streamB
+      opened <- openPingSession sw conn
+      case opened of
+        Left err -> expectationFailure $ "ping session failed to open: " ++ show err
+        Right sess -> do
+          reservedOpen <- readPeerOutboundStreams sw (connPeerId conn)
+          reservedOpen `shouldBe` 1
+          closePingSession sess
+          closePingSession sess
+          closes <- readIORef closeCountRef
+          closes `shouldBe` 1
+          reservedClosed <- readPeerOutboundStreams sw (connPeerId conn)
+          reservedClosed `shouldBe` 0
+      done <- timeout 1000000 (wait responder)
+      done `shouldBe` Just ()
+
+    it "withPingSession closes the session when the action throws" $ do
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      closedRef <- newIORef False
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (pure (recordClose closedRef streamA))
+      responder <- async $ pingResponder streamB
+      outcome <- try $ withPingSession sw conn $ \_sess ->
+        throwIO (userError "boom") :: IO ()
+      case outcome of
+        Left (_ :: IOError) -> pure ()  -- the action's exception propagates
+        Right (r :: Either PingError ()) -> expectationFailure $
+          "expected the exception to propagate, got: " ++ show r
+      -- The session (and its stream) must still have been closed, so
+      -- the responder's echo loop sees EOF and exits on its own.
+      closed <- readIORef closedRef
+      closed `shouldBe` True
+      done <- timeout 1000000 (wait responder)
+      done `shouldBe` Just ()
+
+    it "a ping after a timed-out ping on the same session is rejected" $ do
+      -- A late echo from the slow responder would corrupt the next
+      -- exchange, so a failed ping closes the session: the session must
+      -- reject further pings instead of reusing the poisoned stream.
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (pure streamA)
+      responder <- async $ do
+        negResult <- negotiateResponder streamB [pingProtocolId]
+        negResult `shouldBe` Accepted pingProtocolId
+        -- Swallow the payload and never echo.
+        _ <- readNBytes streamB pingSize
+        pure ()
+      opened <- openPingSession sw conn
+      case opened of
+        Left err -> expectationFailure $ "ping session failed to open: " ++ show err
+        Right sess -> do
+          first <- pingWithTimeout 200000 sess
+          first `shouldBe` Left PingTimeout
+          second <- ping sess
+          case second of
+            Left (PingStreamError _) -> pure ()
+            other -> expectationFailure $
+              "expected Left PingStreamError after a timed-out ping, got: " ++ show other
+      wait responder
 
     it "pingWithTimeout returns Left PingTimeout and closes the stream when no echo arrives" $ do
       (streamA, _closeA, streamB) <- mkClosableStreamPair


### PR DESCRIPTION
Closes the #170 remainder that PR #200 left blocked on then-open bugs, both since fixed: #163 (PingSession API, #212) and #165 (mergeIdentify + pushIdentify, #213).

## New coverage

### Ping stream lifecycle / PingTimeout (`PingSpec`)

| Gap | Test |
|---|---|
| Session close releases the stream exactly once | `closePingSession closes the stream and releases its reservation exactly once` — double `closePingSession`, underlying close count is 1, and the Switch's per-peer outbound stream reservation goes 1 → 0 |
| Session leak on exception | `withPingSession closes the session when the action throws` — exception propagates, stream still closed, responder exits on EOF |
| Poisoned stream reuse after timeout | `a ping after a timed-out ping on the same session is rejected` — `Left PingTimeout`, then `Left PingStreamError` (a late echo would corrupt the next exchange) |

(#212 already covers: single-stream reuse, close on completion/mismatch/timeout/rejection, ping-after-close, responder-side close.)

### Identify push merge semantics (`IdentifySpec`)

| Gap | Test |
|---|---|
| Merge policy pinned field-by-field | `mergeIdentify replaces present optional fields and non-empty repeated fields wholesale` — repeated fields are replaced, never unioned/appended |
| Empty update | `mergeIdentify keeps every known field when the update is empty` and `handleIdentifyPush with an empty message leaves the peer entry untouched` (stored entry byte-identical) |
| Per-connection observedAddr + stream close | `pushIdentify sends each connection its own observedAddr and closes every push stream` — two connections, distinct remote addrs, distinct messages, both streams closed |
| Per-peer failure isolation | `pushIdentify keeps pushing to the remaining peers when one connection fails` — dead muxer on one conn, the other still receives the push |

Push from an unknown peer creating an entry was already asserted by the pre-existing `handleIdentifyPush stores info in peer store` test (empty store).

### Identify push E2E (`IntegrationSpec`)

- `switchListen pushes the new listen address to already-connected peers` — A starts listening after connecting; B's peer store gains A's new address over `/ipfs/id/push/1.0.0` without B calling `requestIdentify`. First test of the state-change → push trigger wired in #213.

## Verification

- `cabal build` + `cabal test` (GHC 9.10.3): 969 examples, 0 failures. New E2E run 5x without flakes.
- TDD sanity check: removing the `closePingSession` idempotency guard deadlocked the exactly-once test; removing `mergeIdentify`'s keep-on-empty branch failed exactly the two empty-update tests. Breakage reverted before commit.

## Remainder (not addressable as tests today)

- **publicKey / peer-id validation** (`identify rejects a publicKey that does not derive the claimed peer id`) — the validation itself is unimplemented; it was #165 point 3, explicitly left out of #213. Needs an implementation change first.
- **Concurrent-ping E2E rows** (`concurrent pings to one peer do not open a second outbound stream`, `no handler threads remain blocked after N pings`) — `PingSession` does not serialize concurrent pings on its single stream, so these need session-level locking first. Sequential reuse and per-ping resource release are covered.
- **Cross-implementation identify/ping in `interop/`** — delegated to #129 with the unified-testing work.

Refs #170