### PR TITLE
test: close #174 remainder — decapsulate, parsing strictness, multihash cases, integration

### DIFF
--- a/src/LibP2P/Multiaddr.hs
+++ b/src/LibP2P/Multiaddr.hs
@@ -9,11 +9,13 @@ module LibP2P.Multiaddr
   , fromBytes
   , toBytes
   , encapsulate
+  , decapsulate
   , protocols
   , splitP2P
   ) where
 
 import Data.ByteString (ByteString)
+import Data.List (isPrefixOf, tails)
 import Data.Text (Text)
 import LibP2P.Crypto.PeerId (PeerId (..))
 import LibP2P.Multiaddr.Codec
@@ -47,6 +49,19 @@ toBytes (Multiaddr ps) = encodeProtocols ps
 -- | Encapsulate: append another multiaddr's protocols.
 encapsulate :: Multiaddr -> Multiaddr -> Multiaddr
 encapsulate (Multiaddr a) (Multiaddr b) = Multiaddr (a <> b)
+
+-- | Decapsulate: remove the last occurrence of the given suffix multiaddr
+-- and everything after it (specs/addressing). Returns the original
+-- multiaddr unchanged when the suffix does not occur. Decapsulating the
+-- empty multiaddr is a no-op, making 'decapsulate' a left inverse of
+-- 'encapsulate': @decapsulate (encapsulate a b) b == a@ for non-empty b.
+decapsulate :: Multiaddr -> Multiaddr -> Multiaddr
+decapsulate ma@(Multiaddr a) (Multiaddr b)
+  | null b = ma
+  | otherwise =
+      case [i | (i, suffix) <- zip [0 :: Int ..] (tails a), b `isPrefixOf` suffix] of
+        [] -> ma
+        matches -> Multiaddr (take (last matches) a)
 
 -- | Get the list of protocols in a multiaddr.
 protocols :: Multiaddr -> [Protocol]

--- a/src/LibP2P/Multiaddr/Codec.hs
+++ b/src/LibP2P/Multiaddr/Codec.hs
@@ -8,6 +8,7 @@ module LibP2P.Multiaddr.Codec
 
 import Data.Bits (shiftL, shiftR, (.&.))
 import Data.ByteString (ByteString)
+import Data.Char (isDigit)
 import qualified Data.ByteString as BS
 import Data.IP (IPv6, fromHostAddress6, toHostAddress6)
 import Data.Text (Text)
@@ -154,12 +155,20 @@ protocolsToText = T.concat . map renderOne
     renderBase58 = TE.decodeUtf8 . B58.encode
 
 -- | Parse human-readable text form to a list of protocols.
+--
+-- Strict per the multiaddr spec and go-multiaddr behaviour: the input
+-- must be non-empty, must begin with @/@, and must not contain empty
+-- components (so a bare @/@, doubled slashes, and trailing slashes are
+-- all rejected).
 textToProtocols :: Text -> Either String [Protocol]
 textToProtocols input
-  | T.null input = Right []
+  | T.null input = Left "textToProtocols: empty multiaddr"
+  | T.head input /= '/' = Left "textToProtocols: multiaddr must begin with /"
   | otherwise =
-      let parts = filter (not . T.null) $ T.splitOn "/" input
-       in parseParts parts
+      let parts = T.splitOn "/" (T.drop 1 input)
+       in if any T.null parts
+            then Left "textToProtocols: empty component in multiaddr"
+            else parseParts parts
   where
     parseParts :: [Text] -> Either String [Protocol]
     parseParts [] = Right []
@@ -217,16 +226,25 @@ textToProtocols input
       more <- parseParts rest
       Right (proto : more)
 
+    -- Strict dotted-decimal: exactly four octets, digits only (no sign,
+    -- hex, or whitespace), no leading zeros, each in 0..255. Matches
+    -- go-multiaddr, which rejects e.g. "010.0.0.1" and "-1.0.0.1".
     parseIPv4 :: Text -> Either String Word32
-    parseIPv4 t = case map (readMaybe . T.unpack) (T.splitOn "." t) of
-      [Just a, Just b, Just c, Just d]
-        | all (\x -> x <= (255 :: Int)) [a, b, c, d] ->
-            Right $
-              (fromIntegral a `shiftL` 24)
-                + (fromIntegral b `shiftL` 16)
-                + (fromIntegral c `shiftL` 8)
-                + fromIntegral d
+    parseIPv4 t = case mapM parseOctet (T.splitOn "." t) of
+      Just [a, b, c, d] ->
+        Right $
+          (fromIntegral a `shiftL` 24)
+            + (fromIntegral b `shiftL` 16)
+            + (fromIntegral c `shiftL` 8)
+            + fromIntegral d
       _ -> Left $ "textToProtocols: invalid IPv4 address: " <> T.unpack t
+
+    parseOctet :: Text -> Maybe Integer
+    parseOctet o
+      | T.length o > 1 && T.head o == '0' = Nothing -- no leading zeros
+      | otherwise = do
+          n <- parseDecimal o
+          if n <= 255 then Just n else Nothing
 
     -- | Parse IPv6 text (e.g. "::1", "fe80::1") to 16-byte ByteString.
     parseIPv6 :: Text -> Either String ByteString
@@ -235,11 +253,22 @@ textToProtocols input
         Just ipv6 -> Right (ipv6ToBytes ipv6)
         Nothing -> Left $ "textToProtocols: invalid IPv6 address: " <> T.unpack t
 
+    -- Strict decimal port: digits only (no sign, hex, or whitespace),
+    -- in 0..65535. Leading zeros are accepted, matching go-multiaddr's
+    -- strconv.ParseUint behaviour.
     parsePort :: Text -> Either String Word16
-    parsePort t = case readMaybe (T.unpack t) of
+    parsePort t = case parseDecimal t of
       Just n
-        | n >= (0 :: Int) && n <= 65535 -> Right (fromIntegral n)
+        | n <= 65535 -> Right (fromIntegral n)
       _ -> Left $ "textToProtocols: invalid port: " <> T.unpack t
+
+    -- Non-negative decimal, digits only. Parsed via Integer so absurdly
+    -- long digit strings cannot wrap around a fixed-width type.
+    parseDecimal :: Text -> Maybe Integer
+    parseDecimal t
+      | T.null t = Nothing
+      | not (T.all isDigit t) = Nothing
+      | otherwise = readMaybe (T.unpack t)
 
     -- | Parse a peer ID from text, accepting both base58btc and CIDv1 formats.
     -- Validates the decoded bytes as a well-formed multihash.

--- a/src/LibP2P/Transport/TCP.hs
+++ b/src/LibP2P/Transport/TCP.hs
@@ -27,37 +27,49 @@ newTCPTransport = pure $ Transport
   , transportCanDial = canDialTCP
   }
 
--- | Check if a multiaddr is a TCP address (/ip4/.../tcp/... or /ip6/.../tcp/...).
+-- | Drop a trailing /p2p/<peer-id> component if present. Identify- and
+-- DHT-learned addresses carry the peer ID suffix; the TCP transport
+-- connects to the transport portion only.
+stripP2P :: Multiaddr -> Multiaddr
+stripP2P (Multiaddr ps) = case reverse ps of
+  (P2P _ : rest) -> Multiaddr (reverse rest)
+  _ -> Multiaddr ps
+
+-- | Check if a multiaddr is a TCP address (/ip4/.../tcp/... or
+-- /ip6/.../tcp/...), optionally with a trailing /p2p/<peer-id> component.
 canDialTCP :: Multiaddr -> Bool
-canDialTCP (Multiaddr [IP4 _, TCP _]) = True
-canDialTCP (Multiaddr [IP6 _, TCP _]) = True
-canDialTCP _ = False
+canDialTCP addr = case stripP2P addr of
+  Multiaddr [IP4 _, TCP _] -> True
+  Multiaddr [IP6 _, TCP _] -> True
+  _ -> False
 
 -- | Extract (HostName, ServiceName) from a TCP multiaddr.
+-- A trailing /p2p/<peer-id> component is ignored.
 multiaddrToHostPort :: Multiaddr -> Either String (String, String)
-multiaddrToHostPort (Multiaddr [IP4 w, TCP port]) =
-  Right (renderIPv4 w, show port)
-multiaddrToHostPort (Multiaddr [IP6 bs, TCP port]) =
-  Right (renderIPv6 bs, show port)
-multiaddrToHostPort _ =
-  Left "multiaddrToHostPort: expected /ip4/.../tcp/... or /ip6/.../tcp/..."
+multiaddrToHostPort addr = case stripP2P addr of
+  Multiaddr [IP4 w, TCP port] -> Right (renderIPv4 w, show port)
+  Multiaddr [IP6 bs, TCP port] -> Right (renderIPv6 bs, show port)
+  _ -> Left "multiaddrToHostPort: expected /ip4/.../tcp/... or /ip6/.../tcp/..."
 
 -- | Dial a TCP address by directly constructing a SockAddr from the Multiaddr.
+-- A trailing /p2p/<peer-id> component is stripped before connecting; the
+-- original (unstripped) multiaddr is kept as the connection's remote address.
 tcpDial :: Multiaddr -> IO RawConnection
-tcpDial addr@(Multiaddr [IP4 w, TCP port]) = do
-  let hostAddr = NS.tupleToHostAddress (octet 3 w, octet 2 w, octet 1 w, octet 0 w)
-      sockAddr = NS.SockAddrInet (fromIntegral port) hostAddr
-  sock <- NS.socket NS.AF_INET NS.Stream NS.defaultProtocol
-  NS.connect sock sockAddr
-  mkRawConnection sock addr
-tcpDial addr@(Multiaddr [IP6 bs, TCP port]) = do
-  let ipv6 = bytesToIPv6 bs
-      hostAddr6 = toHostAddress6 ipv6
-      sockAddr = NS.SockAddrInet6 (fromIntegral port) 0 hostAddr6 0
-  sock <- NS.socket NS.AF_INET6 NS.Stream NS.defaultProtocol
-  NS.connect sock sockAddr
-  mkRawConnection sock addr
-tcpDial _ = fail "tcpDial: unsupported multiaddr"
+tcpDial addr = case stripP2P addr of
+  Multiaddr [IP4 w, TCP port] -> do
+    let hostAddr = NS.tupleToHostAddress (octet 3 w, octet 2 w, octet 1 w, octet 0 w)
+        sockAddr = NS.SockAddrInet (fromIntegral port) hostAddr
+    sock <- NS.socket NS.AF_INET NS.Stream NS.defaultProtocol
+    NS.connect sock sockAddr
+    mkRawConnection sock addr
+  Multiaddr [IP6 bs, TCP port] -> do
+    let ipv6 = bytesToIPv6 bs
+        hostAddr6 = toHostAddress6 ipv6
+        sockAddr = NS.SockAddrInet6 (fromIntegral port) 0 hostAddr6 0
+    sock <- NS.socket NS.AF_INET6 NS.Stream NS.defaultProtocol
+    NS.connect sock sockAddr
+    mkRawConnection sock addr
+  _ -> fail "tcpDial: unsupported multiaddr"
 
 -- | Create a RawConnection from a connected socket.
 mkRawConnection :: NS.Socket -> Multiaddr -> IO RawConnection

--- a/test/LibP2P/Core/MultihashSpec.hs
+++ b/test/LibP2P/Core/MultihashSpec.hs
@@ -3,6 +3,7 @@ module LibP2P.Core.MultihashSpec (spec) where
 import qualified Data.ByteString as BS
 import Data.Word (Word8)
 import LibP2P.Core.Multihash
+import LibP2P.Core.Varint (encodeUvarint)
 import Test.Hspec
 import Test.QuickCheck
 
@@ -29,10 +30,20 @@ spec = do
       -- 0x00 + 0x03 + original data
       result `shouldBe` BS.pack [0x00, 0x03, 0x01, 0x02, 0x03]
 
-    it "SHA-256 of empty input produces valid multihash" $ do
-      let result = encodeMultihash SHA256 BS.empty
-      BS.take 2 result `shouldBe` BS.pack [0x12, 0x20]
-      BS.length result `shouldBe` 34
+    it "encodes SHA-256 of empty input to the known vector" $ do
+      -- SHA-256("") = e3b0c442 98fc1c14 9afbf4c8 996fb924 27ae41e4 649b934c a495991b 7852b855
+      let expectedDigest = BS.pack
+            [ 0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14
+            , 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24
+            , 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c
+            , 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55
+            ]
+      encodeMultihash SHA256 BS.empty `shouldBe` BS.pack [0x12, 0x20] <> expectedDigest
+
+    it "encodes a 200-byte identity digest with a 2-byte length varint" $ do
+      let input = BS.replicate 200 0x42
+      -- varint(200) = 0xc8 0x01
+      encodeMultihash Identity input `shouldBe` BS.pack [0x00, 0xc8, 0x01] <> input
 
   describe "decodeMultihash" $ do
     it "decodes identity multihash" $ do
@@ -55,6 +66,22 @@ spec = do
       -- Claims 5 bytes but only 2 available
       let encoded = BS.pack [0x00, 0x05, 0xAA, 0xBB]
       decodeMultihash encoded `shouldSatisfy` isLeft
+
+    it "rejects a multihash claiming a digest length larger than the input" $ do
+      -- Declared length 2^63-1 with zero digest bytes: must not decode
+      -- as an empty digest via Int truncation.
+      let encoded = BS.pack [0x00] <> encodeUvarint (2 ^ (63 :: Int) - 1)
+      decodeMultihash encoded `shouldSatisfy` isLeft
+      validateMultihash encoded `shouldSatisfy` isLeft
+
+    it "never succeeds when the declared length exceeds the available bytes" $
+      property $
+        forAll (chooseInt (0, 200)) $ \avail ->
+          forAll (chooseInt (avail + 1, avail + 300)) $ \declared ->
+            let mh = BS.pack [0x00]
+                    <> encodeUvarint (fromIntegral declared)
+                    <> BS.replicate avail 0xAA
+             in isLeft (decodeMultihash mh) && isLeft (validateMultihash mh)
 
   describe "round-trip property" $ do
     it "decode(encode(Identity, data)) == (Identity, data)" $
@@ -89,6 +116,11 @@ spec = do
     it "rejects Identity multihash with digest > 42 bytes" $ do
       let mh = BS.pack [0x00, 0x2B] <> BS.replicate 43 0x42  -- 43 bytes
       validateMultihash mh `shouldSatisfy` isLeft
+
+    it "accepts Identity multihash with digest of exactly 42 bytes" $ do
+      let digest = BS.replicate 42 0x42
+      let mh = BS.pack [0x00, 0x2A] <> digest
+      validateMultihash mh `shouldBe` Right (Identity, digest)
 
     it "rejects multihash with trailing bytes" $ do
       -- Valid SHA-256 multihash + extra byte

--- a/test/LibP2P/Multiaddr/MultiaddrSpec.hs
+++ b/test/LibP2P/Multiaddr/MultiaddrSpec.hs
@@ -1,15 +1,19 @@
 module LibP2P.Multiaddr.MultiaddrSpec (spec) where
 
+import Data.ByteArray.Encoding (Base (Base32), convertToBase)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base58 as B58
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import Data.Word (Word64)
 import LibP2P.Core.Varint (encodeUvarint)
-import LibP2P.Crypto.PeerId (PeerId (..))
+import LibP2P.Crypto.PeerId (PeerId (..), toCIDv1)
 import LibP2P.Multiaddr.Codec
 import LibP2P.Multiaddr
 import LibP2P.Multiaddr.Protocol
 import Test.Hspec
+import Test.QuickCheck
 
 spec :: Spec
 spec = do
@@ -229,6 +233,210 @@ spec = do
       let invalidMh = BS.pack [0xDE, 0xAD]  -- unknown hash code 0xDE
       let encoded = encodeUvarint 421 <> encodeUvarint (fromIntegral (BS.length invalidMh)) <> invalidMh
       decodeProtocols encoded `shouldSatisfy` isLeft
+
+  describe "Text parsing strictness" $ do
+    it "rejects the empty string" $
+      textToProtocols "" `shouldSatisfy` isLeft
+
+    it "rejects a bare slash" $
+      textToProtocols "/" `shouldSatisfy` isLeft
+
+    it "rejects a multiaddr without a leading slash" $
+      textToProtocols "ip4/127.0.0.1/tcp/4001" `shouldSatisfy` isLeft
+
+    it "rejects doubled slashes" $
+      textToProtocols "//ip4/127.0.0.1/tcp/4001" `shouldSatisfy` isLeft
+
+    it "rejects a trailing slash" $
+      textToProtocols "/ip4/127.0.0.1/tcp/4001/" `shouldSatisfy` isLeft
+
+    it "rejects an IPv4 octet above 255" $
+      textToProtocols "/ip4/256.0.0.1/tcp/4001" `shouldSatisfy` isLeft
+
+    it "rejects a negative IPv4 octet" $
+      textToProtocols "/ip4/-1.0.0.1/tcp/4001" `shouldSatisfy` isLeft
+
+    it "rejects an IPv4 octet with leading zeros" $
+      textToProtocols "/ip4/010.0.0.1/tcp/4001" `shouldSatisfy` isLeft
+
+    it "rejects a hexadecimal IPv4 octet" $
+      textToProtocols "/ip4/0xff.0.0.1/tcp/4001" `shouldSatisfy` isLeft
+
+    it "rejects an IPv4 address with fewer than four octets" $
+      textToProtocols "/ip4/1.2.3/tcp/4001" `shouldSatisfy` isLeft
+
+    it "rejects an IPv4 address with more than four octets" $
+      textToProtocols "/ip4/1.2.3.4.5/tcp/4001" `shouldSatisfy` isLeft
+
+    it "accepts 0.0.0.0 and 255.255.255.255" $ do
+      textToProtocols "/ip4/0.0.0.0/tcp/4001"
+        `shouldBe` Right [IP4 0x00000000, TCP 4001]
+      textToProtocols "/ip4/255.255.255.255/tcp/4001"
+        `shouldBe` Right [IP4 0xffffffff, TCP 4001]
+
+    it "rejects a TCP port above 65535" $
+      textToProtocols "/ip4/127.0.0.1/tcp/65536" `shouldSatisfy` isLeft
+
+    it "rejects a negative TCP port" $
+      textToProtocols "/ip4/127.0.0.1/tcp/-1" `shouldSatisfy` isLeft
+
+    it "rejects a hexadecimal TCP port" $
+      textToProtocols "/ip4/127.0.0.1/tcp/0x50" `shouldSatisfy` isLeft
+
+    it "rejects a non-numeric TCP port" $
+      textToProtocols "/ip4/127.0.0.1/tcp/port" `shouldSatisfy` isLeft
+
+    it "accepts ports 0 and 65535" $ do
+      textToProtocols "/ip4/127.0.0.1/tcp/0" `shouldBe` Right [IP4 0x7f000001, TCP 0]
+      textToProtocols "/ip4/127.0.0.1/tcp/65535" `shouldBe` Right [IP4 0x7f000001, TCP 65535]
+
+    it "accepts a port with leading zeros (go-multiaddr compatible)" $
+      textToProtocols "/ip4/127.0.0.1/tcp/0080" `shouldBe` Right [IP4 0x7f000001, TCP 80]
+
+    it "rejects a malformed IPv6 literal" $ do
+      textToProtocols "/ip6/zzzz" `shouldSatisfy` isLeft
+      textToProtocols "/ip6/1:2:3" `shouldSatisfy` isLeft
+
+  describe "Binary decoding strictness" $ do
+    it "rejects trailing garbage after a valid component" $ do
+      let bytes = BS.pack [0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x0f, 0xa1, 0x00]
+      decodeProtocols bytes `shouldSatisfy` isLeft
+      fromBytes bytes `shouldSatisfy` isLeft
+
+    it "rejects truncated ip4 address bytes" $
+      decodeProtocols (BS.pack [0x04, 0x7f, 0x00]) `shouldSatisfy` isLeft
+
+    it "rejects truncated tcp port bytes" $
+      decodeProtocols (BS.pack [0x06, 0x0f]) `shouldSatisfy` isLeft
+
+    it "rejects a varint-prefixed component shorter than its declared length" $ do
+      let bytes = encodeUvarint 53 <> encodeUvarint 5 <> "ab"
+      decodeProtocols bytes `shouldSatisfy` isLeft
+
+    it "rejects invalid UTF-8 in a dns component" $ do
+      let bytes = encodeUvarint 53 <> encodeUvarint 2 <> BS.pack [0xff, 0xfe]
+      decodeProtocols bytes `shouldSatisfy` isLeft
+
+  describe "P2P multihash forms" $ do
+    let idMH = BS.pack $ [0x00, 0x24, 0x08, 0x01, 0x12, 0x20] <> replicate 32 0xAB
+        idB58 = TE.decodeUtf8 (B58.encode idMH)
+
+    it "parses /p2p/<CIDv1> and /p2p/<base58btc> to the same component" $ do
+      let cid = toCIDv1 (PeerId idMH)
+      textToProtocols ("/p2p/" <> cid) `shouldBe` Right [P2P idMH]
+      textToProtocols ("/p2p/" <> cid) `shouldBe` textToProtocols ("/p2p/" <> idB58)
+
+    it "renders an identity-hash peer id back as base58btc, even when parsed from CIDv1" $ do
+      let cid = toCIDv1 (PeerId idMH)
+      case textToProtocols ("/p2p/" <> cid) of
+        Right ps -> protocolsToText ps `shouldBe` ("/p2p/" <> idB58)
+        Left err -> expectationFailure err
+
+    it "rejects a CIDv1 with a non-libp2p-key codec" $ do
+      -- codec 0x55 (raw) instead of 0x72 (libp2p-key)
+      textToProtocols ("/p2p/" <> mkCIDText 1 0x55 idMH) `shouldSatisfy` isLeft
+
+    it "rejects a CIDv1 wrapping an invalid multihash" $
+      textToProtocols ("/p2p/" <> mkCIDText 1 0x72 (BS.pack [0xDE, 0xAD]))
+        `shouldSatisfy` isLeft
+
+    it "binary round-trips a p2p component with an identity multihash at the 42-byte boundary" $ do
+      let mh = BS.pack $ [0x00, 0x2A] <> replicate 42 0x42
+      decodeProtocols (encodeProtocols [P2P mh]) `shouldBe` Right [P2P mh]
+
+    it "binary rejects a p2p component with an identity digest above 42 bytes" $ do
+      let mh = BS.pack $ [0x00, 0x2B] <> replicate 43 0x42
+          bytes = encodeUvarint 421 <> encodeUvarint (fromIntegral (BS.length mh)) <> mh
+      decodeProtocols bytes `shouldSatisfy` isLeft
+
+    it "binary round-trips a p2p component with a SHA-256 multihash" $ do
+      let mh = BS.pack $ [0x12, 0x20] <> replicate 32 0xCD
+      decodeProtocols (encodeProtocols [P2P mh]) `shouldBe` Right [P2P mh]
+
+  describe "decapsulate" $ do
+    let relayed =
+          Multiaddr
+            [ IP4 0x7f000001
+            , TCP 4001
+            , P2PCircuit
+            , P2P (BS.pack ([0x12, 0x20] <> replicate 32 0x01))
+            ]
+
+    it "removes the suffix and everything after it" $
+      decapsulate relayed (Multiaddr [P2PCircuit])
+        `shouldBe` Multiaddr [IP4 0x7f000001, TCP 4001]
+
+    it "removes from the last occurrence of the suffix" $ do
+      let ma = Multiaddr [WS, TCP 1, WS, TCP 2]
+      decapsulate ma (Multiaddr [WS]) `shouldBe` Multiaddr [WS, TCP 1]
+
+    it "returns the original when the suffix is absent" $ do
+      let ma = Multiaddr [IP4 0x7f000001, TCP 4001]
+      decapsulate ma (Multiaddr [WS]) `shouldBe` ma
+
+    it "decapsulating by the empty multiaddr is a no-op" $
+      decapsulate relayed (Multiaddr []) `shouldBe` relayed
+
+    it "splits a relayed address on /p2p-circuit" $ do
+      let relayTransport = decapsulate relayed (Multiaddr [P2PCircuit])
+      encapsulate relayTransport (Multiaddr [P2PCircuit]) `shouldBe`
+        Multiaddr [IP4 0x7f000001, TCP 4001, P2PCircuit]
+
+    it "is a left inverse of encapsulate (property)" $
+      property $
+        forAll ((,) <$> listOf genProtocol <*> listOf1 genProtocol) $ \(a, b) ->
+          decapsulate (encapsulate (Multiaddr a) (Multiaddr b)) (Multiaddr b)
+            === Multiaddr a
+
+  describe "Property: binary round-trip" $ do
+    it "decode(encode(ps)) == ps for arbitrary protocol stacks" $
+      property $
+        forAll (listOf genProtocol) $ \ps ->
+          decodeProtocols (encodeProtocols ps) === Right ps
+
+    it "fromBytes(toBytes(ma)) == ma for arbitrary multiaddrs" $
+      property $
+        forAll (listOf genProtocol) $ \ps ->
+          fromBytes (toBytes (Multiaddr ps)) === Right (Multiaddr ps)
+
+-- | Generate a protocol component whose binary form is canonical
+-- (valid multihash for p2p, valid UTF-8 dns names).
+genProtocol :: Gen Protocol
+genProtocol =
+  oneof
+    [ IP4 <$> arbitrary
+    , IP6 . BS.pack <$> vector 16
+    , TCP <$> arbitrary
+    , UDP <$> arbitrary
+    , P2P <$> genIdentityMultihash
+    , DNS <$> genDnsName
+    , DNS4 <$> genDnsName
+    , DNS6 <$> genDnsName
+    , DNSAddr <$> genDnsName
+    , pure QuicV1
+    , pure WS
+    , pure WSS
+    , pure P2PCircuit
+    , pure WebTransport
+    , pure NoiseProto
+    ]
+  where
+    genIdentityMultihash = do
+      n <- chooseInt (0, 42)
+      bytes <- vector n
+      pure (BS.pack (0x00 : fromIntegral n : bytes))
+    genDnsName =
+      T.pack <$> listOf1 (elements (['a' .. 'z'] ++ ['0' .. '9'] ++ "-."))
+
+-- | Build a CIDv1 text form ('b' + base32lower, no padding) with an
+-- arbitrary version, codec and multihash payload.
+mkCIDText :: Word64 -> Word64 -> BS.ByteString -> Text
+mkCIDText version codec mh =
+  let bytes = encodeUvarint version <> encodeUvarint codec <> mh
+      b32 = convertToBase Base32 bytes :: BS.ByteString
+      noPad = BS.filter (/= 0x3D) b32
+      lower = BS.map (\w -> if w >= 0x41 && w <= 0x5A then w + 32 else w) noPad
+   in "b" <> TE.decodeUtf8 lower
 
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True

--- a/test/LibP2P/Switch/ListenImplSpec.hs
+++ b/test/LibP2P/Switch/ListenImplSpec.hs
@@ -12,7 +12,7 @@ import Control.Exception (SomeException, try)
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (KeyPair, publicKey)
 import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
-import LibP2P.Multiaddr (Multiaddr (..))
+import LibP2P.Multiaddr (Multiaddr (..), fromBytes, fromText, toBytes, toText)
 import LibP2P.Multiaddr.Protocol (Protocol (..))
 import LibP2P.Switch.ConnPool (lookupConn)
 import LibP2P.Switch.Dial (dial)
@@ -60,6 +60,19 @@ spec = do
       case addrs of
         [Multiaddr [IP4 0x7f000001, TCP port]] -> port `shouldSatisfy` (> 0)
         _ -> expectationFailure $ "unexpected address: " ++ show addrs
+      switchClose sw
+
+    it "reported listen address round-trips through the text and binary codecs" $ do
+      -- Integration: the multiaddr the Switch reports after binding must
+      -- survive parse/render unchanged, so peers can dial exactly what
+      -- identify advertises.
+      (sw, _pid, _kp) <- mkTestSwitch
+      addrs <- switchListen sw defaultConnectionGater [loopbackAddr]
+      case addrs of
+        [addr] -> do
+          fromText (toText addr) `shouldBe` Right addr
+          fromBytes (toBytes addr) `shouldBe` Right addr
+        _ -> expectationFailure $ "unexpected addresses: " ++ show addrs
       switchClose sw
 
     it "binds on multiple addresses and returns all resolved addresses" $ do

--- a/test/LibP2P/Transport/TCPSpec.hs
+++ b/test/LibP2P/Transport/TCPSpec.hs
@@ -4,7 +4,8 @@ import Control.Concurrent.Async (concurrently)
 import Control.Exception (SomeException, try)
 import qualified Data.ByteString as BS
 import Data.Word (Word8)
-import LibP2P.Multiaddr (fromText)
+import LibP2P.Multiaddr (Multiaddr (..), encapsulate, fromText)
+import LibP2P.Multiaddr.Protocol (Protocol (..))
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
 import LibP2P.Transport.TCP (multiaddrToHostPort, newTCPTransport)
 import LibP2P.Transport
@@ -21,11 +22,26 @@ spec = do
       let Right addr = fromText "/ip6/::1/tcp/8080"
       multiaddrToHostPort addr `shouldBe` Right ("::1", "8080")
 
+    it "ignores a trailing /p2p component" $ do
+      let addr = Multiaddr [IP4 0x7f000001, TCP 8080, P2P testPeerIdMH]
+      multiaddrToHostPort addr `shouldBe` Right ("127.0.0.1", "8080")
+
   describe "transportCanDial" $ do
     it "returns True for /ip4/127.0.0.1/tcp/4001" $ do
       transport <- newTCPTransport
       let Right addr = fromText "/ip4/127.0.0.1/tcp/4001"
       transportCanDial transport addr `shouldBe` True
+
+    it "returns True for a TCP address with a trailing /p2p component" $ do
+      -- Identify- and DHT-learned addresses carry the /p2p suffix; the
+      -- transport must still recognise them as dialable.
+      transport <- newTCPTransport
+      let addr = Multiaddr [IP4 0x7f000001, TCP 4001, P2P testPeerIdMH]
+      transportCanDial transport addr `shouldBe` True
+
+    it "returns False for a /p2p component alone" $ do
+      transport <- newTCPTransport
+      transportCanDial transport (Multiaddr [P2P testPeerIdMH]) `shouldBe` False
 
   describe "Loopback" $ do
     it "listen on /ip4/127.0.0.1/tcp/0, dial, exchange data" $ do
@@ -46,6 +62,25 @@ spec = do
       streamWrite serverIO "world"
       received2 <- BS.pack <$> mapM (const (streamReadByte clientIO)) [1 :: Int .. 5]
       received2 `shouldBe` "world"
+      rcClose clientConn
+      rcClose serverConn
+      listenerClose listener
+
+    it "dials an address with a trailing /p2p component (suffix stripped before connect)" $ do
+      transport <- newTCPTransport
+      let Right listenAddr = fromText "/ip4/127.0.0.1/tcp/0"
+      listener <- transportListen transport listenAddr
+      let boundAddr = listenerAddr listener
+          dialAddr = encapsulate boundAddr (Multiaddr [P2P testPeerIdMH])
+      (serverConn, clientConn) <-
+        concurrently
+          (listenerAccept listener)
+          (transportDial transport dialAddr)
+      -- The connection works and the remote addr keeps the /p2p suffix
+      streamWrite (rcStreamIO clientConn) "x"
+      b <- streamReadByte (rcStreamIO serverConn)
+      BS.singleton b `shouldBe` "x"
+      rcRemoteAddr clientConn `shouldBe` dialAddr
       rcClose clientConn
       rcClose serverConn
       listenerClose listener
@@ -80,4 +115,8 @@ spec = do
         Right conn -> do
           rcClose conn
           expectationFailure "Expected dial to fail"
+
+-- | An Ed25519-shaped identity multihash usable as a /p2p component.
+testPeerIdMH :: BS.ByteString
+testPeerIdMH = BS.pack $ [0x00, 0x24, 0x08, 0x01, 0x12, 0x20] <> replicate 32 0xAB
 


### PR DESCRIPTION
## Summary

Closes out the remainder of #174 left open by PR #203: `decapsulate`, multihash cases, text-parsing strictness, and integration coverage through the real dial/listen path. Small src additions plus 55 new test examples (1008 total, 0 failures with GHC 9.10.3).

## New src behaviour

**`Multiaddr.decapsulate`** (`src/LibP2P/Multiaddr.hs`) — per specs/addressing: removes the *last* occurrence of the given suffix and everything after it; returns the original when absent; left inverse of `encapsulate` (pinned by a QuickCheck property). Splits relayed addresses on `/p2p-circuit`.

**TCP dial path accepts a trailing `/p2p` component** (`src/LibP2P/Transport/TCP.hs`) — `canDialTCP`, `multiaddrToHostPort`, and `tcpDial` now strip a trailing `/p2p/<peer-id>` before connecting (original address kept as the connection's remote addr). Identify- and DHT-learned addresses carry this suffix and previously always failed to dial. Verified end-to-end against a real listener.

## Parser behaviour changes (each pinned by a test)

`textToProtocols` (`src/LibP2P/Multiaddr/Codec.hs`) was lenient; it now matches go-multiaddr:

- **Empty string, bare `/`, doubled slashes, trailing slash rejected** — previously all parsed (empty segments were silently filtered).
- **Missing leading slash rejected** — `ip4/127.0.0.1/tcp/4001` previously parsed.
- **IPv4 octets are strict dotted-decimal**: `-1.0.0.1` previously *passed* validation (the octet check had no lower bound) and encoded garbage bytes; `010.0.0.1` parsed as `10.0.0.1`; `0xff.0.0.1` parsed via Haskell's hex literal syntax. All now rejected.
- **Ports are strict decimal digits**: `0x50` previously parsed as port 80. Digits-only, parsed via `Integer` so long digit strings cannot wrap a fixed-width type. Leading zeros still accepted (`strconv.ParseUint` compatible).

No callers relied on the lenient forms (all in-repo multiaddr text uses canonical leading-slash form).

## New tests

- **decapsulate** (6): suffix removal, last-occurrence, absent-suffix no-op, `/p2p-circuit` split, empty-suffix no-op, left-inverse property.
- **Text strictness** (18): the rejections above, plus accepting boundaries `0.0.0.0` / `255.255.255.255`, ports 0/65535, malformed IPv6 literals.
- **Binary strictness** (5): trailing garbage after a valid component, truncated ip4/tcp/varint-prefixed bytes, invalid UTF-8 in a dns component (`decodeUtf8Safe` was untested).
- **P2P multihash forms** (6): `/p2p/<CIDv1>` ≡ `/p2p/<base58btc>`, wrong-codec CIDv1 (0x55 raw) and invalid-multihash CIDv1 rejected, canonical base58 rendering after CIDv1 parse, identity 42-byte boundary accept + 43-byte reject in binary p2p components, SHA-256 multihash round-trip.
- **Multihash** (5): SHA-256("") known vector `e3b0...b855`, 200-byte identity digest with 2-byte length varint, exactly-42-byte identity accept, absurd declared-length rejection (2^63-1 unit + QuickCheck property over declared > available).
- **Properties**: first `Arbitrary`-style generator for `Protocol`; binary round-trip over arbitrary protocol stacks; `fromBytes`/`toBytes` (previously never called in tests).
- **Integration**: real-listener dial of `/ip4/127.0.0.1/tcp/<port>/p2p/<id>` at the transport layer; Switch-level check that the listen address reported by `switchListen` round-trips unchanged through both text and binary codecs.

## Verification

- TDD sanity check: flipped `decapsulate` to use the *first* occurrence — the last-occurrence test fails with `expected: Multiaddr [WS,TCP 1] / but got: Multiaddr []`; reverted before committing.
- `cabal build` + `cabal test` (GHC 9.10.3): **1008 examples, 0 failures**.

## Still open from #174

certhash (466) / tls (448) / sni (449) / http (480) protocols are not implemented, so their table rows and parse tests remain; Ed25519 PeerId encoding vectors and non-minimal-varint PeerId aliasing belong to the peer-id vector work (#176).

Refs #174