### PR TITLE
test: yamux property tests, go-yamux trace replay, EOF mid-frame (remainder of #171)

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -150,6 +150,9 @@ test-suite libp2p-hs-test
     LibP2P.Yamux.SessionSpec
     LibP2P.Yamux.StateMachineSpec
     LibP2P.Yamux.LifecycleSpec
+    LibP2P.Yamux.PropertySpec
+    LibP2P.Yamux.TraceReplaySpec
+    LibP2P.Yamux.TransportEofSpec
     LibP2P.Transport.TCPSpec
     LibP2P.Switch.ConnPoolSpec
     LibP2P.Switch.ConnectionLifecycleSpec

--- a/src/LibP2P/Yamux/Session.hs
+++ b/src/LibP2P/Yamux/Session.hs
@@ -20,6 +20,7 @@ module LibP2P.Yamux.Session
   ) where
 
 import Control.Concurrent.STM
+import Control.Exception (finally)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
@@ -149,11 +150,11 @@ ping sess = do
           , yhLength = pingId
           }
   atomically $ writeTQueue (ysessSendCh sess) (hdr, BS.empty)
-  -- Wait for ACK
-  atomically $ takeTMVar waiter
+  -- Wait for ACK (or a session-failure notification)
+  result <- atomically $ takeTMVar waiter
   -- Cleanup
   atomically $ modifyTVar' (ysessPings sess) (Map.delete pingId)
-  pure (Right ())
+  pure result
 
 -- | Send a GoAway frame with the specified error code.
 -- Sets ysessShutdown to True so no new streams can be opened.
@@ -173,8 +174,14 @@ sendGoAway sess code = do
 
 -- | Receive loop: reads 12-byte headers from transport and dispatches frames.
 -- This loop runs until the transport connection is closed or an error occurs.
+--
+-- Whenever the loop terminates -- transport EOF or error (ysessRead
+-- throws), a fatal protocol error, or cancellation -- the session is
+-- torn down via failSession so that no reader, writer or ping waiter
+-- is left blocked forever on a session that can no longer make
+-- progress.
 recvLoop :: YamuxSession -> IO ()
-recvLoop sess = go
+recvLoop sess = go `finally` failSession sess
   where
     go = do
       -- Read 12-byte header
@@ -190,6 +197,23 @@ recvLoop sess = go
             else do
               continue <- dispatchFrame sess hdr
               when continue go
+
+-- | Tear down the session once the receive loop can no longer make
+-- progress (transport EOF mid-frame, transport error, or a fatal
+-- protocol error). Mirrors go-yamux, which closes every stream with
+-- the session error on exit: new streams are refused, every registered
+-- stream is reset so blocked readers and writers observe an error
+-- instead of hanging, and every pending ping fails with
+-- YamuxSessionShutdown.
+failSession :: YamuxSession -> IO ()
+failSession sess = atomically $ do
+  writeTVar (ysessShutdown sess) True
+  streams <- readTVar (ysessStreams sess)
+  mapM_ (\s -> writeTVar (ysState s) StreamReset) (Map.elems streams)
+  writeTVar (ysessStreams sess) Map.empty
+  pings <- readTVar (ysessPings sess)
+  mapM_ (\w -> tryPutTMVar w (Left YamuxSessionShutdown)) (Map.elems pings)
+  writeTVar (ysessPings sess) Map.empty
 
 -- | Dispatch a decoded frame to the appropriate handler.
 -- Returns False when a fatal protocol error occurred and the receive
@@ -404,7 +428,7 @@ handlePing sess hdr
       atomically $ do
         pMap <- readTVar (ysessPings sess)
         case Map.lookup pingId pMap of
-          Just waiter -> putTMVar waiter ()
+          Just waiter -> putTMVar waiter (Right ())
           Nothing -> pure ()
   | otherwise = pure ()
 

--- a/src/LibP2P/Yamux/Types.hs
+++ b/src/LibP2P/Yamux/Types.hs
@@ -10,6 +10,7 @@ module LibP2P.Yamux.Types
   , YamuxError (..)
   , YamuxStream (..)
   , YamuxSession (..)
+  , PingWaiter
   ) where
 
 import Control.Concurrent.STM (TBQueue, TMVar, TQueue, TVar)
@@ -17,6 +18,10 @@ import Data.ByteString (ByteString)
 import qualified Data.Map.Strict as Map
 import Data.Word (Word32)
 import LibP2P.Yamux.Frame (GoAwayCode, YamuxHeader)
+
+-- | Result delivered to a pending ping waiter: Right on a matching ACK,
+-- Left when the session dies before the ACK arrives.
+type PingWaiter = TMVar (Either YamuxError ())
 
 -- | SessionRole determines stream ID parity (spec.md §Stream Identification).
 -- Client uses odd IDs (1, 3, 5, ...), Server uses even IDs (2, 4, 6, ...).
@@ -65,7 +70,7 @@ data YamuxSession = YamuxSession
   , ysessSendCh :: !(TQueue (YamuxHeader, ByteString)) -- ^ Outbound frame queue
   , ysessShutdown :: !(TVar Bool) -- ^ Local GoAway sent
   , ysessRemoteGoAway :: !(TVar (Maybe GoAwayCode)) -- ^ Code of the remote GoAway, if one was received
-  , ysessPings :: !(TVar (Map.Map Word32 (TMVar ()))) -- ^ Pending ping responses
+  , ysessPings :: !(TVar (Map.Map Word32 PingWaiter)) -- ^ Pending ping responses
   , ysessNextPingId :: !(TVar Word32)
   , ysessWrite :: !(ByteString -> IO ()) -- ^ Underlying transport write
   , ysessRead :: !(Int -> IO ByteString) -- ^ Underlying transport read exact N bytes

--- a/test/LibP2P/Yamux/HostilePeer.hs
+++ b/test/LibP2P/Yamux/HostilePeer.hs
@@ -9,11 +9,17 @@
 -- state-machine tests: with two of our sessions wired together, any
 -- frame shape a conformant-but-differently-written peer may send is
 -- structurally unreachable.
+--
+-- The transport is a chunk-based in-memory pipe that can be closed:
+-- closing the inject direction makes the session's next read throw an
+-- EOF IOError once the buffered bytes run out, exactly like the
+-- production readExact-over-socket wiring in Switch.Upgrade.
 module LibP2P.Yamux.HostilePeer
   ( HostilePeer (..)
   , withHostilePeer
   , injectFrame
   , expectFrame
+  , expectBytes
   , acceptWithin
   , awaitState
   , awaitTrue
@@ -36,31 +42,90 @@ data HostilePeer = HostilePeer
   -- ^ The session under test (recvLoop/sendLoop already running)
   , hpInject :: ByteString -> IO ()
   -- ^ Write raw bytes into the session's receive side
+  , hpCloseInject :: IO ()
+  -- ^ Signal transport EOF on the session's receive side: after the
+  -- already-injected bytes are consumed, the session's read throws
   , hpNextFrame :: IO (YamuxHeader, ByteString)
   -- ^ Decode the next frame the session wrote (header + Data payload)
+  , hpRecvRaw :: Int -> IO ByteString
+  -- ^ Read exactly n raw bytes the session wrote (byte-exact asserts)
   }
+
+-- | One direction of the in-memory transport: a queue of chunks, a
+-- leftover buffer for partially consumed chunks, and a closed flag.
+data Pipe = Pipe
+  { pipeChunks :: TQueue ByteString
+  , pipeLeftover :: TVar ByteString
+  , pipeClosed :: TVar Bool
+  }
+
+newPipe :: IO Pipe
+newPipe = Pipe <$> newTQueueIO <*> newTVarIO BS.empty <*> newTVarIO False
+
+pipeWrite :: Pipe -> ByteString -> IO ()
+pipeWrite p bs
+  | BS.null bs = pure ()
+  | otherwise = atomically $ writeTQueue (pipeChunks p) bs
+
+pipeClose :: Pipe -> IO ()
+pipeClose p = atomically $ writeTVar (pipeClosed p) True
+
+-- | Read exactly n bytes, blocking until they arrive. Throws an
+-- IOError on EOF before n bytes are available, mirroring the
+-- production transport read (readExact fails on a short read).
+pipeRead :: Pipe -> Int -> IO ByteString
+pipeRead p n = go [] n
+  where
+    go acc 0 = pure (BS.concat (reverse acc))
+    go acc want = do
+      mChunk <- atomically $ do
+        leftover <- readTVar (pipeLeftover p)
+        if not (BS.null leftover)
+          then do
+            writeTVar (pipeLeftover p) BS.empty
+            pure (Just leftover)
+          else do
+            mc <- tryReadTQueue (pipeChunks p)
+            case mc of
+              Just c -> pure (Just c)
+              Nothing -> do
+                closed <- readTVar (pipeClosed p)
+                if closed then pure Nothing else retry
+      case mChunk of
+        Nothing -> ioError (userError "pipeRead: transport EOF mid-read")
+        Just c
+          | BS.length c <= want -> go (c : acc) (want - BS.length c)
+          | otherwise -> do
+              let (use, rest) = BS.splitAt want c
+              atomically $ writeTVar (pipeLeftover p) rest
+              go (use : acc) 0
 
 -- | Run an action against a session wired to a raw byte peer.
 withHostilePeer :: SessionRole -> (HostilePeer -> IO a) -> IO a
 withHostilePeer role action = do
-  toSession <- newTQueueIO
-  fromSession <- newTQueueIO
-  let writeTo q bs = mapM_ (atomically . writeTQueue q) (BS.unpack bs)
-      readFrom q n = BS.pack <$> mapM (const (atomically (readTQueue q))) [1 .. n]
-  sess <- newSession role (writeTo fromSession) (readFrom toSession)
+  toSession <- newPipe
+  fromSession <- newPipe
+  sess <- newSession role (pipeWrite fromSession) (pipeRead toSession)
   let nextFrame = do
-        hdrBytes <- readFrom fromSession headerSize
+        hdrBytes <- pipeRead fromSession headerSize
         case decodeHeader hdrBytes of
           Left err -> fail ("frame recorder: " <> err)
           Right hdr -> do
             payload <-
               if yhType hdr == FrameData && yhLength hdr > 0
-                then readFrom fromSession (fromIntegral (yhLength hdr))
+                then pipeRead fromSession (fromIntegral (yhLength hdr))
                 else pure BS.empty
             pure (hdr, payload)
   withAsync (sendLoop sess) $ \_ ->
     withAsync (recvLoop sess) $ \_ ->
-      action (HostilePeer sess (writeTo toSession) nextFrame)
+      action
+        HostilePeer
+          { hpSession = sess
+          , hpInject = pipeWrite toSession
+          , hpCloseInject = pipeClose toSession
+          , hpNextFrame = nextFrame
+          , hpRecvRaw = pipeRead fromSession
+          }
 
 -- | Inject a frame (header plus optional Data payload) as raw bytes.
 injectFrame :: HostilePeer -> YamuxHeader -> ByteString -> IO ()
@@ -74,6 +139,15 @@ expectFrame hp = do
   case mFrame of
     Just frame -> pure frame
     Nothing -> fail "expected an outbound frame within 1s, got none"
+
+-- | Assert that the session's next outbound bytes are exactly the
+-- given ones (byte-exact golden assertion), failing after 1s.
+expectBytes :: HostilePeer -> ByteString -> Expectation
+expectBytes hp expected = do
+  mGot <- timeout 1000000 (hpRecvRaw hp (BS.length expected))
+  case mGot of
+    Just got -> got `shouldBe` expected
+    Nothing -> expectationFailure "expected outbound bytes within 1s, got none"
 
 -- | Accept an inbound stream, failing loudly after 1s.
 acceptWithin :: HostilePeer -> IO YamuxStream

--- a/test/LibP2P/Yamux/PropertySpec.hs
+++ b/test/LibP2P/Yamux/PropertySpec.hs
@@ -1,0 +1,170 @@
+-- | QuickCheck properties for Yamux (issue #171).
+--
+-- Frame codec: encode/decode round-trips over arbitrary valid headers,
+-- and rejection of arbitrary invalid type/version bytes (the type at
+-- the codec level, the version at the session level, where the spec
+-- places the check).
+--
+-- Window accounting: for any sequence of writes and peer window
+-- grants, the session never puts more data bytes on the wire than the
+-- advertised send window allows, converges to exactly the deliverable
+-- amount, and keeps its bookkeeping consistent with the model.
+module LibP2P.Yamux.PropertySpec (spec) where
+
+import Control.Concurrent.Async (async, cancel)
+import Control.Concurrent.STM
+import Control.Exception (finally)
+import Control.Monad (forM, void)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Either (isLeft)
+import Data.Word (Word8)
+import LibP2P.Yamux.Frame
+import LibP2P.Yamux.HostilePeer
+import LibP2P.Yamux.Session
+import LibP2P.Yamux.Stream (streamWrite)
+import LibP2P.Yamux.Types
+import System.Timeout (timeout)
+import Test.Hspec
+import Test.QuickCheck
+
+genFrameType :: Gen FrameType
+genFrameType = elements [FrameData, FrameWindowUpdate, FramePing, FrameGoAway]
+
+genFlags :: Gen Flags
+genFlags = Flags <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+-- | Any header the codec can produce: every type, every flag
+-- combination, arbitrary version/stream-id/length.
+genHeader :: Gen YamuxHeader
+genHeader =
+  YamuxHeader
+    <$> arbitrary
+    <*> genFrameType
+    <*> genFlags
+    <*> arbitrary
+    <*> arbitrary
+
+-- | A 12-byte block whose type byte (offset 1) is outside the four
+-- spec-defined frame types; every other byte is arbitrary.
+genInvalidTypeHeader :: Gen ByteString
+genInvalidTypeHeader = do
+  b0 <- arbitrary
+  t <- fromIntegral <$> chooseInt (0x04, 0xFF)
+  rest <- vectorOf 10 (arbitrary :: Gen Word8)
+  pure (BS.pack (b0 : t : rest))
+
+spec :: Spec
+spec = do
+  describe "Frame codec properties" $ do
+    it "round-trips any valid header through encode/decode" $
+      forAll genHeader $ \hdr ->
+        decodeHeader (encodeHeader hdr) === Right hdr
+
+    it "always encodes to exactly 12 bytes" $
+      forAll genHeader $ \hdr ->
+        BS.length (encodeHeader hdr) === headerSize
+
+    it "rejects any 12-byte block with an unknown type byte" $
+      forAll genInvalidTypeHeader $ \bs ->
+        property (isLeft (decodeHeader bs))
+
+    it "rejects any input shorter than 12 bytes" $
+      forAll (chooseInt (0, 11) >>= \n -> vectorOf n (arbitrary :: Gen Word8)) $
+        \ws -> property (isLeft (decodeHeader (BS.pack ws)))
+
+  describe "Session-level rejection of invalid header bytes" $ do
+    it "terminates with GoAway(0x01) on any nonzero version byte" $
+      withMaxSuccess 25 $
+        forAll (chooseInt (1, 255)) $ \v -> ioProperty $
+          withHostilePeer RoleServer $ \hp -> do
+            let hdr = YamuxHeader (fromIntegral v) FrameData defaultFlags 1 0
+            injectFrame hp hdr BS.empty
+            (goAway, _) <- expectFrame hp
+            yhType goAway `shouldBe` FrameGoAway
+            yhLength goAway `shouldBe` 0x01
+            pure True
+
+    it "terminates with GoAway(0x01) on any unknown type byte" $
+      withMaxSuccess 25 $
+        forAll genInvalidTypeHeader $ \bs -> ioProperty $
+          withHostilePeer RoleServer $ \hp -> do
+            hpInject hp bs
+            (goAway, _) <- expectFrame hp
+            yhType goAway `shouldBe` FrameGoAway
+            yhLength goAway `shouldBe` 0x01
+            pure True
+
+  describe "Window accounting properties" $ do
+    it "never sends more data than the advertised send window for any op sequence" $
+      withMaxSuccess 30 $
+        forAll genOps $ \ops -> ioProperty (runWindowOps ops)
+
+-- | One step of the window-accounting scenario: a local write of n
+-- bytes, or the peer granting a window update of the given delta.
+data WindowOp = OpWrite Int | OpGrant Int
+  deriving (Show)
+
+genOps :: Gen [WindowOp]
+genOps = do
+  n <- chooseInt (1, 10)
+  vectorOf n $
+    frequency
+      [ (3, OpWrite <$> chooseInt (1, 100000))
+      , (2, OpGrant <$> chooseInt (0, 150000))
+      ]
+
+-- | Drive an outbound stream with the given op sequence and check that
+-- the bytes observed on the wire never exceed the advertised window,
+-- converge to exactly min(totalWritten, window), and that the stream's
+-- remaining send window matches the model afterwards.
+runWindowOps :: [WindowOp] -> IO Bool
+runWindowOps ops =
+  withHostilePeer RoleClient $ \hp -> do
+    Right stream <- openStream (hpSession hp)
+    (synHdr, _) <- expectFrame hp
+    flagSYN (yhFlags synHdr) `shouldBe` True
+    writers <- fmap concat . forM ops $ \op -> case op of
+      OpWrite n -> do
+        a <- async (void (streamWrite stream (BS.replicate n 0x61)))
+        pure [a]
+      OpGrant d -> do
+        let hdr = YamuxHeader 0 FrameWindowUpdate defaultFlags 1 (fromIntegral d)
+        injectFrame hp hdr BS.empty
+        pure []
+    let totalWritten = sum [n | OpWrite n <- ops]
+        limit = fromIntegral initialWindowSize + sum [d | OpGrant d <- ops]
+        expected = min totalWritten limit
+        drain acc
+          | acc == expected = pure ()
+          | otherwise = do
+              (hdr, payload) <- expectFrame hp
+              yhType hdr `shouldBe` FrameData
+              let acc' = acc + BS.length payload
+              if acc' > limit
+                then
+                  expectationFailure $
+                    "sent " <> show acc' <> " bytes, window allows " <> show limit
+                else drain acc'
+    flip finally (mapM_ cancel writers) $ do
+      drain 0
+      -- After convergence the sender must stay quiet: any further data
+      -- frame would either overrun the window or duplicate data.
+      extra <- timeout 50000 (hpNextFrame hp)
+      case extra of
+        Nothing -> pure ()
+        Just (hdr, _) ->
+          expectationFailure ("unexpected extra frame: " <> show hdr)
+      -- Bookkeeping: the remaining send window equals the advertised
+      -- window minus what was actually delivered.
+      settled <- timeout 1000000 $ atomically $ do
+        w <- readTVar (ysSendWindow stream)
+        check (fromIntegral w == limit - expected)
+      case settled of
+        Just () -> pure True
+        Nothing -> do
+          w <- readTVarIO (ysSendWindow stream)
+          expectationFailure $
+            "send window settled at " <> show w
+              <> ", model expects " <> show (limit - expected)
+          pure False

--- a/test/LibP2P/Yamux/TraceReplaySpec.hs
+++ b/test/LibP2P/Yamux/TraceReplaySpec.hs
@@ -1,0 +1,80 @@
+-- | Golden trace replay against go-yamux wire behaviour (issue #171).
+--
+-- Each test replays a hand-derived, byte-exact session trace through
+-- the hostile-peer harness and asserts every frame on both directions
+-- literally, byte for byte. The inject-side bytes mirror what go-yamux
+-- (as used by go-libp2p) puts on the wire; the expect-side bytes are
+-- what a conformant peer must observe from us.
+--
+-- Header layout (spec.md): Version(1) Type(1) Flags(2 BE)
+-- StreamID(4 BE) Length(4 BE).
+module LibP2P.Yamux.TraceReplaySpec (spec) where
+
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.STM (readTVarIO)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Word (Word8)
+import LibP2P.Yamux.HostilePeer
+import LibP2P.Yamux.Session (ping)
+import LibP2P.Yamux.Stream (streamClose, streamRead)
+import LibP2P.Yamux.Types
+import Test.Hspec
+
+bytes :: [Word8] -> ByteString
+bytes = BS.pack
+
+spec :: Spec
+spec = do
+  describe "go-yamux trace replay" $ do
+    it "replays a single-shot RPC: WindowUpdate+SYN open, data, FIN, FIN teardown" $
+      withHostilePeer RoleServer $ \hp -> do
+        -- >>> peer opens stream 1 the go-yamux way: WindowUpdate|SYN,
+        --     delta 0 (no extra window beyond the implicit 256 KiB)
+        hpInject hp $
+          bytes [0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]
+        stream <- acceptWithin hp
+        -- <<< we acknowledge the stream: WindowUpdate|ACK, delta 0
+        expectBytes hp $
+          bytes [0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]
+        -- >>> peer sends the request: Data, 5 bytes, "hello"
+        hpInject hp $
+          bytes [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x05]
+            <> "hello"
+        received <- streamRead stream
+        received `shouldBe` Right "hello"
+        -- <<< consuming the request credits the window back: plain
+        --     WindowUpdate, delta 5
+        expectBytes hp $
+          bytes [0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x05]
+        -- >>> peer half-closes: Data|FIN, no payload
+        hpInject hp $
+          bytes [0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]
+        eof <- streamRead stream
+        eof `shouldBe` Left YamuxStreamClosed
+        -- local close completes the teardown
+        closeRes <- streamClose stream
+        closeRes `shouldBe` Right ()
+        -- <<< our half-close: Data|FIN, no payload
+        expectBytes hp $
+          bytes [0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]
+        st <- readTVarIO (ysState stream)
+        st `shouldBe` StreamClosed
+
+    it "replays a ping round-trip in each direction with byte-exact opaque echo" $
+      withHostilePeer RoleClient $ \hp -> do
+        withAsync (ping (hpSession hp)) $ \pingA -> do
+          -- <<< our ping: Ping|SYN, StreamID 0, opaque 1 (first ping id)
+          expectBytes hp $
+            bytes [0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]
+          -- >>> peer echoes it: Ping|ACK with the same opaque value
+          hpInject hp $
+            bytes [0x00, 0x02, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]
+          pingRes <- wait pingA
+          pingRes `shouldBe` Right ()
+        -- >>> peer pings us: Ping|SYN, opaque 0xDEADBEEF
+        hpInject hp $
+          bytes [0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF]
+        -- <<< we echo the exact opaque value back: Ping|ACK
+        expectBytes hp $
+          bytes [0x00, 0x02, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF]

--- a/test/LibP2P/Yamux/TransportEofSpec.hs
+++ b/test/LibP2P/Yamux/TransportEofSpec.hs
@@ -1,0 +1,76 @@
+-- | Transport EOF mid-frame (issue #171).
+--
+-- When the underlying transport hits EOF partway through a frame --
+-- after a partial header, or after a header whose declared payload
+-- never fully arrives -- the session must fail cleanly: the receive
+-- loop terminates, blocked readers and pending pings are unblocked
+-- with an error instead of hanging, and no new streams can be opened.
+module LibP2P.Yamux.TransportEofSpec (spec) where
+
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.STM (readTVarIO)
+import qualified Data.ByteString as BS
+import Data.Word (Word32)
+import LibP2P.Yamux.Frame
+import LibP2P.Yamux.HostilePeer
+import LibP2P.Yamux.Session
+import LibP2P.Yamux.Stream (streamRead, streamWrite)
+import LibP2P.Yamux.Types
+import System.Timeout (timeout)
+import Test.Hspec
+
+synF :: Flags
+synF = defaultFlags {flagSYN = True}
+
+dataHdr :: Flags -> Word32 -> Word32 -> YamuxHeader
+dataHdr = YamuxHeader 0 FrameData
+
+-- | Establish inbound stream 1 on a server-role session, consuming the
+-- WindowUpdate ACK.
+openAccepted :: HostilePeer -> IO YamuxStream
+openAccepted hp = do
+  injectFrame hp (dataHdr synF 1 0) BS.empty
+  stream <- acceptWithin hp
+  (ackHdr, _) <- expectFrame hp
+  flagACK (yhFlags ackHdr) `shouldBe` True
+  pure stream
+
+spec :: Spec
+spec = do
+  describe "Transport EOF after a partial header" $ do
+    it "unblocks a blocked reader and a pending ping with an error, refuses new streams" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        withAsync (streamRead stream) $ \readerA ->
+          withAsync (ping (hpSession hp)) $ \pingA -> do
+            (pingSyn, _) <- expectFrame hp
+            yhType pingSyn `shouldBe` FramePing
+            -- 5 of the 12 header bytes arrive, then the transport dies
+            hpInject hp (BS.pack [0x00, 0x00, 0x00, 0x00, 0x00])
+            hpCloseInject hp
+            readerRes <- timeout 1000000 (wait readerA)
+            readerRes `shouldBe` Just (Left YamuxStreamReset)
+            pingRes <- timeout 1000000 (wait pingA)
+            pingRes `shouldBe` Just (Left YamuxSessionShutdown)
+        openRes <- openStream (hpSession hp)
+        case openRes of
+          Left err -> err `shouldBe` YamuxSessionShutdown
+          Right _ -> expectationFailure "openStream succeeded after transport EOF"
+
+  describe "Transport EOF after a header but partial payload" $ do
+    it "fails the session cleanly when a declared payload is cut short" $
+      withHostilePeer RoleServer $ \hp -> do
+        stream <- openAccepted hp
+        withAsync (streamRead stream) $ \readerA -> do
+          -- Header declares 100 payload bytes; only 40 arrive before EOF
+          injectFrame hp (dataHdr defaultFlags 1 100) (BS.replicate 40 0x61)
+          hpCloseInject hp
+          readerRes <- timeout 1000000 (wait readerA)
+          readerRes `shouldBe` Just (Left YamuxStreamReset)
+        -- The truncated frame is never delivered as data, the session
+        -- is shut down, and writes on the dead stream fail too
+        awaitTrue (ysessShutdown (hpSession hp))
+        writeRes <- streamWrite stream "late"
+        writeRes `shouldBe` Left YamuxStreamReset
+        st <- readTVarIO (ysState stream)
+        st `shouldBe` StreamReset


### PR DESCRIPTION
## Summary

Completes the three items PR #201 listed as the remainder of #171. Verified against current main first: #208 (LifecycleSpec) already covers the #164 cells, so nothing here overlaps it.

### Property-based tests (`PropertySpec.hs`)

- **Frame codec**: encode/decode round-trip over fully arbitrary valid headers (every type, all 16 flag combinations, arbitrary version/stream-id/length — generalises the existing fixed-shape round-trip), encoded size always 12, rejection of any 12-byte block with an unknown type byte, rejection of any input shorter than 12 bytes.
- **Session-level rejection**: for *any* nonzero version byte and *any* unknown type byte, the session emits GoAway(0x01) on the wire before terminating (the spec places the version check above the codec).
- **Window accounting**: for any generated sequence of local writes and peer window grants, the bytes observed on the wire never exceed the advertised send window, converge to exactly `min(totalWritten, window)`, the sender then stays quiet, and the remaining `ysSendWindow` matches the model.

### Golden trace replay (`TraceReplaySpec.hs`)

Two hand-derived, byte-exact traces mirroring go-yamux wire behaviour, replayed through HostilePeer and asserted frame-by-frame **as literal bytes** on both directions:

1. Single-shot RPC: WindowUpdate+SYN open (the go-libp2p pattern) → WindowUpdate+ACK → Data "hello" → WindowUpdate credit(5) → Data+FIN → local close → Data+FIN, ending in `StreamClosed`.
2. Ping round-trip in each direction, including the exact opaque echo (`0xDEADBEEF`) in the ACK.

### EOF mid-frame (`TransportEofSpec.hs`)

Transport EOF after 5 of 12 header bytes, and after a header declaring 100 payload bytes of which only 40 arrive. The session must fail cleanly: no hang, blocked readers/writers unblocked with an error, pending pings failed, new streams refused.

## Real defect found and fixed (spec-required, small)

The EOF tests exposed that `recvLoop` died **silently** when the transport read threw: blocked `streamRead`/`streamWrite` calls and pending `ping`s hung forever, and `openStream` kept succeeding on a dead session. go-yamux closes every stream with the session error on `exitErr`; we now do the equivalent — `recvLoop` runs `failSession` on any exit (EOF, transport error, fatal protocol error, cancellation): all registered streams are reset, ping waiters fail with `YamuxSessionShutdown` (waiters now carry `Either YamuxError ()`), and the session refuses new streams. TDD verified: with the `finally` teardown removed, both EOF tests fail (`Nothing` from the 1s waits); the codec property was likewise sanity-checked by flipping the FIN bit mask (caught with a shrunk counterexample), then reverted.

## Harness change

HostilePeer's byte-at-a-time `TQueue Word8` transport is replaced by a chunk-based pipe that can be closed to signal EOF (throwing on a short read, exactly like the production `readExact` wiring in `Switch.Upgrade`), plus `hpRecvRaw`/`expectBytes` for byte-exact golden assertions. Chunked transfer also makes the 256 KiB-window property run in milliseconds instead of pushing ~10^6 STM transactions per case.

Test suite: 971 examples, 0 failures (was 792 on main) with GHC 9.10.3.

Not covered (minor audit rows from the issue, unchanged by this PR): ping/GoAway with a nonzero StreamID are still ignored rather than rejected, and the keepalive-mechanism gap remains documented only.

Closes #171