### PR TITLE
test: T3a full MUST/SHOULD conformance sweep and bounded T6 soak tier

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -194,6 +194,8 @@ test-suite libp2p-hs-test
     LibP2P.IntegrationSpec
     LibP2P.FaultInjectionSpec
     LibP2P.WireConformanceSpec
+    LibP2P.ConformanceSpec
+    LibP2P.SoakSpec
   build-depends:
     base       >= 4.18 && < 5,
     bytestring >= 0.10 && < 0.13,

--- a/src/LibP2P/Transport/TCP.hs
+++ b/src/LibP2P/Transport/TCP.hs
@@ -72,8 +72,16 @@ tcpDial addr = case stripP2P addr of
   _ -> fail "tcpDial: unsupported multiaddr"
 
 -- | Create a RawConnection from a connected socket.
+--
+-- TCP_NODELAY is set on every connection (dialed and accepted), matching
+-- go-libp2p and rust-libp2p. libp2p traffic is already coalesced into
+-- frames by the muxer, and the many small write-write-read exchanges of
+-- the upgrade pipeline (multistream-select, Noise, per-stream
+-- negotiation) otherwise stall on Nagle/delayed-ACK interaction —
+-- observed as ~270ms per ping open/close cycle in the soak tier.
 mkRawConnection :: NS.Socket -> Multiaddr -> IO RawConnection
 mkRawConnection sock remoteAddr = do
+  NS.setSocketOption sock NS.NoDelay 1
   localSockAddr <- NS.getSocketName sock
   localAddr <- sockAddrToMultiaddr localSockAddr
   pure RawConnection

--- a/test/LibP2P/ConformanceSpec.hs
+++ b/test/LibP2P/ConformanceSpec.hs
@@ -1,0 +1,196 @@
+-- | Spec-clause conformance tests (T3a tier, #178).
+--
+-- One test per normative clause, named after the clause. This module
+-- pins the clauses of the core specs (multistream-select, noise) that
+-- were testable in-process but not yet covered by any other spec file.
+-- The full clause-by-clause sweep of multistream-select, noise, yamux,
+-- identify and ping — mapping every MUST/SHOULD to the spec file that
+-- covers it — lives in the PR that introduced this module.
+--
+-- Clauses that require a live foreign implementation are delegated to
+-- the interop harness (#129); clauses whose behaviour is not implemented
+-- yet are tracked as their own issues rather than as permanently
+-- failing tests.
+module LibP2P.ConformanceSpec (spec) where
+
+import Control.Concurrent.Async (concurrently)
+import Control.Monad (replicateM)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair, kpPublic)
+import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.MultistreamSelect.Negotiation
+  ( NegotiationResult (..)
+  , StreamIO (..)
+  , mkMemoryStreamPair
+  , negotiateInitiator
+  , negotiateResponder
+  )
+import LibP2P.Noise.Handshake
+  ( HandshakeResult (..)
+  , buildHandshakePayload
+  , decodeNoisePayload
+  , decodePublicKey
+  , encodeNoisePayload
+  , initHandshakeResponder
+  , readHandshakeMsg
+  , writeHandshakeMsg
+  , NoisePayload (..)
+  )
+import LibP2P.Switch.Types (Direction (..))
+import LibP2P.Switch.Upgrade
+  ( performStreamHandshake
+  , readFramedMessage
+  , writeFramedMessage
+  )
+import System.Timeout (timeout)
+import Test.Hspec
+
+-- | A scripted stream: reads come from a canned byte sequence, writes
+-- are captured for byte-exact assertion. Reading past the script
+-- raises EOF. (Same shape as the WireConformanceSpec helper.)
+mkScriptedStream :: ByteString -> IO (StreamIO, IO ByteString)
+mkScriptedStream canned = do
+  writtenRef <- newIORef BS.empty
+  readRef <- newIORef canned
+  let stream = StreamIO
+        { streamWrite = \bs -> modifyIORef' writtenRef (`BS.append` bs)
+        , streamReadByte = do
+            buf <- readIORef readRef
+            case BS.uncons buf of
+              Nothing -> ioError (userError "scripted stream: EOF")
+              Just (b, rest) -> writeIORef readRef rest >> pure b
+        , streamClose = pure ()
+        }
+  pure (stream, readIORef writtenRef)
+
+-- multistream-select messages, hand-derived from the spec:
+-- <varint-length><UTF-8 payload>\n, length includes the trailing \n.
+
+-- | varint(19) "/multistream/1.0.0" \n
+mssHeader :: ByteString
+mssHeader = BS.singleton 0x13 <> "/multistream/1.0.0\n"
+
+-- | A header for a protocol version we do not speak (same length).
+mssWrongHeader :: ByteString
+mssWrongHeader = BS.singleton 0x13 <> "/multistream/2.0.0\n"
+
+-- | varint(7) "/noise" \n
+mssNoise :: ByteString
+mssNoise = BS.singleton 0x07 <> "/noise\n"
+
+-- | varint(13) "/yamux/1.0.0" \n
+mssYamux :: ByteString
+mssYamux = BS.singleton 0x0d <> "/yamux/1.0.0\n"
+
+-- | varint(3) "na" \n
+mssNa :: ByteString
+mssNa = BS.singleton 0x03 <> "na\n"
+
+-- | varint(3) "ls" \n
+mssLs :: ByteString
+mssLs = BS.singleton 0x03 <> "ls\n"
+
+-- | Generate a test identity (PeerId, KeyPair).
+mkTestIdentity :: IO (PeerId, KeyPair)
+mkTestIdentity = do
+  Right kp <- generateKeyPair
+  pure (fromPublicKey (kpPublic kp), kp)
+
+-- | Read exactly n bytes from a stream.
+readN :: StreamIO -> Int -> IO ByteString
+readN stream n = BS.pack <$> replicateM n (streamReadByte stream)
+
+spec :: Spec
+spec = do
+  describe "multistream-select conformance (multiformats/multistream-select README)" $ do
+    -- The protocol id header is part of the negotiation: a peer that
+    -- answers with a different multistream version cannot be talked to.
+    it "initiator verifies the peer's multistream header and aborts on a mismatch" $ do
+      (stream, getWritten) <- mkScriptedStream mssWrongHeader
+      result <- negotiateInitiator stream ["/noise"]
+      result `shouldBe` NoProtocol
+      -- It must not go on to propose a protocol to an incompatible peer.
+      written <- getWritten
+      written `shouldBe` mssHeader
+
+    it "responder verifies the initiator's multistream header and stays silent on a mismatch" $ do
+      (stream, getWritten) <- mkScriptedStream (mssWrongHeader <> mssNoise)
+      result <- negotiateResponder stream ["/noise"]
+      result `shouldBe` NoProtocol
+      written <- getWritten
+      written `shouldBe` BS.empty
+
+    -- "Implementations MAY support ls" / "Implementations MUST NOT
+    -- depend on a remote node supporting ls": a responder without ls
+    -- support answers it like any unknown proposal (na) and the
+    -- negotiation continues.
+    it "responder without ls support answers na to an ls request and negotiation continues" $ do
+      (stream, getWritten) <- mkScriptedStream (mssHeader <> mssLs <> mssNoise)
+      result <- negotiateResponder stream ["/noise"]
+      result `shouldBe` Accepted "/noise"
+      written <- getWritten
+      written `shouldBe` (mssHeader <> mssNa <> mssNoise)
+
+    -- The only valid responses to a proposal are the echoed protocol id
+    -- or na; anything else means the peer is broken or malicious.
+    it "initiator aborts when the response is neither an echo of the proposal nor na" $ do
+      (stream, getWritten) <- mkScriptedStream (mssHeader <> mssYamux)
+      result <- negotiateInitiator stream ["/noise"]
+      result `shouldBe` NoProtocol
+      written <- getWritten
+      written `shouldBe` (mssHeader <> mssNoise)
+
+  describe "noise conformance (specs/noise/README.md, XX pattern)" $ do
+    -- XX message 1 is "-> e": the unencrypted 32-byte X25519 ephemeral
+    -- key and nothing else. The identity payload is only sent in
+    -- messages 2 and 3. This pins both the DH choice (25519 keys are
+    -- 32 bytes) and the absence of a payload in message 1, end-to-end
+    -- through the production framing (2-byte big-endian length prefix).
+    it "initiator's first message is the bare 32-byte ephemeral key with no payload" $ do
+      (initSide, foreignSide) <- mkMemoryStreamPair
+      (pidA, kpA) <- mkTestIdentity
+      (pidB, kpB) <- mkTestIdentity
+      done <- timeout 10000000 $ concurrently
+        (performStreamHandshake kpA Outbound initSide)
+        (runForeignResponderCapturingMsg1 kpB foreignSide)
+      case done of
+        Nothing -> expectationFailure "handshake against the foreign responder hung"
+        Just ((_sess, hr), (msg1Frame, seenInitiator)) -> do
+          -- 2-byte BE length prefix declares exactly 32 bytes.
+          BS.take 2 msg1Frame `shouldBe` BS.pack [0x00, 0x20]
+          BS.length msg1Frame `shouldBe` 34
+          -- Both sides authenticated each other from the payloads in
+          -- messages 2 and 3, so the handshake as a whole is honest.
+          hrRemotePeerId hr `shouldBe` pidB
+          seenInitiator `shouldBe` pidA
+
+-- | A hand-rolled honest XX responder that records the raw framed
+-- message 1 exactly as it appeared on the wire, then completes the
+-- handshake and returns the initiator identity from the msg3 payload.
+runForeignResponderCapturingMsg1
+  :: KeyPair -> StreamIO -> IO (ByteString, PeerId)
+runForeignResponderCapturingMsg1 kp stream = do
+  (st0, staticPub) <- initHandshakeResponder kp
+
+  -- Capture the raw frame: length prefix plus declared payload.
+  prefix <- readN stream 2
+  let declared = fromIntegral (BS.index prefix 0) * 256
+              + fromIntegral (BS.index prefix 1)
+  msg1 <- readN stream declared
+  (_p1, st1) <- either fail pure $ readHandshakeMsg st0 msg1
+
+  -- Message 2: -> e, ee, s, es with our identity payload.
+  payload <- either fail pure $
+    encodeNoisePayload <$> buildHandshakePayload kp staticPub
+  (msg2, st2) <- either fail pure $ writeHandshakeMsg st1 payload
+  writeFramedMessage stream msg2
+
+  -- Message 3: <- s, se with the initiator's identity payload.
+  msg3 <- readFramedMessage stream
+  (p3, _stFinal) <- either fail pure $ readHandshakeMsg st2 msg3
+  np <- either fail pure $ decodeNoisePayload p3
+  pk <- either fail pure $ decodePublicKey (npIdentityKey np)
+  pure (prefix <> msg1, fromPublicKey pk)

--- a/test/LibP2P/SoakSpec.hs
+++ b/test/LibP2P/SoakSpec.hs
@@ -1,0 +1,205 @@
+-- | Bounded soak tests (T6 tier, #178).
+--
+-- The soak tier exists to catch monotonic leaks that only bite after N
+-- cycles: stream-map growth in the muxer, reservation counters that
+-- drift upward because a release path is missed, pool entries that
+-- accumulate. A full wall-clock soak (hours of connect/disconnect
+-- against a live peer) belongs in a separate slow suite; these tests
+-- keep the same shape — many sequential cycles over one connection —
+-- but bounded so they stay CI-friendly (well under 30 seconds).
+--
+-- The leak observables are exact, not statistical: after N cycles the
+-- Switch's reservation counters must be back at their baseline and the
+-- Yamux stream maps must be empty. A leak of even one slot per cycle
+-- shows up as N.
+module LibP2P.SoakSpec (spec) where
+
+import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.STM
+  ( atomically
+  , newTQueueIO
+  , readTQueue
+  , readTVar
+  , retry
+  , writeTQueue
+  )
+import Control.Exception (bracket)
+import Control.Monad (forM_, replicateM)
+import qualified Data.ByteString as BS
+import Data.Either (isLeft, isRight)
+import qualified Data.Map.Strict as Map
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair, publicKey)
+import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.Multiaddr (Multiaddr (..))
+import LibP2P.Multiaddr.Protocol (Protocol (..))
+import LibP2P.Protocol.Identify (registerIdentifyHandlers)
+import LibP2P.Protocol.Ping (registerPingHandler, sendPing)
+import LibP2P.Switch (addTransport, newSwitch, switchClose)
+import LibP2P.Switch.Dial (dial)
+import LibP2P.Switch.Listen (defaultConnectionGater, switchListen)
+import LibP2P.Switch.ResourceManager
+  ( ResourceManager (..)
+  , ResourceScope (..)
+  , ResourceUsage (..)
+  )
+import LibP2P.Switch.Types (Connection (..), Switch (..))
+import LibP2P.Transport.TCP (newTCPTransport)
+import qualified LibP2P.Yamux.Session as Yamux
+import LibP2P.Yamux.Stream (streamClose, streamRead, streamWrite)
+import LibP2P.Yamux.Types
+  ( SessionRole (..)
+  , YamuxSession (..)
+  , ysStreamId
+  )
+import System.Timeout (timeout)
+import Test.Hspec
+
+-- | Number of sequential cycles per soak test. Large enough that a
+-- one-slot-per-cycle leak is unmistakable, small enough for CI.
+soakCycles :: Int
+soakCycles = 500
+
+-- | Generate a test identity (PeerId, KeyPair).
+mkTestIdentity :: IO (PeerId, KeyPair)
+mkTestIdentity = do
+  Right kp <- generateKeyPair
+  pure (fromPublicKey (publicKey kp), kp)
+
+-- | Loopback address with port 0 (OS assigns ephemeral port).
+loopbackAddr :: Multiaddr
+loopbackAddr = Multiaddr [IP4 0x7f000001, TCP 0]
+
+-- | A test node with TCP + Identify + Ping, torn down via bracket.
+withNode :: ((Switch, PeerId) -> IO a) -> IO a
+withNode action = bracket setup (switchClose . fst) action
+  where
+    setup = do
+      (pid, kp) <- mkTestIdentity
+      sw <- newSwitch pid kp
+      tcp <- newTCPTransport
+      addTransport sw tcp
+      registerIdentifyHandlers sw
+      registerPingHandler sw
+      pure (sw, pid)
+
+-- | Two connected nodes: B listens, A dials.
+withConnectedPair
+  :: ((Switch, PeerId) -> (Switch, PeerId) -> Connection -> IO a) -> IO a
+withConnectedPair action =
+  withNode $ \(swB, pidB) -> do
+    addrs <- switchListen swB defaultConnectionGater [loopbackAddr]
+    withNode $ \(swA, pidA) -> do
+      dialResult <- dial swA pidB [head addrs]
+      case dialResult of
+        Left err -> fail $ "withConnectedPair: dial failed: " ++ show err
+        Right conn -> action (swA, pidA) (swB, pidB) conn
+
+-- | System-scope resource usage of a switch.
+systemUsage :: Switch -> IO ResourceUsage
+systemUsage sw =
+  atomically $ readTVar (rsUsage (rmSystemScope (swResourceMgr sw)))
+
+-- | Block (bounded) until both switches report zero stream
+-- reservations at the system scope. The responder releases its inbound
+-- reservation asynchronously when the handler thread exits, so the
+-- test waits on the STM condition instead of sleeping.
+waitForZeroStreams :: Switch -> Switch -> IO ()
+waitForZeroStreams swA swB = do
+  drained <- timeout 10000000 $ atomically $ do
+    uA <- readTVar (rsUsage (rmSystemScope (swResourceMgr swA)))
+    uB <- readTVar (rsUsage (rmSystemScope (swResourceMgr swB)))
+    let zero u = ruStreamsInbound u == 0 && ruStreamsOutbound u == 0
+    if zero uA && zero uB then pure () else retry
+  case drained of
+    Just () -> pure ()
+    Nothing -> do
+      uA <- systemUsage swA
+      uB <- systemUsage swB
+      fail $ "stream reservations never drained to zero: dialer=" ++ show uA
+          ++ " listener=" ++ show uB
+
+-- | In-memory byte-stream transport pair for Yamux sessions.
+mkMemoryTransportPair ::
+  IO
+    ( (BS.ByteString -> IO (), Int -> IO BS.ByteString)
+    , (BS.ByteString -> IO (), Int -> IO BS.ByteString)
+    )
+mkMemoryTransportPair = do
+  qAtoB <- newTQueueIO
+  qBtoA <- newTQueueIO
+  let writeTo q bs = mapM_ (atomically . writeTQueue q) (BS.unpack bs)
+      readFrom q n = BS.pack <$> replicateM n (atomically (readTQueue q))
+  pure ((writeTo qAtoB, readFrom qBtoA), (writeTo qBtoA, readFrom qAtoB))
+
+-- | A Yamux session pair with all background loops running.
+withSessionPair :: ((YamuxSession, YamuxSession) -> IO a) -> IO a
+withSessionPair action = do
+  ((writeA, readA), (writeB, readB)) <- mkMemoryTransportPair
+  client <- Yamux.newSession RoleClient writeA readA
+  server <- Yamux.newSession RoleServer writeB readB
+  withAsync (Yamux.sendLoop client) $ \_ ->
+    withAsync (Yamux.recvLoop client) $ \_ ->
+      withAsync (Yamux.sendLoop server) $ \_ ->
+        withAsync (Yamux.recvLoop server) $ \_ ->
+          action (client, server)
+
+spec :: Spec
+spec = do
+  describe "Switch-level soak: repeated one-shot pings over one connection" $
+    it "leaves zero stream reservations and one healthy pooled connection after 500 cycles" $
+      withConnectedPair $ \(swA, pidA) (swB, pidB) conn -> do
+        -- Each sendPing is a full stream lifecycle: reserve, open,
+        -- negotiate /ipfs/ping/1.0.0, 32-byte echo, close, release.
+        forM_ [1 .. soakCycles] $ \(i :: Int) -> do
+          result <- sendPing swA conn
+          case result of
+            Right _ -> pure ()
+            Left err -> fail $ "ping cycle " ++ show i ++ " failed: " ++ show err
+
+        -- No reservation drift: every cycle released both its outbound
+        -- (dialer) and inbound (responder) stream slot.
+        waitForZeroStreams swA swB
+
+        -- The connection itself is still the only reservation held.
+        uA <- systemUsage swA
+        uB <- systemUsage swB
+        (ruConnsOutbound uA, ruConnsInbound uA) `shouldBe` (1, 0)
+        (ruConnsInbound uB, ruConnsOutbound uB) `shouldBe` (1, 0)
+
+        -- No pool growth: exactly one connection each way.
+        poolA <- atomically $ readTVar (swConnPool swA)
+        poolB <- atomically $ readTVar (swConnPool swB)
+        fmap length (Map.lookup pidB poolA) `shouldBe` Just 1
+        fmap length (Map.lookup pidA poolB) `shouldBe` Just 1
+
+        -- The connection is still usable after the soak.
+        finalPing <- sendPing swA conn
+        finalPing `shouldSatisfy` isRight
+
+  describe "Yamux-level soak: repeated stream open/close cycles on one session" $
+    it "does not grow the stream maps over 500 full FIN/FIN lifecycles" $
+      withSessionPair $ \(client, server) -> do
+        forM_ [1 .. soakCycles] $ \(i :: Int) -> do
+          Right sc <- Yamux.openStream client
+          Right ss <- Yamux.acceptStream server
+          Right () <- streamWrite sc "x"
+          firstRead <- streamRead ss
+          firstRead `shouldBe` Right "x"
+          Right () <- streamClose sc
+          -- The server observes EOF once the FIN arrives, then closes
+          -- its own side, which reclaims the map slot on both ends.
+          eof <- streamRead ss
+          eof `shouldSatisfy` isLeft
+          _ <- streamClose ss
+          -- Stream IDs must keep advancing: a stale map entry would
+          -- otherwise collide silently.
+          ysStreamId sc `shouldBe` fromIntegral (2 * i - 1)
+
+        -- Both session maps must be empty; even a single leaked slot
+        -- per cycle would show up as 500 here.
+        drained <- timeout 10000000 $ atomically $ do
+          mClient <- readTVar (ysessStreams client)
+          mServer <- readTVar (ysessStreams server)
+          if Map.null mClient && Map.null mServer then pure () else retry
+        drained `shouldBe` Just ()


### PR DESCRIPTION
## Summary

Finishes what PR #206 left open on #178: the T3a full MUST/SHOULD sweep of the core specs and the T6 soak tier. The soak tier immediately paid for itself by surfacing a real transport defect (missing TCP_NODELAY, fixed here).

- `test/LibP2P/ConformanceSpec.hs` — clause-named tests for every normative clause that was testable in-process and not already covered (table below)
- `test/LibP2P/SoakSpec.hs` — bounded leak-detection soak: 500 one-shot ping cycles over one real TCP connection (reservation counters, pool size, connection still usable) and 500 FIN/FIN stream lifecycles at the Yamux layer (stream maps empty). Exact observables, not statistical: a one-slot-per-cycle leak shows up as N
- `src/LibP2P/Transport/TCP.hs` — set TCP_NODELAY on every dialed and accepted connection (go-libp2p/rust-libp2p parity). The soak measured ~270ms per ping cycle from Nagle/delayed-ACK stalls in the upgrade pipeline's small write-write-read exchanges; 500 pings drop from 136s to 0.65s, and the whole suite now finishes in ~13s

## T3a clause-by-clause sweep

### multistream-select ([multiformats/multistream-select](https://github.com/multiformats/multistream-select))

| Clause | Status |
|---|---|
| Messages are varint-length-prefixed UTF-8 ending in `\n` (length includes `\n`) | covered — WireConformanceSpec golden vectors, NegotiationSpec |
| Both sides exchange the `/multistream/1.0.0` header | covered — WireConformanceSpec transcripts |
| Initiator verifies the peer's header and aborts on mismatch | **added now** — ConformanceSpec |
| Responder verifies the initiator's header, stays silent on mismatch | **added now** — ConformanceSpec |
| `na` for unsupported protocol, exact bytes `0x03 6e 61 0a` | covered — WireConformanceSpec, NegotiationSpec |
| Reply to a proposal must be echo or `na`; anything else aborts | **added now** — ConformanceSpec |
| `ls` is optional; implementations MUST NOT depend on remote `ls` | **added now** — ConformanceSpec (responder answers `na` to `ls` and negotiation continues; we never send `ls`) |
| Initiator SHOULD send header+proposal in one packet | not implemented → delegated **#227** |
| Declared length validated before payload read (1024 cap, 9-byte varint limit) | covered — NegotiationSpec (#159/#160) |

### noise (`specs/noise/`)

| Clause | Status |
|---|---|
| XX MUST be supported | covered — HandshakeSpec, ForeignPeerSpec, UpgradeSpec, IntegrationSpec |
| MUST support 25519 DH, ChaChaPoly, SHA256 | **added now** (partial) — ConformanceSpec pins msg1 as a 32-byte X25519 `e`; full ciphersuite pinning against a foreign stack → delegated **#129** |
| 2-byte BE length prefix, 65535-byte cap | covered — HandshakeSpec framing + boundary table |
| Message 1 carries no identity payload (payloads live in msg2/msg3) | **added now** — ConformanceSpec, end-to-end through production framing |
| MUST decode `identity_key`, validate `identity_sig` against the static key, terminate immediately on failure | covered — ForeignPeerSpec (forged/replayed signature rejection, both directions) |
| Signature domain `noise-libp2p-static-key:` ‖ static pubkey | covered — HandshakeSpec (literal prefix bytes) |
| Early data MUST NOT be processed beyond signature validation; unknown extension fields skipped | covered — HandshakeSpec (unknown protobuf fields) |
| MUST terminate before nonce reuse at 2^64−1 messages | not testable in-process (2^64 messages); same position as go-libp2p |

### yamux (HashiCorp spec.md)

| Clause | Status |
|---|---|
| 12-byte header, version 0, frame types, flag encoding | covered — FrameSpec (docs-example golden vectors), PropertySpec |
| Unknown type / non-zero version → GoAway(0x01) | covered — StateMachineSpec |
| Stream ID parity, duplicate-SYN rejection | covered — SessionSpec |
| 256 KiB initial window; sender MUST NOT exceed recv window; length validated before payload read | covered — FrameSpec, SessionSpec (#143), StateMachineSpec |
| Ping opaque value echoed exactly | covered — SessionSpec, TraceReplaySpec |
| GoAway codes 0x00/0x01/0x02 | covered — FrameSpec, LifecycleSpec |
| Accept backlog MUST be bounded | covered — LifecycleSpec |
| FIN/RST lifecycle, half-close semantics | covered — StreamSpec, StateMachineSpec, SessionSpec, TraceReplaySpec (go-yamux traces) |
| Stream map does not grow over many lifecycles | **added now** — SoakSpec |

### identify (`specs/identify/`) — spec is descriptive, no RFC-2119 keywords

| Requirement | Status |
|---|---|
| varint-length-delimited protobuf | covered — IdentifySpec (#144), WireConformanceSpec |
| Field numbers / wire types | covered — MessageSpec, WireConformanceSpec |
| `observedAddr` = dialer's address as seen by the listener | covered — IdentifySpec (#167), IntegrationSpec |
| Responder closes the stream after writing | covered — IdentifySpec |
| Push merges partial updates into the peer store | covered — IdentifySpec (#165) |
| `/ipfs/id/1.0.0` and `/ipfs/id/push/1.0.0` ids | covered — IdentifySpec |
| `signedPeerRecord` | delegated — #140 |

### ping (`specs/ping/ping.md`) — the clauses unblocked by #163/#212

| Clause | Status |
|---|---|
| 32-byte payload, echo byte-identical | covered — PingSpec (echo + `PingMismatch` on corruption), IntegrationSpec |
| Dialer MUST NOT keep more than one outbound ping stream per peer | covered — PingSpec + IntegrationSpec single-stream reuse (#212) |
| Dialer MAY repeat on the same stream; listener SHOULD loop and echo | covered — PingSpec |
| Dialer SHOULD close the write side after the last payload | covered — PingSpec (session close; responder loop observes EOF) |
| Listener SHOULD finish the echo, exit the loop, close the stream | covered — PingSpec (`handlePing` closes its side) |
| Listener SHOULD accept at most two ping streams per peer | not implemented → delegated **#226** |

## Remaining tier status

| Tier | Status |
|---|---|
| T3a | done (this PR + the table above; deviations tracked as #226/#227) |
| T3b | done (#206 WireConformanceSpec) |
| T2/T5 | done (#196/#206/#220/#223) |
| T6 | bounded soak added here; full wall-clock soak against live peers belongs to the perf/interop harness → #130 |
| T4 interop modes | delegated → #129/#130/#131 |
| GossipSub sleep-based tests | left to #175 (in progress concurrently) |

## Verification

- TDD sanity: removing the stream-release path in `Switch.Connection.newStream` fails the switch soak at exactly cycle 257 (the per-peer limit of 256); dropping the mss header check fails the new header-verification clause test. Both reverted
- `cabal test` (GHC 9.10.3): 1074 examples, 0 failures, ~13s; new soak and conformance groups re-run 3x with no flakes

Closes #178