### PR TITLE
test: EOF-capable stream harness and peer-disconnect coverage (#172)

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -143,6 +143,7 @@ test-suite libp2p-hs-test
     LibP2P.Crypto.KeyImportSpec
     LibP2P.Crypto.SpecVectors
     LibP2P.Crypto.SpecVectorsSpec
+    LibP2P.EofStream
     LibP2P.MultistreamSelect.NegotiationSpec
     LibP2P.Yamux.FrameSpec
     LibP2P.Yamux.HostilePeer

--- a/src/LibP2P/MultistreamSelect/Negotiation.hs
+++ b/src/LibP2P/MultistreamSelect/Negotiation.hs
@@ -127,8 +127,15 @@ readMessage stream = do
 -- The read loop is bounded at 'maxVarintBytes' (9 bytes per the
 -- unsigned-varint spec) so a peer streaming continuation bytes (0x80)
 -- cannot keep us reading and accumulating forever.
+--
+-- Like 'readExactBounded', I/O failures (stream reset, EOF from a peer
+-- that disconnected mid-negotiation) are returned as 'Left', so the
+-- negotiation functions report them as 'NoProtocol' instead of leaking
+-- an exception.
 readVarint :: StreamIO -> IO (Either String ByteString)
-readVarint stream = go 0 []
+readVarint stream =
+  go 0 [] `catch` \(e :: IOException) ->
+    pure (Left ("readVarint: read failed: " <> show e))
   where
     go :: Int -> [Word8] -> IO (Either String ByteString)
     go n acc

--- a/test/LibP2P/EofStream.hs
+++ b/test/LibP2P/EofStream.hs
@@ -1,0 +1,72 @@
+-- | An EOF-capable in-memory stream pair: the deterministic sibling of
+-- 'mkMemoryStreamPair' (#172).
+--
+-- 'mkMemoryStreamPair' cannot model disconnection: both halves get
+-- @streamClose = pure ()@ and a read on an empty queue blocks forever,
+-- so the whole "peer hangs up mid-conversation" test class is
+-- inexpressible with it. This pair models a TCP half-close
+-- (@shutdown(SHUT_WR)@): 'streamClose' closes the caller's OUTGOING
+-- direction, after which the peer's reads first drain any buffered
+-- bytes and then throw an EOF 'IOError' — exactly like a socket that
+-- received FIN. Writes into a direction the writer already closed also
+-- fail, like writing to a shut-down socket.
+--
+-- Real-socket disconnect behaviour (whole-node survival, dial
+-- teardown) is covered over TCP in 'LibP2P.FaultInjectionSpec'; this
+-- harness exists for deterministic, in-process assertions on the exact
+-- negotiation/handshake results a peer disconnect must produce.
+module LibP2P.EofStream (mkEofStreamPair) where
+
+import Control.Concurrent.STM
+import qualified Data.ByteString as BS
+import Data.Word (Word8)
+import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
+import System.IO.Error (eofErrorType, mkIOError)
+
+-- | One direction of the duplex pair: a byte queue plus a closed flag
+-- set by the writing side's 'streamClose'.
+data HalfDuplex = HalfDuplex
+  { hdQueue  :: TQueue Word8
+  , hdClosed :: TVar Bool
+  }
+
+newHalfDuplex :: IO HalfDuplex
+newHalfDuplex = HalfDuplex <$> newTQueueIO <*> newTVarIO False
+
+-- | Create an in-memory stream pair where each side can signal EOF.
+-- Closing side A makes side B's reads throw an EOF 'IOError' once the
+-- bytes already written have been drained, and vice versa.
+mkEofStreamPair :: IO (StreamIO, StreamIO)
+mkEofStreamPair = do
+  aToB <- newHalfDuplex
+  bToA <- newHalfDuplex
+  pure (mkEnd aToB bToA, mkEnd bToA aToB)
+  where
+    mkEnd outgoing incoming = StreamIO
+      { streamWrite    = writeHalf outgoing
+      , streamReadByte = readHalf incoming
+      , streamClose    = atomically (writeTVar (hdClosed outgoing) True)
+      }
+
+    writeHalf hd bs = do
+      ok <- atomically $ do
+        closed <- readTVar (hdClosed hd)
+        if closed
+          then pure False
+          else True <$ mapM_ (writeTQueue (hdQueue hd)) (BS.unpack bs)
+      if ok
+        then pure ()
+        else ioError (mkIOError eofErrorType "write to closed stream" Nothing Nothing)
+
+    readHalf hd = do
+      -- Buffered bytes drain first; EOF only surfaces on an empty queue
+      -- whose writer has closed — matching TCP FIN semantics.
+      r <- atomically $
+        (Just <$> readTQueue (hdQueue hd))
+          `orElse` (do
+            closed <- readTVar (hdClosed hd)
+            check closed
+            pure Nothing)
+      case r of
+        Just b  -> pure b
+        Nothing -> ioError (mkIOError eofErrorType "end of stream" Nothing Nothing)

--- a/test/LibP2P/MultistreamSelect/NegotiationSpec.hs
+++ b/test/LibP2P/MultistreamSelect/NegotiationSpec.hs
@@ -6,8 +6,10 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.IORef (atomicModifyIORef', newIORef)
 import Data.Word (Word8)
+import LibP2P.EofStream (mkEofStreamPair)
 import LibP2P.MultistreamSelect.Negotiation
 import LibP2P.MultistreamSelect.Wire
+import System.IO.Error (isEOFError)
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -164,6 +166,78 @@ spec = do
     it "aborts an unterminated varint prefix after the 9-byte spec limit" $ do
       (streamA, streamB) <- mkMemoryStreamPair
       streamWrite streamA (BS.pack (replicate 64 0x80))
+      result <- timeout 1000000 (negotiateResponder streamB ["/noise"])
+      result `shouldBe` Just NoProtocol
+
+  describe "EOF-capable stream harness" $ do
+    it "delivers buffered bytes before signaling EOF" $ do
+      (streamA, streamB) <- mkEofStreamPair
+      streamWrite streamA (BS.pack [0x61, 0x62, 0x63])
+      streamClose streamA
+      -- The three bytes written before the close are still readable ...
+      readRawBytes streamB 3 `shouldReturn` BS.pack [0x61, 0x62, 0x63]
+      -- ... and only then does the reader see EOF.
+      streamReadByte streamB `shouldThrow` isEOFError
+
+    it "read on a closed empty stream throws EOF immediately" $ do
+      (streamA, streamB) <- mkEofStreamPair
+      streamClose streamA
+      result <- timeout 1000000 (streamReadByte streamB `shouldThrow` isEOFError)
+      result `shouldBe` Just ()
+
+    it "write into a direction the writer closed fails" $ do
+      (streamA, _streamB) <- mkEofStreamPair
+      streamClose streamA
+      streamWrite streamA (BS.pack [0x00]) `shouldThrow` isEOFError
+
+  describe "Negotiation - peer disconnect (EOF harness)" $ do
+    -- Deterministic, in-process counterparts of the real-TCP disconnect
+    -- tests in FaultInjectionSpec: that suite asserts whole-node
+    -- survival over sockets; these assert the exact negotiation result
+    -- a disconnect must produce. All wrapped in 'timeout' because the
+    -- failure mode being guarded against is a hang.
+    it "initiator returns NoProtocol when the peer disconnects before replying" $ do
+      (streamA, streamB) <- mkEofStreamPair
+      streamClose streamB
+      result <- timeout 1000000 (negotiateInitiator streamA ["/noise"])
+      result `shouldBe` Just NoProtocol
+
+    it "initiator returns NoProtocol when the peer disconnects after the header, before answering the proposal" $ do
+      (streamA, streamB) <- mkEofStreamPair
+      -- Hand-rolled peer: echo the header, then hang up before the
+      -- initiator's protocol line is answered.
+      streamWrite streamB multistreamHeaderBytes
+      streamClose streamB
+      result <- timeout 1000000 (negotiateInitiator streamA ["/noise"])
+      result `shouldBe` Just NoProtocol
+
+    it "responder returns NoProtocol when the peer disconnects before sending anything" $ do
+      (streamA, streamB) <- mkEofStreamPair
+      streamClose streamA
+      result <- timeout 1000000 (negotiateResponder streamB ["/noise"])
+      result `shouldBe` Just NoProtocol
+
+    it "responder returns NoProtocol when the peer disconnects after the header, before proposing" $ do
+      (streamA, streamB) <- mkEofStreamPair
+      streamWrite streamA multistreamHeaderBytes
+      streamClose streamA
+      result <- timeout 1000000 (negotiateResponder streamB ["/noise"])
+      result `shouldBe` Just NoProtocol
+
+    it "responder returns NoProtocol on a truncated varint at EOF" $ do
+      (streamA, streamB) <- mkEofStreamPair
+      -- A single continuation byte, then the peer vanishes: EOF lands
+      -- inside the varint read loop.
+      streamWrite streamA (BS.singleton 0x80)
+      streamClose streamA
+      result <- timeout 1000000 (negotiateResponder streamB ["/noise"])
+      result `shouldBe` Just NoProtocol
+
+    it "responder returns NoProtocol on EOF in the middle of a protocol line" $ do
+      (streamA, streamB) <- mkEofStreamPair
+      -- Declared length 7, but only 3 payload bytes arrive before EOF.
+      streamWrite streamA (BS.pack [0x07, 0x2f, 0x6e, 0x6f])
+      streamClose streamA
       result <- timeout 1000000 (negotiateResponder streamB ["/noise"])
       result `shouldBe` Just NoProtocol
 

--- a/test/LibP2P/Noise/ForeignPeerSpec.hs
+++ b/test/LibP2P/Noise/ForeignPeerSpec.hs
@@ -13,13 +13,14 @@
 module LibP2P.Noise.ForeignPeerSpec (spec) where
 
 import Control.Concurrent.Async (concurrently, withAsync)
-import Control.Exception (IOException)
+import Control.Exception (IOException, try)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.List (isInfixOf)
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (KeyPair (..), PublicKey)
 import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.EofStream (mkEofStreamPair)
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..), mkMemoryStreamPair)
 import LibP2P.Noise.Handshake
   ( HandshakeResult (..)
@@ -44,7 +45,22 @@ import LibP2P.Switch.Upgrade
   , writeFramedMessage
   )
 import Data.IORef (newIORef)
+import System.Timeout (timeout)
 import Test.Hspec
+
+-- | Assert that an IO action fails with an 'IOException' within the
+-- given number of microseconds — neither hanging nor succeeding. The
+-- EOF failure mode being guarded against is a hang, so a plain
+-- 'shouldThrow' would be insufficient.
+shouldFailCleanlyWithin :: Int -> IO a -> Expectation
+shouldFailCleanlyWithin us action = do
+  result <- timeout us (try action)
+  case result of
+    Just (Left (_ :: IOException)) -> pure ()
+    Just (Right _) ->
+      expectationFailure "expected a clean failure, but the action succeeded"
+    Nothing ->
+      expectationFailure "expected a clean failure, but the action hung"
 
 -- | Generate a test identity (PeerId, KeyPair).
 mkTestIdentity :: IO (PeerId, KeyPair)
@@ -232,3 +248,79 @@ spec = do
       withAsync (eveResponder streamB) $ \_ ->
         performStreamHandshake kpA Outbound streamA
           `shouldThrow` isSignatureRejection
+
+  describe "Peer disconnect during the handshake (EOF harness)" $ do
+    -- Deterministic, in-process counterparts of the real-TCP disconnect
+    -- tests in FaultInjectionSpec (which assert whole-node survival
+    -- over sockets): here the assertion is that each handshake phase
+    -- fails cleanly — an IOException, not a hang and not a bogus
+    -- success — when the peer vanishes. The EOF-capable pair makes the
+    -- disconnect expressible in process; 'mkMemoryStreamPair' cannot
+    -- model it (reads on an empty queue block forever).
+    it "initiator fails cleanly when the peer disconnects before msg2" $ do
+      (_pidA, kpA) <- mkTestIdentity
+      (streamA, streamB) <- mkEofStreamPair
+      -- The peer hangs up immediately: msg1 is written into the open
+      -- direction, but the reply direction is already at EOF.
+      streamClose streamB
+      shouldFailCleanlyWithin 2000000 $
+        performStreamHandshake kpA Outbound streamA
+
+    it "initiator fails cleanly when the peer disconnects mid-frame of msg2" $ do
+      (_pidA, kpA) <- mkTestIdentity
+      (streamA, streamB) <- mkEofStreamPair
+      -- A frame header declaring 96 bytes, 10 bytes of payload, then
+      -- EOF: the disconnect lands inside 'readFramedMessage'.
+      streamWrite streamB (BS.pack [0x00, 0x60] <> BS.replicate 10 0xAA)
+      streamClose streamB
+      shouldFailCleanlyWithin 2000000 $
+        performStreamHandshake kpA Outbound streamA
+
+    it "responder fails cleanly when the peer disconnects before msg1" $ do
+      (_pidB, kpB) <- mkTestIdentity
+      (streamA, streamB) <- mkEofStreamPair
+      streamClose streamA
+      shouldFailCleanlyWithin 2000000 $
+        performStreamHandshake kpB Inbound streamB
+
+    it "responder fails cleanly when the peer disconnects after msg1, before msg3" $ do
+      -- A well-formed foreign initiator sends a real msg1 and then
+      -- hangs up: the responder consumes msg1, sends msg2 into the
+      -- still-open direction, and must fail cleanly awaiting msg3.
+      (_pidA, kpA) <- mkTestIdentity
+      (_pidB, kpB) <- mkTestIdentity
+      (streamA, streamB) <- mkEofStreamPair
+      (st0, _staticPub) <- initHandshakeInitiator kpA
+      (msg1, _st1) <- either fail pure $ writeHandshakeMsg st0 BS.empty
+      writeFramedMessage streamA msg1
+      streamClose streamA
+      shouldFailCleanlyWithin 2000000 $
+        performStreamHandshake kpB Inbound streamB
+
+    it "established connection: EOF mid-encrypted-frame is a clean error, not a partial read" $ do
+      (_pidA, kpA) <- mkTestIdentity
+      (_pidB, kpB) <- mkTestIdentity
+      (streamA, streamB) <- mkEofStreamPair
+      ((prodSess, _result), foreignSess) <-
+        concurrently
+          (performStreamHandshake kpA Outbound streamA)
+          (runForeignResponderSession kpB streamB)
+      -- Foreign peer sends one complete frame, then a frame whose
+      -- header declares the full ciphertext length but whose body is
+      -- cut off by the disconnect.
+      (ct1, fs1) <- either fail pure $ encryptMessage foreignSess "hello"
+      (ct2, _fs2) <- either fail pure $ encryptMessage fs1 "world!"
+      writeFramedMessage streamB ct1
+      streamWrite streamB
+        (BS.pack [0x00, fromIntegral (BS.length ct2)] <> BS.take 5 ct2)
+      streamClose streamB
+      sendRef <- newIORef prodSess
+      recvRef <- newIORef prodSess
+      bufRef <- newIORef BS.empty
+      let encryptedIO = noiseSessionToStreamIO sendRef recvRef bufRef streamA
+      -- The complete frame decrypts normally ...
+      got <- readExact encryptedIO 5
+      got `shouldBe` "hello"
+      -- ... and the truncated one surfaces as a clean error: no hang,
+      -- and no partially-read or corrupted plaintext handed to the app.
+      shouldFailCleanlyWithin 2000000 $ readExact encryptedIO 6

--- a/test/LibP2P/Noise/HandshakeSpec.hs
+++ b/test/LibP2P/Noise/HandshakeSpec.hs
@@ -210,6 +210,19 @@ spec = do
     it "fails on empty input" $
       decodeNoisePayload BS.empty `shouldSatisfy` isLeft
 
+    it "fails on a truncated tag (a lone field-1 tag byte)" $
+      -- A tag byte with nothing after it: neither a length nor a payload.
+      decodeNoisePayload (BS.singleton 0x0a) `shouldSatisfy` isLeft
+
+    it "buildHandshakePayload returns Left when the private key is malformed" $ do
+      -- A malformed identity key must surface as Left from pure code,
+      -- not abort the process (issue #166, item 3).
+      Right kp <- generateKeyPair
+      let badKP = kp {kpPrivate = PrivateKey Ed25519 (BS.replicate 10 0x00)}
+      case buildHandshakePayload badKP (BS.replicate 32 0xAA) of
+        Left err -> err `shouldContain` "buildHandshakePayload"
+        Right _ -> expectationFailure "expected Left for a malformed private key"
+
   describe "Noise XX handshake" $ do
     it "completes 3-message handshake between initiator and responder" $ do
       -- Generate identity key pairs for both peers


### PR DESCRIPTION
## Summary

Finishes what PR #199 listed as still open on #172:

### (a) EOF-capable stream harness — added here

`mkMemoryStreamPair` cannot model disconnection: `streamClose` is a no-op and a read on an empty queue blocks forever, so the "peer hangs up mid-conversation" class was inexpressible in process. New `test/LibP2P/EofStream.hs` provides `mkEofStreamPair` with TCP half-close semantics (`shutdown(SHUT_WR)`): closing a side's outgoing direction makes the peer's reads drain buffered bytes first, then throw EOF — exactly like a socket that received FIN. Writes into a closed direction fail too.

New tests, every one wrapped in `timeout` because the guarded failure mode is a hang. They are the deterministic, in-process counterparts of `FaultInjectionSpec` (PR #206), which asserts whole-node survival over real TCP; these assert the exact per-function result a disconnect must produce, with no duplication of the socket-level cases:

**mss (`NegotiationSpec`)** — harness sanity (buffered-bytes-then-EOF, immediate EOF, write-after-close), plus: initiator gets `NoProtocol` on EOF before the header reply and after the header but before the proposal answer; responder gets `NoProtocol` on EOF before anything, after the header, on a truncated varint at EOF, and mid protocol line.

**Noise handshake (`ForeignPeerSpec`)** — initiator fails cleanly (IOException, no hang, no bogus success) on EOF before msg2 and mid-frame of msg2; responder on EOF before msg1 and between a well-formed msg1 and msg3.

**Established connection** — a foreign peer sends one complete encrypted frame, then a frame header declaring the full length with the body cut off by EOF: the complete frame decrypts normally and the truncated one surfaces as a clean error — not a hang and not partial/corrupt plaintext handed to the application.

**Driven out by the tests (TDD, failing first):** `readVarint` let the EOF `IOException` escape `negotiateInitiator`/`negotiateResponder` instead of reporting `NoProtocol` — inconsistent with `readExactBounded`, which documents converting I/O failures to `Left`. The five mss disconnect tests were written first and observed failing with `uncaught exception: IOException of type EOF`; `readVarint` now catches `IOException` the same way. Mutation sanity check: making `readExact` retry forever on failure makes all five Noise EOF tests fail with "the action hung"; reverted before commit.

### (b) #166 lenient-protobuf items — verified closed by PR #210, coverage completed

Cross-checked #210's tests against what #172 asked for: field order 2-then-1, unknown-field skipping (extensions field 4 trailing, high-numbered varint between known fields, fixed32/fixed64), missing/truncated required fields, and empty transport messages between data frames are all covered on `main`. Two letter-items from the #172 table were implemented but untested; added here: `decodeNoisePayload` rejects a lone truncated tag byte, and `buildHandshakePayload` returns `Left` (not a process abort) on a malformed private key.

### (c) True heterogeneous conformance — out of scope

Remains delegated to #129 (`libp2p/unified-testing`), as stated in #172 and #199.

## Test plan

- `cabal build` and `cabal test` (GHC 9.10.3): **976 examples, 0 failures**
- TDD red run and hang-detection mutation check described above

Closes #172