### PR TITLE
test: gossipsub #175 remainder — extended validators, two-router wire harness, hardening

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -191,6 +191,7 @@ test-suite libp2p-hs-test
     LibP2P.Protocol.GossipSub.MessageCacheSpec
     LibP2P.Protocol.GossipSub.HeartbeatSpec
     LibP2P.Protocol.GossipSub.HandlerSpec
+    LibP2P.Protocol.GossipSub.MultiNodeSpec
     LibP2P.IntegrationSpec
     LibP2P.FaultInjectionSpec
     LibP2P.WireConformanceSpec

--- a/src/LibP2P/Protocol/GossipSub/Router.hs
+++ b/src/LibP2P/Protocol/GossipSub/Router.hs
@@ -116,8 +116,10 @@ newRouter params localPid sendRPC getTime = do
 
 -- Topic validation
 
--- | Attach an application validator to a topic. Messages the validator rejects
--- are dropped without propagation and count against the sender's P4 score.
+-- | Attach an application validator to a topic. Messages the validator
+-- rejects are dropped without propagation and count against the sender's
+-- P4 score; ignored messages are dropped without any penalty
+-- (gossipsub-v1.1.md extended validators).
 registerValidator :: GossipSubRouter -> Topic -> TopicValidator -> IO ()
 registerValidator router topic v = atomically $
   modifyTVar' (gsValidators router) (Map.insert topic v)
@@ -495,10 +497,14 @@ handlePublishedMessage router sender msg =
           -- in our mesh and delivered within the near-first window
           creditMeshDelivery router sender topic (Just (firstSeen, now))
         Nothing -> do
-          accepted <- runTopicValidator router sender msg
-          if not accepted
-            then rejectMessage router sender msg
-            else do
+          outcome <- runTopicValidator router sender msg
+          case outcome of
+            -- Provably invalid: drop and penalise the source (P4)
+            ValidationReject -> rejectMessage router sender msg
+            -- Undecidable: drop without penalty (extended validators,
+            -- gossipsub-v1.1.md — Ignore must not affect the score)
+            ValidationIgnore -> pure ()
+            ValidationAccept -> do
               -- First valid delivery: P2, plus P3 for mesh senders (#156)
               creditFirstDelivery router sender topic
               creditMeshDelivery router sender topic Nothing
@@ -549,11 +555,11 @@ creditMeshDelivery router sender topic mWindow = do
       sender
 
 -- | Run the topic validator, if one is registered. No validator means accept.
-runTopicValidator :: GossipSubRouter -> PeerId -> PubSubMessage -> IO Bool
+runTopicValidator :: GossipSubRouter -> PeerId -> PubSubMessage -> IO ValidationResult
 runTopicValidator router sender msg = do
   validators <- readTVarIO (gsValidators router)
   case Map.lookup (msgTopic msg) validators of
-    Nothing -> pure True
+    Nothing -> pure ValidationAccept
     Just v  -> v sender msg
 
 -- | Drop a message and charge the propagation source a P4 invalid delivery.

--- a/src/LibP2P/Protocol/GossipSub/Types.hs
+++ b/src/LibP2P/Protocol/GossipSub/Types.hs
@@ -31,6 +31,7 @@ module LibP2P.Protocol.GossipSub.Types
     -- * Errors
   , GossipSubError (..)
     -- * Topic validation
+  , ValidationResult (..)
   , TopicValidator
     -- * Configuration
   , GossipSubParams (..)
@@ -187,10 +188,23 @@ instance Exception GossipSubError
 
 -- Topic validation
 
--- | Application validator for a topic. Receives the propagation source and the
--- message; returning False drops the message without propagation
--- (specs/pubsub/README.md, "Topic validation").
-type TopicValidator = PeerId -> PubSubMessage -> IO Bool
+-- | Outcome of an application topic validator (gossipsub-v1.1.md
+-- "Extended Validators"). The trichotomy exists because rejection is a
+-- scoring event while ignoring is not: a message that is provably invalid
+-- (Reject) counts against the propagation source's P4 counter, whereas a
+-- message that merely cannot be validated right now (Ignore) is dropped
+-- without penalising the peer that relayed it.
+data ValidationResult
+  = ValidationAccept  -- ^ Deliver and propagate the message
+  | ValidationReject  -- ^ Drop without propagation; penalise the source (P4)
+  | ValidationIgnore  -- ^ Drop without propagation; no penalty
+  deriving (Show, Eq)
+
+-- | Application validator for a topic. Receives the propagation source and
+-- the message and decides whether it is delivered and forwarded
+-- (specs/pubsub/README.md "Topic validation"; gossipsub-v1.1.md extended
+-- validators).
+type TopicValidator = PeerId -> PubSubMessage -> IO ValidationResult
 
 -- Configuration
 

--- a/test/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HeartbeatSpec.hs
@@ -11,7 +11,7 @@ import Data.Time (UTCTime, addUTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import LibP2P.Crypto.PeerId (PeerId (..))
 import LibP2P.Protocol.GossipSub.Types
-import LibP2P.Protocol.GossipSub.Router (newRouter, addPeer, peerScore)
+import LibP2P.Protocol.GossipSub.Router (newRouter, addPeer, handleIHave, peerScore)
 import LibP2P.Protocol.GossipSub.MessageCache (newMessageCache, cachePut, cacheGetGossipIds)
 import LibP2P.Protocol.GossipSub.Score (markPeerInMesh)
 import LibP2P.Protocol.GossipSub.Heartbeat
@@ -98,6 +98,31 @@ spec = do
                 Nothing -> False) sent
         length pruneMsgs `shouldSatisfy` (>= 1)
 
+      it "withholds PX in the PRUNE to a negative-score peer" $ do
+        -- gossipsub-v1.1.md peer exchange: PX is only supplied to peers in
+        -- good standing — handing an attacker a list of topic peers on the
+        -- way out would aid eclipse attacks.
+        (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
+        let bad = mkPeerId 1
+            routerNeg = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = \pid ->
+                      if pid == bad then -1 else 0 } }
+        addMeshPeer routerNeg bad "t" fixedTime
+        -- Other well-scoring topic peers exist, so PX would have content
+        mapM_ (\n -> addSubscribedPeer routerNeg (mkPeerId n) "t" fixedTime)
+          [2..5 :: Int]
+        heartbeatOnce routerNeg
+        sent <- readIORef logRef
+        let prunes = [ p | (to, rpc) <- sent, to == bad
+                         , Just ctrl <- [rpcControl rpc], p <- ctrlPrune ctrl ]
+        case prunes of
+          [p] -> prunePeers p `shouldBe` []
+          _   -> expectationFailure "expected exactly one PRUNE to the bad peer"
+        -- And the backoff penalty is recorded
+        backoff <- readTVarIO (gsBackoff routerNeg)
+        Map.member (bad, "t") backoff `shouldBe` True
+
       it "GRAFTs when mesh is undersubscribed (< D_lo)" $ do
         (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
         -- D=6, D_lo=4: add 2 mesh peers + 4 more subscribed but not in mesh
@@ -137,6 +162,31 @@ spec = do
         mesh <- readTVarIO (gsMesh router)
         let meshPeers = Map.findWithDefault Set.empty "t" mesh
         Set.member backoffPeer meshPeers `shouldBe` False
+
+      it "enforces the backoff across heartbeats and grafts after expiry" $ do
+        -- gossipsub-v1.1.md backoff: the pruned peer stays out of the mesh
+        -- for the whole backoff window, however many heartbeats that
+        -- spans, and becomes an ordinary candidate again once it ends.
+        (router, _, timeRef) <- mkHeartbeatRouter localPid fixedTime
+        let pid = mkPeerId 1
+        addSubscribedPeer router pid "t" fixedTime
+        atomically $ do
+          modifyTVar' (gsSubscriptions router) (Set.insert "t")
+          modifyTVar' (gsBackoff router) $
+            Map.insert (pid, "t") (addUTCTime 30 fixedTime)
+        let inMesh = do
+              mesh <- readTVarIO (gsMesh router)
+              pure (Set.member pid (Map.findWithDefault Set.empty "t" mesh))
+        -- Two heartbeats inside the window: still excluded
+        heartbeatOnce router
+        inMesh `shouldReturn` False
+        writeIORef timeRef (addUTCTime 15 fixedTime)
+        heartbeatOnce router
+        inMesh `shouldReturn` False
+        -- First heartbeat after expiry: grafted again
+        writeIORef timeRef (addUTCTime 31 fixedTime)
+        heartbeatOnce router
+        inMesh `shouldReturn` True
 
       it "PRUNEs when mesh is oversubscribed (> D_hi)" $ do
         (router, logRef, _) <- mkHeartbeatRouter localPid fixedTime
@@ -395,6 +445,26 @@ spec = do
           Nothing -> expectationFailure "peer not found"
         promises <- readTVarIO (gsIWantPromises router)
         promises `shouldBe` Map.empty
+
+      it "drives the peer's score negative after a broken IHAVE promise" $ do
+        -- End-to-end P7: the promise is created by the router's own
+        -- IHAVE handling (not injected), expires on heartbeat, and the
+        -- resulting penalty is visible in peerScore — w7 is negative by
+        -- default, so a broken promise alone must take the score below 0.
+        (router, _, timeRef) <- mkHeartbeatRouter localPid fixedTime
+        let pid = mkPeerId 1
+        addPeer router pid GossipSubPeer False fixedTime
+        peerScore router pid `shouldReturn` 0
+        -- Peer advertises a message id we have not seen: router IWANTs it
+        -- and records the promise with deadline paramIWantFollowupTime (3s)
+        handleIHave router pid [IHave "t" [BS.pack [1]]]
+        promises <- readTVarIO (gsIWantPromises router)
+        Map.member (pid, BS.pack [1]) promises `shouldBe` True
+        -- The peer never delivers; past the deadline the promise breaks
+        writeIORef timeRef (addUTCTime 4 fixedTime)
+        heartbeatOnce router
+        score <- peerScore router pid
+        score `shouldSatisfy` (< 0)
 
       it "does not penalize before the deadline" $ do
         (router, _, _) <- mkHeartbeatRouter localPid fixedTime

--- a/test/LibP2P/Protocol/GossipSub/MultiNodeSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/MultiNodeSpec.hs
@@ -1,0 +1,152 @@
+-- | Multi-router GossipSub tests (#175).
+--
+-- Two complete routers are wired to each other through their injectable
+-- 'gsSendRPC' functions: every RPC a router emits is handed synchronously
+-- to the other router's 'handleRPC', so the full wire protocol
+-- (subscription announcements, GRAFT/PRUNE, publish, IHAVE/IWANT) runs
+-- between two independent router states with no threads, no sleeps and no
+-- shared TVars. A per-link gate simulates message loss for the
+-- gossip-recovery scenario.
+module LibP2P.Protocol.GossipSub.MultiNodeSpec (spec) where
+
+import Test.Hspec
+
+import Control.Concurrent.STM
+import Control.Monad (when)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.IORef
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Time (UTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair (..))
+import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.Protocol.GossipSub.Heartbeat (heartbeatOnce)
+import LibP2P.Protocol.GossipSub.Router
+import LibP2P.Protocol.GossipSub.Types
+
+fixedTime :: UTCTime
+fixedTime = posixSecondsToUTCTime 1000000
+
+-- | A node: identity, router, delivered payloads, and a link gate that
+-- drops this node's outbound RPCs while closed.
+data Node = Node
+  { nodePid       :: PeerId
+  , nodeKey       :: KeyPair
+  , nodeRouter    :: GossipSubRouter
+  , nodeDelivered :: IORef [ByteString]
+  , nodeGate      :: IORef Bool
+  }
+
+-- | Build two routers whose sendRPC functions feed each other's handleRPC
+-- directly. Mesh-based publish (no flood) so mesh delivery and gossip
+-- recovery are distinguishable.
+mkLinkedPair :: IO (Node, Node)
+mkLinkedPair = do
+  kpA <- either (error . ("keygen failed: " <>)) pure =<< generateKeyPair
+  kpB <- either (error . ("keygen failed: " <>)) pure =<< generateKeyPair
+  let pidA = fromPublicKey (kpPublic kpA)
+      pidB = fromPublicKey (kpPublic kpB)
+      params = defaultGossipSubParams { paramFloodPublish = False }
+  gateA <- newIORef True
+  gateB <- newIORef True
+  -- Tie the recursive knot: each sender needs the other router
+  routerBRef <- newIORef (error "routerB not yet created")
+  routerARef <- newIORef (error "routerA not yet created")
+  let sendA to rpc = when (to == pidB) $ do
+        open <- readIORef gateA
+        when open $ do
+          rb <- readIORef routerBRef
+          handleRPC rb pidA rpc
+      sendB to rpc = when (to == pidA) $ do
+        open <- readIORef gateB
+        when open $ do
+          ra <- readIORef routerARef
+          handleRPC ra pidB rpc
+  routerA <- newRouter params pidA sendA (pure fixedTime)
+  routerB <- newRouter params pidB sendB (pure fixedTime)
+  writeIORef routerARef routerA
+  writeIORef routerBRef routerB
+  deliveredA <- newIORef []
+  deliveredB <- newIORef []
+  atomically $ do
+    writeTVar (gsOnMessage routerA) (\_ msg -> modifyIORef' deliveredA (++ [msgData msg]))
+    writeTVar (gsOnMessage routerB) (\_ msg -> modifyIORef' deliveredB (++ [msgData msg]))
+  -- Both sides register the connection (normally done by the stream handler)
+  addPeer routerA pidB GossipSubPeer True fixedTime
+  addPeer routerB pidA GossipSubPeer False fixedTime
+  pure ( Node pidA kpA routerA deliveredA gateA
+       , Node pidB kpB routerB deliveredB gateB
+       )
+
+spec :: Spec
+spec = do
+  describe "GossipSub.MultiNode (two wired routers)" $ do
+    it "forms a mesh over the wire: join announcements lead to mutual GRAFT" $ do
+      (a, b) <- mkLinkedPair
+      join (nodeRouter a) "t"   -- announces to B before B subscribes
+      join (nodeRouter b) "t"   -- announces to A, then GRAFTs A
+      -- B selected A into its mesh and A accepted the GRAFT
+      meshB <- readTVarIO (gsMesh (nodeRouter b))
+      Map.findWithDefault Set.empty "t" meshB `shouldBe` Set.singleton (nodePid a)
+      meshA <- readTVarIO (gsMesh (nodeRouter a))
+      Map.findWithDefault Set.empty "t" meshA `shouldBe` Set.singleton (nodePid b)
+      -- Each router learned the other's subscription from the wire
+      peersA <- readTVarIO (gsPeers (nodeRouter a))
+      fmap psTopics (Map.lookup (nodePid b) peersA) `shouldBe` Just (Set.singleton "t")
+      peersB <- readTVarIO (gsPeers (nodeRouter b))
+      fmap psTopics (Map.lookup (nodePid a) peersB) `shouldBe` Just (Set.singleton "t")
+
+    it "delivers via the mesh, then recovers a lost message via IHAVE/IWANT" $ do
+      (a, b) <- mkLinkedPair
+      join (nodeRouter a) "t"
+      join (nodeRouter b) "t"
+
+      -- Phase 1: mesh delivery. A publishes; the signed message crosses
+      -- the wire, passes B's StrictSign validation and reaches B's app.
+      publish (nodeRouter a) "t" (BS.pack [1]) (Just (nodeKey a))
+      readIORef (nodeDelivered b) `shouldReturn` [BS.pack [1]]
+
+      -- Phase 2: B drops out of A's mesh (PRUNE over the wire, with a
+      -- backoff so A's heartbeat cannot immediately re-graft it).
+      handleRPC (nodeRouter a) (nodePid b) emptyRPC
+        { rpcControl = Just emptyControlMessage
+            { ctrlPrune = [Prune "t" [] (Just 300)] } }
+      meshA <- readTVarIO (gsMesh (nodeRouter a))
+      Map.findWithDefault Set.empty "t" meshA `shouldBe` Set.empty
+
+      -- Phase 3: the link drops while A publishes; B never sees the message.
+      writeIORef (nodeGate a) False
+      publish (nodeRouter a) "t" (BS.pack [2]) (Just (nodeKey a))
+      readIORef (nodeDelivered b) `shouldReturn` [BS.pack [1]]
+
+      -- Phase 4: link restored; A's heartbeat gossips IHAVE to B (a
+      -- non-mesh topic peer), B IWANTs the unseen id, A serves it from
+      -- the mcache, and B finally delivers it — all in one synchronous
+      -- heartbeat call.
+      writeIORef (nodeGate a) True
+      heartbeatOnce (nodeRouter a)
+      readIORef (nodeDelivered b) `shouldReturn` [BS.pack [1], BS.pack [2]]
+      -- B is still outside A's mesh: this was gossip, not mesh repair
+      meshA' <- readTVarIO (gsMesh (nodeRouter a))
+      Map.findWithDefault Set.empty "t" meshA' `shouldBe` Set.empty
+      -- The IWANT promise B recorded against A was fulfilled
+      promisesB <- readTVarIO (gsIWantPromises (nodeRouter b))
+      promisesB `shouldBe` Map.empty
+
+    it "dedups over the wire: a re-sent message is not delivered twice" $ do
+      (a, b) <- mkLinkedPair
+      join (nodeRouter a) "t"
+      join (nodeRouter b) "t"
+      publish (nodeRouter a) "t" (BS.pack [7]) (Just (nodeKey a))
+      readIORef (nodeDelivered b) `shouldReturn` [BS.pack [7]]
+      -- Replay the exact message B already received (a duplicate forward)
+      cacheB <- readTVarIO (gsMessageCache (nodeRouter b))
+      case map ceMessage (Map.elems (mcIndex cacheB)) of
+        [m] -> handleRPC (nodeRouter b) (nodePid a) emptyRPC { rpcPublish = [m] }
+        _   -> expectationFailure "expected exactly one cached message at B"
+      readIORef (nodeDelivered b) `shouldReturn` [BS.pack [7]]
+      seenB <- readTVarIO (gsSeen (nodeRouter b))
+      Map.size seenB `shouldBe` 1

--- a/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
@@ -393,6 +393,47 @@ spec = do
         mesh <- readTVarIO (gsMesh router)
         Set.member sender (Map.findWithDefault Set.empty "blocks" mesh) `shouldBe` False
 
+      it "extends the backoff when a peer GRAFTs during the backoff window" $ do
+        -- gossipsub-v1.1.md GRAFT flood protection: re-GRAFTing inside the
+        -- backoff window restarts the full backoff, it does not merely
+        -- keep the old (shorter) expiry (#157).
+        (router, _, _) <- mkTestRouterWithTime localPid fixedTime
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsSubscriptions router) (Set.insert "blocks")
+        -- Backoff about to expire in 10s
+        atomically $ modifyTVar' (gsBackoff router) $
+          Map.insert (sender, "blocks") (addUTCTime 10 fixedTime)
+        handleGraft router sender [Graft "blocks"]
+        backoff <- readTVarIO (gsBackoff router)
+        -- Restarted at the full paramPruneBackoff (60s) from now
+        Map.lookup (sender, "blocks") backoff
+          `shouldBe` Just (addUTCTime 60 fixedTime)
+
+      it "rejects a negative-score peer's GRAFT with a fresh backoff penalty" $ do
+        -- The rejection is not just a PRUNE reply: it starts a backoff so
+        -- the peer cannot immediately re-GRAFT or be re-selected by the
+        -- heartbeat fill (gossipsub-v1.1.md score-gated GRAFT).
+        (router, logRef) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            routerNeg = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const (-1) } }
+        addPeer routerNeg sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsSubscriptions routerNeg) (Set.insert "blocks")
+        handleGraft routerNeg sender [Graft "blocks"]
+        mesh <- readTVarIO (gsMesh routerNeg)
+        Set.member sender (Map.findWithDefault Set.empty "blocks" mesh) `shouldBe` False
+        backoff <- readTVarIO (gsBackoff routerNeg)
+        Map.lookup (sender, "blocks") backoff
+          `shouldBe` Just (addUTCTime 60 fixedTime)
+        -- The PRUNE reply carries no PX: peer exchange is withheld from
+        -- peers below threshold (eclipse-attack hardening, #157/#156)
+        sent <- readIORef logRef
+        case prunesTo sender sent of
+          [p] -> prunePeers p `shouldBe` []
+          _   -> expectationFailure "expected exactly one PRUNE reply"
+
     describe "handlePrune" $ do
       it "removes peer from mesh" $ do
         (router, _) <- mkTestRouter localPid
@@ -774,8 +815,10 @@ spec = do
         handleRPC router sender emptyRPC { rpcPublish = [forged] }
         invalidCount router sender "t" `shouldReturn` 1
 
+    -- gossipsub-v1.1.md "Extended Validators": Accept propagates, Reject
+    -- drops with a P4 penalty, Ignore drops without penalising the source.
     describe "topic validators" $ do
-      it "drops a message the topic validator rejects" $ do
+      it "drops a message the topic validator rejects and charges P4" $ do
         (router, logRef) <- mkTestRouter localPid
         let sender = mkPeerId 1
             meshPeer = mkPeerId 2
@@ -785,12 +828,33 @@ spec = do
         deliveredRef <- newIORef (0 :: Int)
         atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
           modifyIORef' deliveredRef (+ 1)
-        registerValidator router "t" (\_ _ -> pure False)
+        registerValidator router "t" (\_ _ -> pure ValidationReject)
         kp <- newKeyPair
         handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
         readIORef deliveredRef `shouldReturn` 0
         readIORef logRef `shouldReturn` []
         invalidCount router sender "t" `shouldReturn` 1
+
+      it "neither delivers nor forwards on Ignore, without a P4 penalty" $ do
+        -- The Accept/Reject/Ignore distinction is the point of extended
+        -- validators (gossipsub-v1.1.md): an application that cannot
+        -- validate a message right now must be able to drop it without
+        -- punishing the peer that relayed it.
+        (router, logRef) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            meshPeer = mkPeerId 2
+        addPeer router sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsMesh router) $
+          Map.insert "t" (Set.fromList [sender, meshPeer])
+        deliveredRef <- newIORef (0 :: Int)
+        atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
+          modifyIORef' deliveredRef (+ 1)
+        registerValidator router "t" (\_ _ -> pure ValidationIgnore)
+        kp <- newKeyPair
+        handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
+        readIORef deliveredRef `shouldReturn` 0
+        readIORef logRef `shouldReturn` []
+        invalidCount router sender "t" `shouldReturn` 0
 
       it "propagates a message the topic validator accepts" $ do
         (router, _) <- mkTestRouter localPid
@@ -799,10 +863,40 @@ spec = do
         deliveredRef <- newIORef (0 :: Int)
         atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
           modifyIORef' deliveredRef (+ 1)
-        registerValidator router "t" (\_ _ -> pure True)
+        registerValidator router "t" (\_ _ -> pure ValidationAccept)
         kp <- newKeyPair
         handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
         readIORef deliveredRef `shouldReturn` 1
+
+      it "applies validators per topic" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        deliveredRef <- newIORef ([] :: [Topic])
+        atomically $ writeTVar (gsOnMessage router) $ \topic _ ->
+          modifyIORef' deliveredRef (++ [topic])
+        registerValidator router "vetoed" (\_ _ -> pure ValidationReject)
+        -- Distinct keys give distinct message ids (from <> seqno), so the
+        -- second message is not swallowed by dedup
+        kp1 <- newKeyPair
+        kp2 <- newKeyPair
+        handleRPC router sender emptyRPC
+          { rpcPublish = [signedMessage kp1 "vetoed" (BS.pack [1])] }
+        handleRPC router sender emptyRPC
+          { rpcPublish = [signedMessage kp2 "open" (BS.pack [2])] }
+        readIORef deliveredRef `shouldReturn` ["open"]
+
+      it "receives the propagation source and the message" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+        addPeer router sender GossipSubPeer False fixedTime
+        seenRef <- newIORef ([] :: [(PeerId, ByteString)])
+        registerValidator router "t" $ \src msg -> do
+          modifyIORef' seenRef (++ [(src, msgData msg)])
+          pure ValidationAccept
+        kp <- newKeyPair
+        handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [7])] }
+        readIORef seenRef `shouldReturn` [(sender, BS.pack [7])]
 
       it "unregisterValidator restores unvalidated propagation" $ do
         (router, _) <- mkTestRouter localPid
@@ -811,7 +905,7 @@ spec = do
         deliveredRef <- newIORef (0 :: Int)
         atomically $ writeTVar (gsOnMessage router) $ \_ _ ->
           modifyIORef' deliveredRef (+ 1)
-        registerValidator router "t" (\_ _ -> pure False)
+        registerValidator router "t" (\_ _ -> pure ValidationReject)
         unregisterValidator router "t"
         kp <- newKeyPair
         handleRPC router sender emptyRPC { rpcPublish = [signedMessage kp "t" (BS.pack [1])] }
@@ -983,6 +1077,32 @@ spec = do
         case Map.lookup sender peers of
           Just ps -> psTopics ps `shouldBe` Set.empty
           Nothing -> expectationFailure "peer not found"
+
+      it "ignores a graylisted peer's GRAFT and publishes entirely" $ do
+        -- gossipsub-v1.1.md graylist: below stGraylistThreshold the whole
+        -- RPC is ignored — control messages included, with no PRUNE reply
+        -- and no message processing.
+        (router, logRef) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            routerGl = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const (-20000) } }
+        addPeer routerGl sender GossipSubPeer False fixedTime
+        atomically $ modifyTVar' (gsSubscriptions routerGl) (Set.insert "blocks")
+        deliveredRef <- newIORef (0 :: Int)
+        atomically $ writeTVar (gsOnMessage routerGl) $ \_ _ ->
+          modifyIORef' deliveredRef (+ 1)
+        kp <- newKeyPair
+        handleRPC routerGl sender emptyRPC
+          { rpcPublish = [signedMessage kp "blocks" (BS.pack [1])]
+          , rpcControl = Just emptyControlMessage { ctrlGraft = [Graft "blocks"] }
+          }
+        mesh <- readTVarIO (gsMesh routerGl)
+        Map.findWithDefault Set.empty "blocks" mesh `shouldBe` Set.empty
+        readIORef deliveredRef `shouldReturn` 0
+        readIORef logRef `shouldReturn` []
+        seen <- readTVarIO (gsSeen routerGl)
+        Map.size seen `shouldBe` 0
 
       it "flood publish skips peers below the publish threshold" $ do
         (router, logRef) <- mkTestRouter localPid
@@ -1224,6 +1344,26 @@ spec = do
         sent <- readIORef logRef
         let served = concat [ rpcPublish rpc | (pid, rpc) <- sent, pid == sender ]
         length served `shouldBe` 2
+
+      it "a hostile peer exhausting its IHAVE budget does not starve other peers" $ do
+        -- The flood-protection budgets are per peer: an attacker spamming
+        -- IHAVE batches must not consume the honest peers' allowance.
+        (router, logRef) <- mkTestRouterWithParams
+          defaultGossipSubParams { paramMaxIHaveMessages = 2 } localPid
+        let hostile = mkPeerId 1
+            honest  = mkPeerId 2
+        addPeer router hostile GossipSubPeer False fixedTime
+        addPeer router honest GossipSubPeer False fixedTime
+        -- Hostile volume: 20 batches, 18 over budget
+        mapM_ (\n -> handleIHave router hostile [IHave "t" [BS.pack [n]]]) [1..20]
+        sent0 <- readIORef logRef
+        length (iwantsSent sent0) `shouldBe` 2
+        writeIORef logRef []
+        -- The honest peer's advertisement is still answered
+        handleIHave router honest [IHave "t" [BS.pack [99]]]
+        sent1 <- readIORef logRef
+        map fst sent1 `shouldBe` [honest]
+        iwantsSent sent1 `shouldBe` [[BS.pack [99]]]
 
     -- Issue #157 remainder: direct (explicit) peering agreements,
     -- gossipsub-v1.1.md: direct peers always exchange messages and are


### PR DESCRIPTION
## Summary

Completes the items PR #197 left open on #175 that are now unblocked (#156/#157 fixed by #211, #216; StrictNoSign ids by #218; floodsub by #222). All work verified against current main — nothing here duplicates the coverage those PRs landed.

## Extended topic validators (new API)

`TopicValidator` now returns `ValidationResult` (`Accept` / `Reject` / `Ignore`) instead of `Bool` — the go-libp2p trichotomy from gossipsub-v1.1.md "Extended Validators". `Reject` drops the message and charges the propagation source a P4 invalid delivery; `Ignore` drops without any penalty, which the `Bool` API could not express (#175 named this the whole point of extended validators). Scope kept tight: the type is used only inside `Router.hs` and is not re-exported by the facade, so the signature change touches nothing outside gossipsub. Tests: Reject stops propagation and increments P4; Ignore neither delivers nor forwards and leaves P4 at 0; validators are per-topic; the validator receives the propagation source and message.

## Two-router wire harness (`MultiNodeSpec`)

Two complete routers wired to each other through their injectable `gsSendRPC` functions: every emitted RPC is handed synchronously to the other router's `handleRPC`, so the full wire protocol (subscription announce, GRAFT/PRUNE, publish, IHAVE/IWANT) runs between independent router states with **no threads, no sleeps, fully deterministic**. A per-link gate simulates message loss. Covers:

- mesh formation over the wire: join announcements lead to mutual GRAFT
- publish → mesh delivery → PRUNE-with-backoff → publish lost on a downed link → link restored → one `heartbeatOnce` performs IHAVE gossip → IWANT → mcache serve → delivery at the far side
- wire-level dedup: replaying the exact received message is not delivered twice

## Hardening tests (now unblocked)

- GRAFT during the backoff window restarts the full backoff (not just keeps the old expiry)
- negative-score GRAFT rejection records a backoff penalty and withholds PX from the PRUNE reply
- graylisted peer's GRAFT and publish are ignored entirely (control + messages, no PRUNE reply, seen cache untouched)
- heartbeat PRUNE of a negative-score mesh peer carries no PX even when good candidates exist
- backoff is enforced across multiple heartbeats and the peer is grafted again on the first heartbeat after expiry
- broken IHAVE promise (advertise, never deliver) drives `peerScore` **negative** end-to-end — the P7 accrual is observable in the score, not just the counter
- hostile IHAVE flood (20 batches) exhausts only the attacker's per-peer budget; an honest peer's advertisement is still answered

## TDD sanity check

Temporarily made `ValidationIgnore` charge P4 and disabled the IWANT serve path: 5 tests failed, including the new Ignore test and the multi-node IHAVE/IWANT recovery test. Reverted before committing.

Full suite: **1080 examples, 0 failures** (GHC 9.10.3).

## Remaining from #175 (out of scope here)

- N≥3 in-process mesh tests at scale (20-node convergence to [D_lo, D_hi], mesh healing after mass disconnect, network-wide isolation of a bad-signature publisher)
- cross-implementation signing/mesh tests against go-libp2p (belongs with the interop workstream, #129-#132)

Refs #175