### PR TITLE
fix(gossipsub): floodsub compatibility — negotiate /floodsub/1.0.0 and flood to floodsub peers

### DIFF
--- a/src/LibP2P/Protocol/GossipSub/Handler.hs
+++ b/src/LibP2P/Protocol/GossipSub/Handler.hs
@@ -26,6 +26,7 @@ module LibP2P.Protocol.GossipSub.Handler
     -- * Constants
   , gossipSubProtocolId
   , gossipSubProtocolIdV10
+  , floodSubProtocolId
   ) where
 
 import Control.Concurrent.Async (Async, async, cancel)
@@ -91,14 +92,22 @@ gossipSubProtocolId = "/meshsub/1.1.0"
 gossipSubProtocolIdV10 :: ProtocolId
 gossipSubProtocolIdV10 = "/meshsub/1.0.0"
 
+-- | FloodSub protocol ID, advertised alongside the meshsub protocols so
+-- that floodsub-only peers still get a pubsub stream (#157,
+-- gossipsub-v1.0.md "Compatibility with FloodSub").
+floodSubProtocolId :: ProtocolId
+floodSubProtocolId = "/floodsub/1.0.0"
+
 -- | All protocol IDs we register and offer, preferred first.
 gossipSubProtocolIds :: [ProtocolId]
-gossipSubProtocolIds = [gossipSubProtocolId, gossipSubProtocolIdV10]
+gossipSubProtocolIds =
+  [gossipSubProtocolId, gossipSubProtocolIdV10, floodSubProtocolId]
 
 -- | Map a negotiated protocol ID to the peer's protocol version.
 protocolFor :: ProtocolId -> PeerProtocol
 protocolFor proto
   | proto == gossipSubProtocolIdV10 = GossipSubV10Peer
+  | proto == floodSubProtocolId     = FloodSubPeer
   | otherwise                       = GossipSubPeer
 
 -- | A GossipSub node: Router + Switch integration.

--- a/src/LibP2P/Protocol/GossipSub/Heartbeat.hs
+++ b/src/LibP2P/Protocol/GossipSub/Heartbeat.hs
@@ -130,6 +130,7 @@ fillUndersubscribed router topic meshPeers now = do
                            , Set.member topic (psTopics ps)
                            , not (Set.member pid meshPeers)
                            , not (Set.member pid direct)  -- never graft direct peers
+                           , psProtocol ps /= FloodSubPeer  -- floodsub peers have no mesh (#157)
                            , not (isInBackoff backoffMap pid topic now)
                            , computeScore (gsScoreParams router) pid ps ipMap now >= 0
                            ]
@@ -224,6 +225,7 @@ fanoutMaintenance router = do
                                , Set.member topic (psTopics ps)
                                , not (Set.member pid fanoutPeers)
                                , not (Set.member pid direct)
+                               , psProtocol ps /= FloodSubPeer  -- flooded, never fanout members (#157)
                                ]
           let needed = d - Set.size fanoutPeers
           selected <- sampleIO (min needed (length eligible)) eligible
@@ -257,11 +259,13 @@ emitGossip router = do
       let meshPeers = Map.findWithDefault Set.empty topic meshMap
           -- Eligible: subscribed to topic, not in mesh, and scoring at or
           -- above the gossip threshold — no gossip is emitted towards
-          -- peers below it (gossipsub-v1.1.md gossip threshold)
+          -- peers below it (gossipsub-v1.1.md gossip threshold). Floodsub
+          -- peers never receive control messages, IHAVE included (#157).
           gossipThreshold = stGossipThreshold (gsThresholds router)
           nonMeshPeers = [ pid | (pid, ps) <- Map.toList peersMap
                                , Set.member topic (psTopics ps)
                                , not (Set.member pid meshPeers)
+                               , psProtocol ps /= FloodSubPeer
                                , computeScore (gsScoreParams router) pid ps ipMap now
                                    >= gossipThreshold
                                ]

--- a/src/LibP2P/Protocol/GossipSub/Router.hs
+++ b/src/LibP2P/Protocol/GossipSub/Router.hs
@@ -201,6 +201,26 @@ directTopicPeers router peers topic =
     Just ps -> Set.member topic (psTopics ps)
     Nothing -> False) (paramDirectPeers (gsParams router))
 
+-- FloodSub peers (gossipsub-v1.0.md "Compatibility with FloodSub")
+
+-- | True when the peer negotiated /floodsub/1.0.0. Floodsub peers have
+-- no mesh and understand no gossipsub control messages: they are flooded
+-- every message for topics they subscribe to and must never be grafted,
+-- pruned or gossiped to.
+isFloodSubPeer :: Map.Map PeerId PeerState -> PeerId -> Bool
+isFloodSubPeer peers pid = case Map.lookup pid peers of
+  Just ps -> psProtocol ps == FloodSubPeer
+  Nothing -> False
+
+-- | Known floodsub peers subscribed to the topic. They receive every
+-- published and forwarded message for it (flooding).
+floodSubTopicPeers :: Map.Map PeerId PeerState -> Topic -> Set.Set PeerId
+floodSubTopicPeers peers topic =
+  Map.foldlWithKey' (\acc pid ps ->
+    if psProtocol ps == FloodSubPeer && Set.member topic (psTopics ps)
+    then Set.insert pid acc
+    else acc) Set.empty peers
+
 -- Protocol version gating
 
 -- | True when the peer negotiated /meshsub/1.1.0. Unknown peers are
@@ -256,12 +276,14 @@ join router topic = do
     let currentMesh = Map.findWithDefault Set.empty topic meshNow
     peerMap <- readTVar (gsPeers router)
     -- Direct peers are never mesh candidates (gossipsub-v1.1.md
-    -- explicit peering agreements)
+    -- explicit peering agreements); neither are floodsub peers, which
+    -- have no mesh and would not understand the GRAFT (#157)
     let eligible = Map.foldlWithKey' (\acc pid ps ->
           if Set.member topic (psTopics ps)
              && not (Set.member pid currentMesh)
              && pid /= gsLocalPeerId router
              && not (isDirectPeer router pid)
+             && psProtocol ps /= FloodSubPeer
           then Set.insert pid acc
           else acc) Set.empty peerMap
     pure (foPeers, eligible)
@@ -364,18 +386,21 @@ publish router topic payload mKeyPair = do
             else acc) [] peers
       mapM_ (\pid -> gsSendRPC router pid pubRPC) targets
     else do
-      -- Mesh-based publish; subscribed direct peers are always included
-      -- although they are never mesh or fanout members
+      -- Mesh-based publish; subscribed direct and floodsub peers are
+      -- always included although they are never mesh or fanout members
+      -- (floodsub peers are flooded every message for their topics, #157)
       peers <- readTVarIO (gsPeers router)
       let direct = directTopicPeers router peers topic
+          flood  = floodSubTopicPeers peers topic
       meshPeers <- atomically $ do
         m <- readTVar (gsMesh router)
         pure (Map.findWithDefault Set.empty topic m)
       if not (Set.null meshPeers)
         then mapM_ (\pid -> gsSendRPC router pid pubRPC)
-               (Set.toList (Set.union meshPeers direct))
+               (Set.toList (Set.unions [meshPeers, direct, flood]))
         else do
-          -- Fanout: use existing or create new (direct peers excluded)
+          -- Fanout: use existing or create new (direct and floodsub
+          -- peers excluded from selection but always sent to)
           foPeers <- atomically $ do
             fo <- readTVar (gsFanout router)
             pure (Map.findWithDefault Set.empty topic fo)
@@ -385,6 +410,7 @@ publish router topic payload mKeyPair = do
                     if Set.member topic (psTopics ps)
                        && pid /= gsLocalPeerId router
                        && not (isDirectPeer router pid)
+                       && psProtocol ps /= FloodSubPeer
                     then pid : acc
                     else acc) [] peers
               selected <- sampleIO (min (paramD (gsParams router)) (length eligible)) eligible
@@ -397,7 +423,7 @@ publish router topic payload mKeyPair = do
               atomically $ modifyTVar' (gsFanoutPub router) (Map.insert topic now)
               pure foPeers
           mapM_ (\pid -> gsSendRPC router pid pubRPC)
-            (Set.toList (Set.union targets direct))
+            (Set.toList (Set.unions [targets, direct, flood]))
 
   -- Deliver to local application
   onMsg <- readTVarIO (gsOnMessage router)
@@ -559,9 +585,15 @@ handleOneGraft router sender now (Graft topic) = do
   -- with no peers has no mesh entry but its GRAFTs must be accepted
   -- (gossipsub-v1.0.md GRAFT handling; issue #155).
   subs <- readTVarIO (gsSubscriptions router)
+  peersMap <- readTVarIO (gsPeers router)
   let subscribed = Set.member topic subs
 
-  if not subscribed
+  if isFloodSubPeer peersMap sender
+    then
+      -- Floodsub peers have no mesh and understand no control messages:
+      -- never graft them and never answer with PRUNE (#157)
+      pure []
+    else if not subscribed
     then
       -- gossipsub-v1.1.md GRAFT flood protection: GRAFTs for unknown
       -- topics are ignored — replying with PRUNE (the v1.0 behaviour)
@@ -666,7 +698,12 @@ handleOnePrune router sender now prune = do
 handleIHave :: GossipSubRouter -> PeerId -> [IHave] -> IO ()
 handleIHave router sender ihaves = do
   score <- peerScore router sender
-  unless (score < stGossipThreshold (gsThresholds router) || null ihaves) $ do
+  peersMap <- readTVarIO (gsPeers router)
+  -- Floodsub peers never receive control messages, so an (unexpected)
+  -- IHAVE from one must not be answered with IWANT (#157)
+  unless (score < stGossipThreshold (gsThresholds router)
+          || isFloodSubPeer peersMap sender
+          || null ihaves) $ do
     let params = gsParams router
     withinBudget <- atomically $ do
       counts <- readTVar (gsIHaveCounts router)
@@ -735,7 +772,9 @@ handleSubscriptions router sender subs = atomically $
 
 -- | Forward a message to mesh peers for its topic, excluding the sender.
 -- Subscribed direct peers always receive the message even though they
--- are never mesh members (gossipsub-v1.1.md explicit peering).
+-- are never mesh members (gossipsub-v1.1.md explicit peering), and so do
+-- subscribed floodsub peers, which are flooded before the mesh
+-- (gossipsub-v1.0.md: forward "to every peer in peers.floodsub[topic]").
 forwardMessage :: GossipSubRouter -> PeerId -> PubSubMessage -> IO ()
 forwardMessage router sender msg = do
   let topic = msgTopic msg
@@ -744,7 +783,8 @@ forwardMessage router sender msg = do
     pure (Map.findWithDefault Set.empty topic m)
   peers <- readTVarIO (gsPeers router)
   let direct = directTopicPeers router peers topic
-      targets = Set.delete sender (Set.union meshPeers direct)
+      flood  = floodSubTopicPeers peers topic
+      targets = Set.delete sender (Set.unions [meshPeers, direct, flood])
       fwdRPC = emptyRPC { rpcPublish = [msg] }
   mapM_ (\pid -> gsSendRPC router pid fwdRPC) (Set.toList targets)
 

--- a/src/LibP2P/Protocol/GossipSub/Types.hs
+++ b/src/LibP2P/Protocol/GossipSub/Types.hs
@@ -11,6 +11,7 @@ module LibP2P.Protocol.GossipSub.Types
   ( -- * Protocol constants
     gossipSubProtocolId
   , gossipSubProtocolIdV10
+  , floodSubProtocolId
   , maxRPCSize
     -- * Topic and message identity
   , Topic
@@ -84,6 +85,13 @@ gossipSubProtocolId = "/meshsub/1.1.0"
 -- fully backwards compatible with v1.0 of the protocol).
 gossipSubProtocolIdV10 :: Text
 gossipSubProtocolIdV10 = "/meshsub/1.0.0"
+
+-- | FloodSub protocol identifier. Advertised alongside the meshsub
+-- protocols (gossipsub-v1.0.md "Compatibility with FloodSub"): floodsub
+-- peers receive all messages for topics they subscribe to and are never
+-- sent gossipsub control messages.
+floodSubProtocolId :: Text
+floodSubProtocolId = "/floodsub/1.0.0"
 
 -- | Maximum RPC message size: 1 MiB.
 maxRPCSize :: Int
@@ -261,11 +269,13 @@ defaultGossipSubParams = GossipSubParams
 
 -- | Peer's negotiated protocol capability. Peers on /meshsub/1.0.0 must
 -- not receive v1.1 control extensions (PX records or the backoff field
--- in PRUNE).
+-- in PRUNE). Peers on /floodsub/1.0.0 have no mesh: they are flooded
+-- every message for topics they subscribe to and never receive control
+-- messages (gossipsub-v1.0.md "Compatibility with FloodSub").
 data PeerProtocol
   = GossipSubPeer     -- ^ GossipSub v1.1 (/meshsub/1.1.0)
   | GossipSubV10Peer  -- ^ GossipSub v1.0 (/meshsub/1.0.0)
-  | FloodSubPeer      -- ^ FloodSub only (/floodsub/1.0.0, not yet negotiated)
+  | FloodSubPeer      -- ^ FloodSub only (/floodsub/1.0.0)
   deriving (Show, Eq)
 
 -- | Per-peer state tracked by the router.

--- a/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
@@ -28,6 +28,7 @@ import LibP2P.MultistreamSelect.Negotiation
   )
 import LibP2P.Protocol.GossipSub.Handler
   ( GossipSubNode (..)
+  , floodSubProtocolId
   , gossipJoin
   , gossipLeave
   , gossipPublish
@@ -281,6 +282,23 @@ spec = do
       case (h11', h10') of
         (Nothing, Nothing) -> pure ()
         _ -> expectationFailure "both protocol versions should be unregistered after stop"
+
+    -- Issue #157 last item: floodsub compatibility — /floodsub/1.0.0 is
+    -- registered alongside the meshsub protocols so floodsub-only peers
+    -- get a pubsub stream.
+    it "registers a handler for /floodsub/1.0.0 and removes it on stop" $ do
+      (sw, _pid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      startGossipSub node
+      hFs <- lookupStreamHandler sw floodSubProtocolId
+      case hFs of
+        Just _  -> pure ()
+        Nothing -> expectationFailure "/floodsub/1.0.0 should be registered"
+      stopGossipSub node
+      hFs' <- lookupStreamHandler sw floodSubProtocolId
+      case hFs' of
+        Nothing -> pure ()
+        Just _  -> expectationFailure "/floodsub/1.0.0 should be unregistered after stop"
 
   describe "stopGossipSub" $ do
     it "cancels heartbeat and unregisters handler" $ do

--- a/test/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
@@ -56,6 +56,13 @@ addSubscribedPeer router pid topic now = do
   atomically $ modifyTVar' (gsPeers router) $
     Map.adjust (\ps -> ps { psTopics = Set.singleton topic }) pid
 
+-- | Add a subscribed /floodsub/1.0.0 peer (never a mesh candidate).
+addFloodSubPeer :: GossipSubRouter -> PeerId -> Topic -> UTCTime -> IO ()
+addFloodSubPeer router pid topic now = do
+  addPeer router pid FloodSubPeer False now
+  atomically $ modifyTVar' (gsPeers router) $
+    Map.adjust (\ps -> ps { psTopics = Set.singleton topic }) pid
+
 localPid :: PeerId
 localPid = mkPeerId 0
 
@@ -489,6 +496,47 @@ spec = do
                             , Just ctrl <- [rpcControl rpc]
                             , not (null (ctrlGraft ctrl)) ]
         graftTo `shouldBe` [mkPeerId 1]
+
+    -- Issue #157 last item: floodsub peers are skipped by all mesh/fanout
+    -- maintenance and never receive control messages, including heartbeat
+    -- gossip (gossipsub-v1.0.md "Compatibility with FloodSub").
+    describe "FloodSub compatibility (#157)" $ do
+      it "mesh fill never GRAFTs a floodsub peer" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        let fsPeer = mkPeerId 9
+        addFloodSubPeer router fsPeer "t" fixedTime
+        addSubscribedPeer router (mkPeerId 1) "t" fixedTime
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "t")
+        heartbeatOnce router
+        mesh <- readTVarIO (gsMesh router)
+        let meshPeers = Map.findWithDefault Set.empty "t" mesh
+        Set.member fsPeer meshPeers `shouldBe` False
+        Set.member (mkPeerId 1) meshPeers `shouldBe` True
+        sent <- readIORef logRef
+        let graftTo = [ pid | (pid, rpc) <- sent
+                            , Just ctrl <- [rpcControl rpc]
+                            , not (null (ctrlGraft ctrl)) ]
+        graftTo `shouldBe` [mkPeerId 1]
+
+      it "heartbeat gossip emits no control to a floodsub peer and never selects it into fanout" $ do
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        let fsPeer = mkPeerId 9
+        addFloodSubPeer router fsPeer "t" fixedTime
+        let mkMsg n = PubSubMessage
+              { msgFrom = Nothing, msgData = BS.pack [n], msgSeqNo = Nothing
+              , msgTopic = "t", msgSignature = Nothing, msgKey = Nothing }
+        atomically $ do
+          modifyTVar' (gsFanout router) (Map.insert "t" Set.empty)
+          modifyTVar' (gsMessageCache router) $ \c ->
+            foldl (\acc n -> cachePut (BS.pack [n]) (mkMsg n) acc) c [1, 2, 3]
+        heartbeatOnce router
+        sent <- readIORef logRef
+        let controlTo = [ pid | (pid, rpc) <- sent
+                              , Just _ <- [rpcControl rpc] ]
+        controlTo `shouldBe` []
+        fanout <- readTVarIO (gsFanout router)
+        Set.member fsPeer (Map.findWithDefault Set.empty "t" fanout)
+          `shouldBe` False
 
     describe "Protocol version gating (#157)" $ do
       it "negative-score PRUNE to a /meshsub/1.0.0 peer omits the backoff field" $ do

--- a/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
@@ -121,6 +121,13 @@ addSubscribedPeer router pid topic = do
   atomically $ modifyTVar' (gsPeers router) $
     Map.adjust (\ps -> ps { psTopics = Set.singleton topic }) pid
 
+-- | Add a /floodsub/1.0.0 peer that is subscribed to a topic.
+addFloodSubPeer :: GossipSubRouter -> PeerId -> Topic -> IO ()
+addFloodSubPeer router pid topic = do
+  addPeer router pid FloodSubPeer False fixedTime
+  atomically $ modifyTVar' (gsPeers router) $
+    Map.adjust (\ps -> ps { psTopics = Set.singleton topic }) pid
+
 spec :: Spec
 spec = do
   describe "GossipSub.Router" $ do
@@ -1292,3 +1299,132 @@ spec = do
         sent <- readIORef logRef
         let publishedTo = [ pid | (pid, rpc) <- sent, not (null (rpcPublish rpc)) ]
         publishedTo `shouldBe` [dp]
+
+    -- Issue #157 last item: floodsub compatibility (gossipsub-v1.0.md
+    -- "Compatibility with FloodSub"). Floodsub peers receive every message
+    -- for topics they subscribe to, are never mesh members, and are never
+    -- sent gossipsub control messages.
+    describe "FloodSub compatibility (#157)" $ do
+      it "forwardMessage floods to a subscribed floodsub peer outside the mesh" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let fsPeer   = mkPeerId 9
+            meshPeer = mkPeerId 1
+            sender   = mkPeerId 2
+        addSubscribedPeer router meshPeer "t"
+        addSubscribedPeer router sender "t"
+        addFloodSubPeer router fsPeer "t"
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.fromList [meshPeer, sender])
+        kp <- newKeyPair
+        forwardMessage router sender (signedMessage kp "t" (BS.pack [1]))
+        sent <- readIORef logRef
+        let recipients = Set.fromList
+              [ pid | (pid, rpc) <- sent, not (null (rpcPublish rpc)) ]
+        recipients `shouldBe` Set.fromList [meshPeer, fsPeer]
+
+      it "forwardMessage skips floodsub peers subscribed to other topics" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let fsPeer = mkPeerId 9
+            sender = mkPeerId 2
+        addSubscribedPeer router sender "t"
+        addFloodSubPeer router fsPeer "other"
+        kp <- newKeyPair
+        forwardMessage router sender (signedMessage kp "t" (BS.pack [1]))
+        sent <- readIORef logRef
+        let recipients = [ pid | (pid, rpc) <- sent, not (null (rpcPublish rpc)) ]
+        recipients `shouldBe` []
+
+      it "mesh publish always includes subscribed floodsub peers" $ do
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramFloodPublish = False } localPid
+        let fsPeer   = mkPeerId 9
+            meshPeer = mkPeerId 1
+        addSubscribedPeer router meshPeer "t"
+        addFloodSubPeer router fsPeer "t"
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.singleton meshPeer)
+        kp <- newKeyPair
+        publish router "t" (BS.pack [1]) (Just kp)
+        sent <- readIORef logRef
+        let publishedTo = Set.fromList
+              [ pid | (pid, rpc) <- sent, not (null (rpcPublish rpc)) ]
+        publishedTo `shouldBe` Set.fromList [meshPeer, fsPeer]
+
+      it "fanout publish reaches floodsub peers without selecting them into fanout" $ do
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramFloodPublish = False } localPid
+        let fsPeer = mkPeerId 9
+            gsPeer = mkPeerId 1
+        addSubscribedPeer router gsPeer "t"
+        addFloodSubPeer router fsPeer "t"
+        kp <- newKeyPair
+        publish router "t" (BS.pack [1]) (Just kp)
+        sent <- readIORef logRef
+        let publishedTo = Set.fromList
+              [ pid | (pid, rpc) <- sent, not (null (rpcPublish rpc)) ]
+        publishedTo `shouldBe` Set.fromList [gsPeer, fsPeer]
+        fanout <- readTVarIO (gsFanout router)
+        Set.member fsPeer (Map.findWithDefault Set.empty "t" fanout)
+          `shouldBe` False
+
+      it "delivers and forwards an inbound message from a floodsub peer" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let fsPeer   = mkPeerId 9
+            meshPeer = mkPeerId 1
+        addFloodSubPeer router fsPeer "t"
+        addSubscribedPeer router meshPeer "t"
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.singleton meshPeer)
+        deliveredRef <- newIORef []
+        atomically $ writeTVar (gsOnMessage router) $
+          \topic msg -> modifyIORef' deliveredRef (++ [(topic, msgData msg)])
+        kp <- newKeyPair
+        let msg = signedMessage kp "t" (BS.pack [42])
+        handleRPC router fsPeer emptyRPC { rpcPublish = [msg] }
+        readIORef deliveredRef `shouldReturn` [("t", BS.pack [42])]
+        sent <- readIORef logRef
+        let forwardedTo = [ pid | (pid, rpc) <- sent, not (null (rpcPublish rpc)) ]
+        forwardedTo `shouldBe` [meshPeer]
+
+      it "join never adds a floodsub peer to the mesh or sends it control" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let fsPeer = mkPeerId 9
+        addFloodSubPeer router fsPeer "t"
+        join router "t"
+        mesh <- readTVarIO (gsMesh router)
+        Set.member fsPeer (Map.findWithDefault Set.empty "t" mesh) `shouldBe` False
+        sent <- readIORef logRef
+        let controlTo = [ pid | (pid, rpc) <- sent
+                              , Just _ <- [rpcControl rpc] ]
+        controlTo `shouldBe` []
+
+      it "ignores GRAFT from a floodsub peer without grafting it" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let fsPeer = mkPeerId 9
+        addFloodSubPeer router fsPeer "t"
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "t")
+        handleGraft router fsPeer [Graft "t"]
+        mesh <- readTVarIO (gsMesh router)
+        Set.member fsPeer (Map.findWithDefault Set.empty "t" mesh) `shouldBe` False
+        sent <- readIORef logRef
+        prunesTo fsPeer sent `shouldBe` []
+
+      it "never replies PRUNE to a rejected GRAFT from a floodsub peer" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let fsPeer = mkPeerId 9
+            routerNeg = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const (-1) } }
+        addFloodSubPeer routerNeg fsPeer "t"
+        atomically $ modifyTVar' (gsSubscriptions routerNeg) (Set.insert "t")
+        handleGraft routerNeg fsPeer [Graft "t"]
+        sent <- readIORef logRef
+        prunesTo fsPeer sent `shouldBe` []
+
+      it "never replies IWANT to an IHAVE from a floodsub peer" $ do
+        (router, logRef) <- mkTestRouter localPid
+        let fsPeer = mkPeerId 9
+        addFloodSubPeer router fsPeer "t"
+        handleIHave router fsPeer [IHave "t" [BS.pack [1]]]
+        sent <- readIORef logRef
+        iwantsSent sent `shouldBe` []


### PR DESCRIPTION
## Summary

Implements the last remaining item of #157: floodsub compatibility per gossipsub-v1.0.md "Compatibility with FloodSub". Together with #211 (PX, GRAFT flood protection, scoring wiring) and #216 (/meshsub/1.0.0 negotiation, IHAVE/IWANT caps, direct peering), this completes the issue.

## Protocol negotiation

- The Handler now registers inbound stream handlers for and offers `/floodsub/1.0.0` alongside `/meshsub/1.1.0` and `/meshsub/1.0.0` (preference order: v1.1, v1.0, floodsub) — matching go-libp2p's advertisement.
- The negotiated protocol maps to the `FloodSubPeer` tier of `PeerProtocol`, which existed since Phase 9 but was never constructed.

## Router behaviour towards floodsub peers

- **Flooding:** subscribed floodsub peers receive every published and forwarded message for their topics — mesh publish, fanout publish, and `forwardMessage` all include `peers.floodsub[topic]` (they have no mesh; gossipsub-v1.0.md requires forwarding to floodsub peers before the mesh). Flood publish already reached them as ordinary topic peers.
- **No control messages, ever:** floodsub peers are excluded from join GRAFTs, heartbeat mesh-fill GRAFTs, heartbeat IHAVE gossip, and fanout selection. A GRAFT from a floodsub peer is ignored without a PRUNE reply (accept and reject paths both), and an IHAVE from one is never answered with IWANT.
- **Inbound:** messages from floodsub peers flow through the unchanged validation/scoring pipeline and are delivered to the application and forwarded normally.

## Tests

TDD (11 new red tests first, all green after): flooding on forward/mesh-publish/fanout-publish, exclusion from fanout selection, delivery+forwarding of inbound floodsub messages, join/mesh-fill/gossip emitting no control to floodsub peers, GRAFT ignored without PRUNE (both score paths), IHAVE never answered with IWANT, and `/floodsub/1.0.0` handler registration/unregistration. 974 examples, 0 failures with GHC 9.10.3.

Closes #157