### PR TITLE
fix(relay): close the #177 remainder — refresh at capacity, rsvAddrs/voucher, relay-chain refusal, limit off-by-one, multi-host circuit

### DIFF
--- a/src/LibP2P/NAT.hs
+++ b/src/LibP2P/NAT.hs
@@ -22,8 +22,9 @@ module LibP2P.NAT
 
 import Control.Concurrent.STM (atomically)
 import Control.Exception (SomeException, catch, try)
-import LibP2P.Crypto.PeerId (PeerId)
-import LibP2P.Multiaddr (Multiaddr)
+import LibP2P.Crypto.PeerId (PeerId, peerIdBytes)
+import LibP2P.Multiaddr (Multiaddr (..), encapsulate)
+import LibP2P.Multiaddr.Protocol (Protocol (..))
 import LibP2P.MultistreamSelect.Negotiation
   ( NegotiationResult (..)
   , StreamIO (..)
@@ -34,7 +35,8 @@ import LibP2P.NAT.AutoNAT.Message (autoNATProtocolId)
 import LibP2P.NAT.DCUtR (DCUtRConfig (..), handleDCUtR)
 import LibP2P.NAT.DCUtR.Message (dcutrProtocolId)
 import LibP2P.NAT.Relay
-  ( RelayConfig
+  ( HopContext (..)
+  , RelayConfig
   , RelayState
   , defaultRelayConfig
   , handleConnect
@@ -152,10 +154,12 @@ registerRelayHopHandler sw relayState =
     case result of
       Left _ -> pure ()
       Right msg -> case hopType msg of
-        Just HopReserve ->
-          handleReserve relayState stream (connPeerId conn)
-        Just HopConnect ->
-          handleConnect relayState stream (connPeerId conn) msg (openStopStream sw)
+        Just HopReserve -> do
+          ctx <- switchHopContext sw conn
+          handleReserve relayState ctx stream (connPeerId conn)
+        Just HopConnect -> do
+          ctx <- switchHopContext sw conn
+          handleConnect relayState ctx stream (connPeerId conn) msg (openStopStream sw)
         _ -> writeHopMessage stream HopMessage
           { hopType = Just HopStatus
           , hopPeer = Nothing
@@ -163,6 +167,21 @@ registerRelayHopHandler sw relayState =
           , hopLimit = Nothing
           , hopStatus = Just UnexpectedMessage
           }
+
+-- | Build the per-request hop context from the Switch: the relay's own
+-- identity (signs reservation vouchers), its listen addresses with the
+-- @/p2p/\<relay\>@ suffix the circuit-v2 spec requires for reservation
+-- addrs, and the address the requesting connection arrived over.
+switchHopContext :: Switch -> Connection -> IO HopContext
+switchHopContext sw conn = do
+  addrs <- switchListenAddrs sw
+  let relayP2P = Multiaddr [P2P (peerIdBytes (swLocalPeerId sw))]
+  pure HopContext
+    { hcRelayId    = swLocalPeerId sw
+    , hcRelayKey   = swIdentityKey sw
+    , hcRelayAddrs = map (`encapsulate` relayP2P) addrs
+    , hcRemoteAddr = connRemoteAddr conn
+    }
 
 -- | Open a stop-protocol stream to the circuit target over an existing
 -- connection. Returns Nothing when the target is not connected or the

--- a/src/LibP2P/NAT/Relay.hs
+++ b/src/LibP2P/NAT/Relay.hs
@@ -12,6 +12,7 @@ module LibP2P.NAT.Relay
     RelayConfig (..)
   , RelayState (..)
   , ActiveReservation (..)
+  , HopContext (..)
     -- * Configuration
   , defaultRelayConfig
     -- * State management
@@ -24,6 +25,10 @@ module LibP2P.NAT.Relay
     -- * Relay address helpers
   , buildRelayAddrBytes
   , isRelayedConnection
+  , isRelayedAddr
+    -- * Voucher constants
+  , relayRsvpDomain
+  , relayRsvpPayloadType
   ) where
 
 import Data.ByteString (ByteString)
@@ -37,8 +42,12 @@ import qualified Data.Map.Strict as Map
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Word (Word32, Word64)
 import LibP2P.NAT.Relay.Message
+import LibP2P.Multiaddr (Multiaddr (..), fromBytes, toBytes)
+import LibP2P.Multiaddr.Protocol (Protocol (..))
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
-import LibP2P.Crypto.PeerId (PeerId (..))
+import LibP2P.Crypto.Key (KeyPair (..))
+import LibP2P.Crypto.PeerId (PeerId (..), peerIdBytes)
+import LibP2P.Crypto.SignedEnvelope (createEnvelope, encodeSignedEnvelope)
 import LibP2P.Core.Varint (encodeUvarint)
 
 -- | Relay server configuration.
@@ -80,49 +89,98 @@ newRelayState config = RelayState config
   <$> newTVarIO Map.empty
   <*> newTVarIO Map.empty
 
+-- | Per-request context for the hop handlers: the relay's own identity
+-- (used to sign reservation vouchers), its public addresses (advertised in
+-- the reservation), and the address the requesting connection arrived over
+-- (used to refuse requests over already-relayed connections).
+data HopContext = HopContext
+  { hcRelayId    :: !PeerId       -- ^ Relay's own peer ID
+  , hcRelayKey   :: !KeyPair      -- ^ Relay identity key, signs vouchers
+  , hcRelayAddrs :: ![Multiaddr]
+    -- ^ Relay public addresses including the trailing @/p2p/\<relay\>@
+    -- component but without @/p2p-circuit@, per circuit-v2 reservation addrs
+  , hcRemoteAddr :: !Multiaddr    -- ^ Address the request arrived over
+  }
+
+-- | Domain separation string for reservation voucher envelopes (circuit-v2).
+relayRsvpDomain :: ByteString
+relayRsvpDomain = "libp2p-relay-rsvp"
+
+-- | Multicodec payload type for reservation vouchers (0x0302).
+relayRsvpPayloadType :: ByteString
+relayRsvpPayloadType = BS.pack [0x03, 0x02]
+
 -- | Handle a RESERVE request from a peer.
-handleReserve :: RelayState -> StreamIO -> PeerId -> IO ()
-handleReserve state stream peerId = do
-  -- Check resource limits
-  reservations <- readTVarIO (rsReservations state)
-  let limit = rcMaxReservations (rsConfig state)
-  if Map.size reservations >= limit
-    -- Per circuit-v2 spec, a reservation rejected because the relay is at
-    -- capacity is RESERVATION_REFUSED (200); RESOURCE_LIMIT_EXCEEDED (201)
-    -- is reserved for relayed-connection limits on CONNECT.
-    then sendHopStatus stream ReservationRefused
-    else do
-      -- Create reservation. Per circuit-v2 spec, Reservation.expire is an
-      -- absolute UTC Unix time in seconds, not a duration.
+handleReserve :: RelayState -> HopContext -> StreamIO -> PeerId -> IO ()
+handleReserve state ctx stream peerId
+  -- Per circuit-v2 spec, relays must not serve requests arriving over an
+  -- already-relayed connection (no relay chains).
+  | isRelayedAddr (hcRemoteAddr ctx) = sendHopStatus stream PermissionDenied
+  | otherwise = do
+      -- Per circuit-v2 spec, Reservation.expire is an absolute UTC Unix
+      -- time in seconds, not a duration.
       now <- getPOSIXTime
       let expiration = floor now + rcReservationDuration (rsConfig state)
           reservation = ActiveReservation
             { arPeerId = peerId
             , arExpiration = expiration
             }
-      atomically $ modifyTVar' (rsReservations state) (Map.insert peerId reservation)
-      -- Send OK response with reservation info
-      let resp = HopMessage
-            { hopType = Just HopStatus
-            , hopPeer = Nothing
-            , hopReservation = Just Reservation
-                { rsvExpire = Just expiration
-                , rsvAddrs = []  -- relay would populate with own addresses
-                , rsvVoucher = Nothing  -- voucher signing handled separately
+      granted <- atomically $ do
+        reservations <- readTVar (rsReservations state)
+        let limit = rcMaxReservations (rsConfig state)
+            isRefresh = Map.member peerId reservations
+        -- A refresh from an existing holder is not a new reservation: it
+        -- must succeed even when the relay is at capacity.
+        if not isRefresh && Map.size reservations >= limit
+          then pure False
+          else do
+            modifyTVar' (rsReservations state) (Map.insert peerId reservation)
+            pure True
+      if not granted
+        -- Per circuit-v2 spec, a reservation rejected because the relay is
+        -- at capacity is RESERVATION_REFUSED (200); RESOURCE_LIMIT_EXCEEDED
+        -- (201) is reserved for relayed-connection limits on CONNECT.
+        then sendHopStatus stream ReservationRefused
+        else do
+          -- Send OK response with reservation info
+          let resp = HopMessage
+                { hopType = Just HopStatus
+                , hopPeer = Nothing
+                , hopReservation = Just Reservation
+                    { rsvExpire = Just expiration
+                    , rsvAddrs = map toBytes (hcRelayAddrs ctx)
+                    , rsvVoucher = signVoucher ctx peerId expiration
+                    }
+                , hopLimit = Just RelayLimit
+                    { rlDuration = Just (rcDefaultDurationLimit (rsConfig state))
+                    , rlData = Just (rcDefaultDataLimit (rsConfig state))
+                    }
+                , hopStatus = Just RelayOK
                 }
-            , hopLimit = Just RelayLimit
-                { rlDuration = Just (rcDefaultDurationLimit (rsConfig state))
-                , rlData = Just (rcDefaultDataLimit (rsConfig state))
-                }
-            , hopStatus = Just RelayOK
-            }
-      writeHopMessage stream resp
+          writeHopMessage stream resp
+
+-- | Sign a reservation voucher: a circuit-v2 Voucher payload wrapped in an
+-- RFC 0002 signed envelope under the relay-rsvp domain.
+signVoucher :: HopContext -> PeerId -> Word64 -> Maybe ByteString
+signVoucher ctx peerId expiration =
+  let payload = encodeVoucher Voucher
+        { vRelay = peerIdBytes (hcRelayId ctx)
+        , vPeer = peerIdBytes peerId
+        , vExpiration = expiration
+        }
+      kp = hcRelayKey ctx
+  in case createEnvelope (kpPrivate kp) (kpPublic kp) relayRsvpDomain relayRsvpPayloadType payload of
+       Left _    -> Nothing  -- voucher is optional per spec; omit if signing fails
+       Right env -> Just (encodeSignedEnvelope env)
 
 -- | Handle a CONNECT request from a peer.
 -- The openStopStream callback is used to open a stop stream to the target.
-handleConnect :: RelayState -> StreamIO -> PeerId -> HopMessage -> (PeerId -> IO (Maybe StreamIO)) -> IO ()
-handleConnect state stream sourcePeerId msg openStopStream = do
-  case hopPeer msg of
+handleConnect :: RelayState -> HopContext -> StreamIO -> PeerId -> HopMessage -> (PeerId -> IO (Maybe StreamIO)) -> IO ()
+handleConnect state ctx stream sourcePeerId msg openStopStream
+  -- Per circuit-v2 spec, a CONNECT arriving over an already-relayed
+  -- connection is refused: circuits cannot be chained through relays.
+  | isRelayedAddr (hcRemoteAddr ctx) = sendHopStatus stream PermissionDenied
+  | otherwise = case hopPeer msg of
     Nothing -> sendHopStatus stream MalformedMessage
     Just peer -> do
       let targetId = PeerId (rpId peer)
@@ -255,15 +313,18 @@ bridgeStreams mLimit streamA streamB = do
       streamClose streamB
 
 -- | Forward bytes from source to destination with a byte limit.
+-- The limit is checked before each read, so the circuit terminates as soon
+-- as exactly @limit@ bytes have been forwarded — no byte beyond the limit
+-- is consumed from the source.
 forwardWithLimit :: StreamIO -> StreamIO -> IORef Int -> Int -> IO ()
 forwardWithLimit src dst countRef limit = go
   where
     go = do
-      b <- streamReadByte src
       count <- readIORef countRef
       if count >= limit
         then pure ()  -- limit reached, stop forwarding
         else do
+          b <- streamReadByte src
           modifyIORef' countRef (+ 1)
           streamWrite dst (BS.singleton b)
           go
@@ -285,9 +346,13 @@ buildRelayAddrBytes relayAddr relayIdBytes targetIdBytes =
     p2pCircuitBytes :: ByteString
     p2pCircuitBytes = encodeUvarint 290
 
--- | Check if raw multiaddr bytes contain P2PCircuit (code 290).
--- Simple heuristic: look for the varint encoding of 290.
+-- | Check whether a multiaddr contains a p2p-circuit component.
+isRelayedAddr :: Multiaddr -> Bool
+isRelayedAddr (Multiaddr ps) = P2PCircuit `elem` ps
+
+-- | Check whether raw multiaddr bytes describe a relayed connection.
+-- Decodes the bytes structurally: the p2p-circuit byte pattern occurring
+-- inside another component (e.g. a peer ID) does not count, unlike the
+-- previous substring heuristic. Undecodable bytes are not relayed.
 isRelayedConnection :: ByteString -> Bool
-isRelayedConnection bs =
-  let circuitMarker = encodeUvarint 290
-  in circuitMarker `BS.isInfixOf` bs
+isRelayedConnection = either (const False) isRelayedAddr . fromBytes

--- a/src/LibP2P/NAT/Relay/Message.hs
+++ b/src/LibP2P/NAT/Relay/Message.hs
@@ -11,6 +11,7 @@
 -- Peer fields: id(1), addrs(2)
 -- Reservation fields: expire(1), addrs(2), voucher(3)
 -- Limit fields: duration(1), data(2)
+-- Voucher fields: relay(1), peer(2), expiration(3)
 module LibP2P.NAT.Relay.Message
   ( -- * Types
     HopMessageType (..)
@@ -21,6 +22,7 @@ module LibP2P.NAT.Relay.Message
   , RelayLimit (..)
   , HopMessage (..)
   , StopMessage (..)
+  , Voucher (..)
     -- * Status conversion
   , relayStatusToWord
   , wordToRelayStatus
@@ -38,6 +40,9 @@ module LibP2P.NAT.Relay.Message
   , decodeStopFramed
   , writeStopMessage
   , readStopMessage
+    -- * Voucher encode/decode
+  , encodeVoucher
+  , decodeVoucher
     -- * Constants
   , maxRelayMessageSize
   , hopProtocolId
@@ -148,6 +153,14 @@ data StopMessage = StopMessage
   , stopPeer   :: !(Maybe RelayPeer)        -- ^ field 2
   , stopLimit  :: !(Maybe RelayLimit)       -- ^ field 3
   , stopStatus :: !(Maybe RelayStatus)      -- ^ field 4
+  } deriving (Show, Eq)
+
+-- | Reservation voucher payload (circuit-v2 voucher.proto). Carried inside
+-- a signed envelope in the 'rsvVoucher' field.
+data Voucher = Voucher
+  { vRelay      :: !ByteString  -- ^ field 1: relay peer ID bytes
+  , vPeer       :: !ByteString  -- ^ field 2: reserving peer ID bytes
+  , vExpiration :: !Word64      -- ^ field 3: reservation expiration (Unix UTC)
   } deriving (Show, Eq)
 
 -- Encoding helpers
@@ -272,6 +285,23 @@ relayLimitParser :: Parser RawMessage RelayLimit
 relayLimitParser = RelayLimit
   <$> at (optional Decode.uint32) (FieldNumber 1)
   <*> at (optional Decode.uint64) (FieldNumber 2)
+
+-- | Encode a reservation voucher payload to protobuf.
+encodeVoucher :: Voucher -> ByteString
+encodeVoucher v = BL.toStrict $ Encode.toLazyByteString $
+     Encode.byteString (FieldNumber 1) (vRelay v)
+  <> Encode.byteString (FieldNumber 2) (vPeer v)
+  <> Encode.uint64 (FieldNumber 3) (vExpiration v)
+
+-- | Decode a reservation voucher payload from protobuf.
+decodeVoucher :: ByteString -> Either ParseError Voucher
+decodeVoucher = parse voucherParser
+
+voucherParser :: Parser RawMessage Voucher
+voucherParser = Voucher
+  <$> at (one Decode.byteString BS.empty) (FieldNumber 1)
+  <*> at (one Decode.byteString BS.empty) (FieldNumber 2)
+  <*> at (one Decode.uint64 0) (FieldNumber 3)
 
 -- Wire framing (same pattern as DHT/AutoNAT)
 

--- a/test/LibP2P/NAT/RegistrationSpec.hs
+++ b/test/LibP2P/NAT/RegistrationSpec.hs
@@ -7,11 +7,12 @@ module LibP2P.NAT.RegistrationSpec (spec) where
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import qualified Data.ByteString as BS
 import Data.Maybe (isJust)
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (KeyPair, publicKey)
 import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey, peerIdBytes)
-import LibP2P.Multiaddr (Multiaddr (..), toBytes)
+import LibP2P.Multiaddr (Multiaddr (..), fromBytes, toBytes)
 import LibP2P.Multiaddr.Protocol (Protocol (..))
 import LibP2P.MultistreamSelect.Negotiation
   ( NegotiationResult (..)
@@ -38,11 +39,12 @@ import LibP2P.NAT.DCUtR.Message
   , readHolePunchMessage
   , writeHolePunchMessage
   )
-import LibP2P.NAT.Relay.Client (makeReservation)
+import LibP2P.NAT.Relay.Client (connectViaRelay, makeReservation)
 import LibP2P.NAT.Relay.Message
   ( HopMessage (..)
   , RelayPeer (..)
   , RelayStatus (..)
+  , Reservation (..)
   , StopMessage (..)
   , StopMessageType (..)
   , hopProtocolId
@@ -199,3 +201,67 @@ spec = do
             hpType resp `shouldBe` HPConnect
             -- The handler advertises B's listen addresses
             hpObsAddrs resp `shouldSatisfy` (not . null)
+
+  describe "multi-host relay circuit" $ do
+    it "bridges reserve → connect → application data across three in-process hosts" $ do
+      -- Three real switches over TCP: relay R serves hop/stop, target A
+      -- reserves on R, source B connects to A through R, and application
+      -- data crosses the bridged circuit in both directions. Hole punching
+      -- against real NATs is out of reach in-process and is covered by the
+      -- interop work (issue #131).
+      (pidR, kpR) <- mkTestIdentity
+      swR <- newSwitch pidR kpR
+      addTransport swR =<< newTCPTransport
+      _ <- registerNATHandlers swR defaultNATConfig
+      addrsR <- switchListen swR defaultConnectionGater [loopbackAddr]
+      -- Target A: consumes the relayed stream (3 bytes in, 2 bytes reply)
+      relayedMVar <- newEmptyMVar
+      (pidA, kpA) <- mkTestIdentity
+      swA <- newSwitch pidA kpA
+      addTransport swA =<< newTCPTransport
+      let configA = defaultNATConfig
+            { ncOnRelayedStream = \src _mLimit stream -> do
+                payload <- mapM (\_ -> streamReadByte stream) [1..3 :: Int]
+                streamWrite stream (BS.pack [9, 8])
+                putMVar relayedMVar (src, payload)
+            }
+      _ <- registerNATHandlers swA configA
+      -- Source B
+      (pidB, kpB) <- mkTestIdentity
+      swB <- newSwitch pidB kpB
+      addTransport swB =<< newTCPTransport
+      result <- timeout 20000000 $ do
+        -- A dials R and reserves
+        connAR <- dial swA pidR [head addrsR] >>= either (fail . show) pure
+        hopA <- openProtoStream swA connAR hopProtocolId
+        rsv <- makeReservation hopA >>= either fail pure
+        hopStatus rsv `shouldBe` Just RelayOK
+        -- The reservation advertises R's addresses, each ending in /p2p/<R>
+        case hopReservation rsv of
+          Nothing -> expectationFailure "expected reservation in RESERVE response"
+          Just r -> do
+            rsvAddrs r `shouldSatisfy` (not . null)
+            mapM_
+              (\addrBytes -> case fromBytes addrBytes of
+                Right (Multiaddr ps) -> last ps `shouldBe` P2P (peerIdBytes pidR)
+                Left err -> expectationFailure $ "undecodable reservation addr: " ++ err)
+              (rsvAddrs r)
+        -- B dials R and connects to A through the circuit
+        connBR <- dial swB pidR [head addrsR] >>= either (fail . show) pure
+        hopB <- openProtoStream swB connBR hopProtocolId
+        connResp <- connectViaRelay hopB pidA >>= either fail pure
+        hopStatus connResp `shouldBe` Just RelayOK
+        -- Application data B → A through the bridged circuit
+        streamWrite hopB (BS.pack [1, 2, 3])
+        (src, payload) <- takeMVar relayedMVar
+        src `shouldBe` pidB
+        payload `shouldBe` [1, 2, 3]
+        -- and A → B back through the same circuit
+        reply <- mapM (\_ -> streamReadByte hopB) [1..2 :: Int]
+        reply `shouldBe` [9, 8]
+      switchClose swA
+      switchClose swB
+      switchClose swR
+      case result of
+        Nothing -> expectationFailure "multi-host relay circuit timed out"
+        Just () -> pure ()

--- a/test/LibP2P/NAT/Relay/ClientSpec.hs
+++ b/test/LibP2P/NAT/Relay/ClientSpec.hs
@@ -11,7 +11,11 @@ import LibP2P.NAT.Relay.Message
 import LibP2P.NAT.Relay
 import LibP2P.NAT.Relay.Client
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
-import LibP2P.Crypto.PeerId (PeerId (..))
+import LibP2P.Multiaddr (Multiaddr (..))
+import LibP2P.Multiaddr.Protocol (Protocol (..))
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (publicKey)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey, peerIdBytes)
 
 -- | Create an in-memory stream pair for testing.
 mkStreamPair :: IO (StreamIO, StreamIO)
@@ -35,6 +39,19 @@ testPeerId = PeerId (BS.pack [0x00, 0x24, 0x08, 0x01, 0x12, 0x20, 0xAA, 0xBB, 0x
 
 targetPeerId :: PeerId
 targetPeerId = PeerId (BS.pack [0x00, 0x24, 0x08, 0x01, 0x12, 0x20, 0x11, 0x22, 0x33, 0x44])
+
+-- | Hop context for a request arriving over a direct (non-relayed)
+-- connection, with a fresh relay identity and one public relay address.
+mkHopContext :: IO HopContext
+mkHopContext = do
+  Right kp <- generateKeyPair
+  let relayId = fromPublicKey (publicKey kp)
+  pure HopContext
+    { hcRelayId    = relayId
+    , hcRelayKey   = kp
+    , hcRelayAddrs = [Multiaddr [IP4 0xCB007105, TCP 4001, P2P (peerIdBytes relayId)]]
+    , hcRemoteAddr = Multiaddr [IP4 0xC0A80102, TCP 51234]
+    }
 
 spec :: Spec
 spec = do
@@ -190,6 +207,7 @@ spec = do
       --   A accepts the stop CONNECT via handleStop
       --   Application data flows both ways through the bridged circuit
       relayState <- newRelayState defaultRelayConfig
+      ctx <- mkHopContext
       let reserver = testPeerId    -- A: the peer holding the reservation
           source = targetPeerId    -- B: the peer connecting through the relay
       -- Step 1: A reserves on the relay
@@ -198,7 +216,7 @@ spec = do
             req <- readHopMessage relayAHop maxRelayMessageSize
             case req of
               Right msg | hopType msg == Just HopReserve ->
-                handleReserve relayState relayAHop reserver
+                handleReserve relayState ctx relayAHop reserver
               _ -> expectationFailure "relay expected a RESERVE request"
       withAsync relayReserveSide $ \reserveAsync -> do
         rsvResult <- makeReservation aHop
@@ -215,7 +233,7 @@ spec = do
             req <- readHopMessage relayBHop maxRelayMessageSize
             case req of
               Right msg | hopType msg == Just HopConnect ->
-                handleConnect relayState relayBHop source msg
+                handleConnect relayState ctx relayBHop source msg
                   (\pid -> pure (if pid == reserver then Just relayStop else Nothing))
               _ -> expectationFailure "relay expected a CONNECT request"
       withAsync relayConnectSide $ \_connectAsync ->

--- a/test/LibP2P/NAT/Relay/MessageSpec.hs
+++ b/test/LibP2P/NAT/Relay/MessageSpec.hs
@@ -239,3 +239,11 @@ spec = do
           encoded = encodeStopMessage msg
           decoded = decodeStopMessage encoded
       decoded `shouldBe` Right msg
+
+    it "Voucher payload encode → decode round-trip" $ do
+      let voucher = Voucher
+            { vRelay = BS.pack [0x00, 0x02, 0xAA, 0xBB]
+            , vPeer = BS.pack [0x00, 0x02, 0x11, 0x22]
+            , vExpiration = 1700003600
+            }
+      decodeVoucher (encodeVoucher voucher) `shouldBe` Right voucher

--- a/test/LibP2P/NAT/Relay/RelaySpec.hs
+++ b/test/LibP2P/NAT/Relay/RelaySpec.hs
@@ -15,7 +15,10 @@ import LibP2P.NAT.Relay
 import LibP2P.MultistreamSelect.Negotiation (StreamIO (..))
 import LibP2P.Multiaddr (Multiaddr (..), toBytes, fromBytes)
 import LibP2P.Multiaddr.Protocol (Protocol (..))
-import LibP2P.Crypto.PeerId (PeerId (..))
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (publicKey)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey, peerIdBytes)
+import LibP2P.Crypto.SignedEnvelope (decodeSignedEnvelope, sePayload, sePayloadType, verifyEnvelope)
 
 -- | Create an in-memory stream pair for testing.
 mkStreamPair :: IO (StreamIO, StreamIO)
@@ -40,6 +43,26 @@ testPeerId = PeerId (BS.pack [0x00, 0x24, 0x08, 0x01, 0x12, 0x20, 0xAA, 0xBB, 0x
 targetPeerId :: PeerId
 targetPeerId = PeerId (BS.pack [0x00, 0x24, 0x08, 0x01, 0x12, 0x20, 0x11, 0x22, 0x33, 0x44])
 
+-- | Hop context for a request arriving over a direct (non-relayed)
+-- connection, with a fresh relay identity and one public relay address.
+mkHopContext :: IO HopContext
+mkHopContext = do
+  Right kp <- generateKeyPair
+  let relayId = fromPublicKey (publicKey kp)
+  pure HopContext
+    { hcRelayId    = relayId
+    , hcRelayKey   = kp
+    , hcRelayAddrs = [Multiaddr [IP4 0xCB007105, TCP 4001, P2P (peerIdBytes relayId)]]
+    , hcRemoteAddr = Multiaddr [IP4 0xC0A80102, TCP 51234]
+    }
+
+-- | The same context but with the request arriving over a relayed connection.
+overRelayed :: HopContext -> HopContext
+overRelayed ctx = ctx
+  { hcRemoteAddr = Multiaddr
+      [IP4 0xCB007105, TCP 4001, P2P (BS.pack [0x00, 0x02, 0xAA, 0xBB]), P2PCircuit]
+  }
+
 spec :: Spec
 spec = do
   describe "Relay server handleReserve" $ do
@@ -54,7 +77,8 @@ spec = do
         , hopLimit = Nothing
         , hopStatus = Nothing
         }
-      handleReserve relayState serverStream testPeerId
+      ctx <- mkHopContext
+      handleReserve relayState ctx serverStream testPeerId
       -- Read response
       result <- readHopMessage clientStream maxRelayMessageSize
       case result of
@@ -78,7 +102,8 @@ spec = do
         , hopStatus = Nothing
         }
       now <- getPOSIXTime
-      handleReserve relayState serverStream testPeerId
+      ctx <- mkHopContext
+      handleReserve relayState ctx serverStream testPeerId
       result <- readHopMessage clientStream maxRelayMessageSize
       let nowSecs = floor now :: Word64
           duration = rcReservationDuration defaultRelayConfig
@@ -110,7 +135,8 @@ spec = do
         , hopLimit = Nothing
         , hopStatus = Nothing
         }
-      handleReserve relayState serverStream testPeerId
+      ctx <- mkHopContext
+      handleReserve relayState ctx serverStream testPeerId
       result <- readHopMessage clientStream maxRelayMessageSize
       case result of
         Right resp -> do
@@ -125,7 +151,134 @@ spec = do
       reservations <- readTVarIO (rsReservations relayState)
       Map.member testPeerId reservations `shouldBe` False
 
+    it "should allow a peer to refresh its own reservation when the relay is at capacity" $ do
+      let config = defaultRelayConfig { rcMaxReservations = 1 }
+      relayState <- newRelayState config
+      ctx <- mkHopContext
+      -- First reservation fills the relay to capacity
+      (clientStream1, serverStream1) <- mkStreamPair
+      handleReserve relayState ctx serverStream1 testPeerId
+      first <- readHopMessage clientStream1 maxRelayMessageSize
+      case first of
+        Right resp -> hopStatus resp `shouldBe` Just RelayOK
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      firstExpire <- do
+        reservations <- readTVarIO (rsReservations relayState)
+        case Map.lookup testPeerId reservations of
+          Just ar -> pure (arExpiration ar)
+          Nothing -> fail "expected stored reservation"
+      -- A refresh from the same peer is not a new reservation: it must
+      -- succeed even though Map.size == rcMaxReservations.
+      (clientStream2, serverStream2) <- mkStreamPair
+      handleReserve relayState ctx serverStream2 testPeerId
+      refreshed <- readHopMessage clientStream2 maxRelayMessageSize
+      case refreshed of
+        Right resp -> do
+          hopStatus resp `shouldBe` Just RelayOK
+          (hopReservation resp >>= rsvExpire) `shouldSatisfy` (/= Nothing)
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      -- Still exactly one reservation, with a refreshed (not earlier) expiry
+      reservations <- readTVarIO (rsReservations relayState)
+      Map.size reservations `shouldBe` 1
+      case Map.lookup testPeerId reservations of
+        Just ar -> arExpiration ar `shouldSatisfy` (>= firstExpire)
+        Nothing -> expectationFailure "expected stored reservation after refresh"
+      -- A different peer must still be refused at capacity
+      (clientStream3, serverStream3) <- mkStreamPair
+      handleReserve relayState ctx serverStream3 targetPeerId
+      other <- readHopMessage clientStream3 maxRelayMessageSize
+      case other of
+        Right resp -> hopStatus resp `shouldBe` Just ReservationRefused
+        Left err -> expectationFailure $ "Read failed: " ++ err
+
+    it "should populate the reservation with the relay's public addresses" $ do
+      relayState <- newRelayState defaultRelayConfig
+      ctx <- mkHopContext
+      (clientStream, serverStream) <- mkStreamPair
+      handleReserve relayState ctx serverStream testPeerId
+      result <- readHopMessage clientStream maxRelayMessageSize
+      case result of
+        Right resp -> case hopReservation resp of
+          Just rsv -> do
+            -- circuit-v2: addrs contains the relay's public addresses
+            -- (including /p2p/<relay>, without a trailing /p2p-circuit)
+            rsvAddrs rsv `shouldBe` map toBytes (hcRelayAddrs ctx)
+            rsvAddrs rsv `shouldSatisfy` (not . null)
+          Nothing -> expectationFailure "Expected reservation in response"
+        Left err -> expectationFailure $ "Read failed: " ++ err
+
+    it "should attach a voucher that verifies as a relay-signed envelope over the reservation" $ do
+      relayState <- newRelayState defaultRelayConfig
+      ctx <- mkHopContext
+      (clientStream, serverStream) <- mkStreamPair
+      handleReserve relayState ctx serverStream testPeerId
+      result <- readHopMessage clientStream maxRelayMessageSize
+      voucherBytes <- case result of
+        Right resp -> case hopReservation resp >>= rsvVoucher of
+          Just vb -> pure vb
+          Nothing -> fail "Expected voucher in reservation"
+        Left err -> fail $ "Read failed: " ++ err
+      -- The voucher is an RFC 0002 signed envelope under the relay-rsvp domain
+      case decodeSignedEnvelope voucherBytes of
+        Left err -> expectationFailure $ "Voucher envelope decode failed: " ++ err
+        Right env -> do
+          sePayloadType env `shouldBe` relayRsvpPayloadType
+          verifyEnvelope env relayRsvpDomain `shouldBe` True
+          -- The signed payload identifies relay, reserving peer and expiry
+          case decodeVoucher (sePayload env) of
+            Left err -> expectationFailure $ "Voucher payload decode failed: " ++ show err
+            Right voucher -> do
+              vRelay voucher `shouldBe` peerIdBytes (hcRelayId ctx)
+              vPeer voucher `shouldBe` peerIdBytes testPeerId
+              vExpiration voucher `shouldSatisfy` (> 0)
+
+    it "should refuse a RESERVE arriving over an already-relayed connection with PERMISSION_DENIED" $ do
+      relayState <- newRelayState defaultRelayConfig
+      ctx <- overRelayed <$> mkHopContext
+      (clientStream, serverStream) <- mkStreamPair
+      handleReserve relayState ctx serverStream testPeerId
+      result <- readHopMessage clientStream maxRelayMessageSize
+      case result of
+        Right resp -> do
+          hopStatus resp `shouldBe` Just PermissionDenied
+          hopReservation resp `shouldBe` Nothing
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      -- No reservation may be stored for the refused peer
+      reservations <- readTVarIO (rsReservations relayState)
+      Map.member testPeerId reservations `shouldBe` False
+
   describe "Relay server handleConnect" $ do
+    it "should refuse a CONNECT arriving over an already-relayed connection with PERMISSION_DENIED" $ do
+      relayState <- newRelayState defaultRelayConfig
+      -- Even with a valid target reservation, relay chains are refused
+      now <- getPOSIXTime
+      let valid = ActiveReservation
+            { arPeerId = targetPeerId
+            , arExpiration = floor now + 3600
+            }
+      atomically $ modifyTVar' (rsReservations relayState) (Map.insert targetPeerId valid)
+      ctx <- overRelayed <$> mkHopContext
+      (clientStream, serverStream) <- mkStreamPair
+      let connectReq = HopMessage
+            { hopType = Just HopConnect
+            , hopPeer = Just RelayPeer
+                { rpId = let PeerId bs = targetPeerId in bs
+                , rpAddrs = []
+                }
+            , hopReservation = Nothing
+            , hopLimit = Nothing
+            , hopStatus = Nothing
+            }
+      writeHopMessage clientStream connectReq
+      handleConnect relayState ctx serverStream testPeerId connectReq (\_pid -> pure Nothing)
+      result <- readHopMessage clientStream maxRelayMessageSize
+      case result of
+        Right resp -> hopStatus resp `shouldBe` Just PermissionDenied
+        Left err -> expectationFailure $ "Read failed: " ++ err
+      -- The refused CONNECT must not consume circuit slots
+      counts <- readTVarIO (rsCircuitCounts relayState)
+      counts `shouldBe` Map.empty
+
     it "should reject CONNECT with NO_RESERVATION when the target reservation has expired" $ do
       relayState <- newRelayState defaultRelayConfig
       -- Insert an already-expired reservation for the target
@@ -147,7 +300,8 @@ spec = do
             , hopStatus = Nothing
             }
       writeHopMessage clientStream connectReq
-      handleConnect relayState serverStream testPeerId connectReq (\_pid -> pure Nothing)
+      ctx <- mkHopContext
+      handleConnect relayState ctx serverStream testPeerId connectReq (\_pid -> pure Nothing)
       result <- readHopMessage clientStream maxRelayMessageSize
       case result of
         Right resp -> hopStatus resp `shouldBe` Just NoReservation
@@ -178,7 +332,8 @@ spec = do
             , hopStatus = Nothing
             }
       writeHopMessage clientStream connectReq
-      handleConnect relayState serverStream testPeerId connectReq (\_pid -> pure Nothing)
+      ctx <- mkHopContext
+      handleConnect relayState ctx serverStream testPeerId connectReq (\_pid -> pure Nothing)
       result <- readHopMessage clientStream maxRelayMessageSize
       case result of
         Right resp -> hopStatus resp `shouldBe` Just ResourceLimitExceeded
@@ -207,7 +362,8 @@ spec = do
             , hopStatus = Nothing
             }
       writeHopMessage clientStream connectReq
-      let runConnect = handleConnect relayState serverStream testPeerId connectReq
+      ctx <- mkHopContext
+      let runConnect = handleConnect relayState ctx serverStream testPeerId connectReq
                          (\_pid -> pure (Just relayStopStream))
       withAsync runConnect $ \connectAsync -> do
         -- Fake target: accept the STOP CONNECT
@@ -249,7 +405,8 @@ spec = do
             , hopStatus = Nothing
             }
       writeHopMessage clientStream connectReq
-      handleConnect relayState serverStream testPeerId connectReq (\_pid -> pure Nothing)
+      ctx <- mkHopContext
+      handleConnect relayState ctx serverStream testPeerId connectReq (\_pid -> pure Nothing)
       result <- readHopMessage clientStream maxRelayMessageSize
       case result of
         Right resp -> hopStatus resp `shouldBe` Just NoReservation
@@ -266,7 +423,8 @@ spec = do
             , hopStatus = Nothing
             }
       writeHopMessage clientStream connectReq
-      handleConnect relayState serverStream testPeerId connectReq (\_pid -> pure Nothing)
+      ctx <- mkHopContext
+      handleConnect relayState ctx serverStream testPeerId connectReq (\_pid -> pure Nothing)
       result <- readHopMessage clientStream maxRelayMessageSize
       case result of
         Right resp -> hopStatus resp `shouldBe` Just MalformedMessage
@@ -293,7 +451,8 @@ spec = do
             }
       writeHopMessage clientStream connectReq
       -- Target has a valid reservation, but the relay cannot reach it
-      handleConnect relayState serverStream testPeerId connectReq (\_pid -> pure Nothing)
+      ctx <- mkHopContext
+      handleConnect relayState ctx serverStream testPeerId connectReq (\_pid -> pure Nothing)
       result <- readHopMessage clientStream maxRelayMessageSize
       case result of
         Right resp -> hopStatus resp `shouldBe` Just ConnectionFailed
@@ -323,7 +482,8 @@ spec = do
             , hopStatus = Nothing
             }
       writeHopMessage clientStream connectReq
-      let runConnect = handleConnect relayState serverStream testPeerId connectReq
+      ctx <- mkHopContext
+      let runConnect = handleConnect relayState ctx serverStream testPeerId connectReq
                          (\_pid -> pure (Just relayStopStream))
       withAsync runConnect $ \connectAsync -> do
         -- Fake target refuses the incoming circuit
@@ -379,11 +539,9 @@ spec = do
             }
           -- Limit of 5 bytes per direction
           limitCfg = Just RelayLimit { rlDuration = Nothing, rlData = Just 5 }
-      -- Queue 6 bytes (one past the limit) before starting the bridge.
-      -- NOTE (#177): the bridge currently only detects the limit after
-      -- reading byte limit+1 from the source; sending exactly `limit` bytes
-      -- does not terminate the circuit. This test therefore sends limit+1
-      -- bytes and asserts termination, forwarding cut-off, and stream close.
+      -- Queue 6 bytes (one past the limit) before starting the bridge. The
+      -- bridge must cut the circuit at exactly `limit` forwarded bytes and
+      -- leave byte limit+1 unconsumed (see the exact-at-limit test below).
       streamWrite streamA1 (BS.pack [1, 2, 3, 4, 5, 6])
       result <- race
         (bridgeStreams limitCfg
@@ -397,6 +555,27 @@ spec = do
       bs <- mapM (\_ -> streamReadByte streamB2) [1..5 :: Int]
       bs `shouldBe` [1, 2, 3, 4, 5]
       -- Both sides of the circuit must be torn down
+      readIORef closedA `shouldReturn` True
+      readIORef closedB `shouldReturn` True
+
+    it "should terminate the bridge once exactly the data limit has been forwarded" $ do
+      (streamA1, streamA2) <- mkStreamPair
+      (streamB1, streamB2) <- mkStreamPair
+      closedA <- newIORef False
+      closedB <- newIORef False
+      let trackClose ref s = s { streamClose = modifyIORef' ref (const True) }
+          limitCfg = Just RelayLimit { rlDuration = Nothing, rlData = Just 5 }
+      -- Exactly the limit's worth of data: the circuit must terminate on its
+      -- own without the bridge having to consume byte limit+1 first.
+      streamWrite streamA1 (BS.pack [1, 2, 3, 4, 5])
+      result <- race
+        (bridgeStreams limitCfg
+           (trackClose closedA streamA2)
+           (trackClose closedB streamB1))
+        (threadDelay 2000000)
+      result `shouldBe` Left ()
+      bs <- mapM (\_ -> streamReadByte streamB2) [1..5 :: Int]
+      bs `shouldBe` [1, 2, 3, 4, 5]
       readIORef closedA `shouldReturn` True
       readIORef closedB `shouldReturn` True
 
@@ -452,3 +631,14 @@ spec = do
       isRelayedConnection circuitAddr `shouldBe` True
       isRelayedConnection directAddr `shouldBe` False
       isRelayedConnection BS.empty `shouldBe` False
+
+    it "should not report a relayed connection when a peer id merely contains the p2p-circuit byte pattern" $ do
+      -- The varint encoding of the p2p-circuit code (290) is 0xA2 0x02. A
+      -- substring scan misfires when those bytes appear inside another
+      -- component, e.g. an identity-multihash peer id with digest A2 02.
+      let trickyPeerId = BS.pack [0x00, 0x02, 0xA2, 0x02]
+          directAddr = toBytes (Multiaddr [IP4 0xCB007101, TCP 4001, P2P trickyPeerId])
+      isRelayedConnection directAddr `shouldBe` False
+      -- Structural inspection must still detect a real circuit component
+      let circuitAddr = toBytes (Multiaddr [IP4 0xCB007101, TCP 4001, P2P trickyPeerId, P2PCircuit])
+      isRelayedConnection circuitAddr `shouldBe` True


### PR DESCRIPTION
## Summary

PR #202 fixed the six assert-nothing NAT tests and listed six src-dependent gaps as out of scope. Since then #207 fixed the reservation-cap status code and #198 registered the NAT handlers on the Switch. This PR closes everything that remained, with a failing-test-first fix for each src change.

## Src fixes (per circuit-v2)

| Gap | Fix |
|---|---|
| Refresh at capacity | `handleReserve` treats a RESERVE from an existing holder as a refresh: it succeeds at `rcMaxReservations`, updates the stored expiration, and still refuses new peers with `RESERVATION_REFUSED`. Capacity check + insert are now one STM transaction. |
| `rsvAddrs` empty | The reservation response carries the relay's public addresses, each with the `/p2p/<relay>` suffix and no trailing `/p2p-circuit`, exactly as circuit-v2 specifies for reservation addrs. |
| Voucher missing | Implemented — #140's SignedEnvelope landed, so the voucher is no longer blocked: a circuit-v2 `Voucher` payload (relay, peer, expiration; new encode/decode in `Relay/Message.hs`) wrapped in an RFC 0002 signed envelope under the `libp2p-relay-rsvp` domain (payload type `0x0302`), signed with the relay identity key. |
| Relayed-connection refusal | `handleReserve`/`handleConnect` now take a `HopContext` (relay identity, public addrs, remote address of the requesting connection — available since #195) and refuse requests arriving over an already-relayed connection with `PERMISSION_DENIED`: no relay chains. The Switch builds the context from `connRemoteAddr`/`switchListenAddrs`. |
| Exact-at-limit termination | `forwardWithLimit` checks the byte limit before reading, so the circuit ends once exactly `limit` bytes are forwarded; byte `limit+1` is never consumed. |
| `isRelayedConnection` false positive | Structural multiaddr decoding replaces the `0xA2 0x02` substring scan, which misfired on peer ids containing that byte pattern. New `isRelayedAddr :: Multiaddr -> Bool` for the typed path. |

## New tests

- Refresh-at-capacity: same peer OK + expiry advances + other peer still refused (verified to fail with the refresh branch disabled).
- `rsvAddrs` equals the relay's advertised addresses; voucher decodes, verifies against the relay-rsvp domain, and its payload names relay/peer/expiration.
- RESERVE and CONNECT over a relayed connection: `PERMISSION_DENIED`, nothing stored, no circuit-slot leak.
- Exact-at-limit bridge termination (failing first: `race` timed out on the unfixed code) and the substring-false-positive regression (failing first: `True`).
- Voucher protobuf round-trip.
- **Multi-host**: three real switches over TCP — target reserves on the relay (asserting the advertised addrs end in `/p2p/<relay>`), source CONNECTs, and application data crosses the bridged circuit in both directions. Ran repeatedly without flakes. NAT-level hole punching stays with the interop work (#131).

## Test results

`cabal test` (GHC 9.10.3): **969 examples, 0 failures**. TDD breakage checks reverted before commit.

Closes #177