### PR TITLE
fix: cap concurrent inbound ping streams at two per peer

### DIFF
--- a/src/LibP2P/Protocol/Ping.hs
+++ b/src/LibP2P/Protocol/Ping.hs
@@ -14,6 +14,13 @@
 -- when the session ends or on the first failed ping. Streams are opened
 -- through the Switch ('newStream'), so each session holds exactly one
 -- stream reservation, released on close.
+--
+-- The listener accepts at most two concurrent ping streams per remote
+-- peer (ping.md: "The listening peer SHOULD accept at most two streams
+-- per peer since cross-stream behavior is non-linear and stream writes
+-- occur asynchronously"). 'registerPingHandler' installs a
+-- 'PingLimiter' that counts live inbound ping streams per peer and
+-- resets the third and subsequent streams without serving them.
 module LibP2P.Protocol.Ping
   ( -- * Protocol ID
     pingProtocolId
@@ -23,6 +30,9 @@ module LibP2P.Protocol.Ping
   , PingSession
     -- * Responder
   , handlePing
+  , PingLimiter
+  , newPingLimiter
+  , handlePingLimited
     -- * Initiator
   , sendPing
   , openPingSession
@@ -35,9 +45,17 @@ module LibP2P.Protocol.Ping
     -- * Constants
   , pingSize
   , pingTimeoutMicros
+  , maxPingStreamsPerPeer
   ) where
 
-import Control.Concurrent.STM (atomically, readTVar, writeTVar)
+import Control.Concurrent.STM
+  ( TVar
+  , atomically
+  , modifyTVar'
+  , newTVarIO
+  , readTVar
+  , writeTVar
+  )
 import Control.Exception (SomeException, catch, finally, try)
 import Control.Monad (unless)
 import qualified Data.ByteString as BS
@@ -74,6 +92,13 @@ pingSize = 32
 pingTimeoutMicros :: Int
 pingTimeoutMicros = 10000000
 
+-- | Maximum concurrent inbound ping streams served per remote peer
+-- (ping.md: "The listening peer SHOULD accept at most two streams per
+-- peer since cross-stream behavior is non-linear and stream writes
+-- occur asynchronously").
+maxPingStreamsPerPeer :: Int
+maxPingStreamsPerPeer = 2
+
 -- | Ping error types.
 data PingError
   = PingTimeout          -- ^ No echo within the timeout
@@ -102,6 +127,36 @@ handlePing stream _remotePeerId = echoLoop `finally` closeQuietly stream
         Right payload -> do
           streamWrite stream payload
           echoLoop
+
+-- | Per-peer accounting of live inbound ping streams, shared by every
+-- invocation of the registered ping handler on one Switch.
+newtype PingLimiter = PingLimiter (TVar (Map.Map PeerId Int))
+
+-- | Create an empty inbound ping stream limiter.
+newPingLimiter :: IO PingLimiter
+newPingLimiter = PingLimiter <$> newTVarIO Map.empty
+
+-- | Serve an inbound ping stream, enforcing the per-peer cap.
+--
+-- If the remote peer already has 'maxPingStreamsPerPeer' live ping
+-- streams, the new stream is reset (closed without serving the echo
+-- loop). Otherwise the stream occupies a slot for the duration of
+-- 'handlePing'; the slot is released when the stream closes or errors.
+handlePingLimited :: PingLimiter -> StreamIO -> PeerId -> IO ()
+handlePingLimited (PingLimiter countsVar) stream peer = do
+  accepted <- atomically $ do
+    counts <- readTVar countsVar
+    let live = Map.findWithDefault 0 peer counts
+    if live >= maxPingStreamsPerPeer
+      then pure False
+      else do
+        writeTVar countsVar (Map.insert peer (live + 1) counts)
+        pure True
+  if accepted
+    then handlePing stream peer `finally` atomically (modifyTVar' countsVar releaseSlot)
+    else closeQuietly stream
+  where
+    releaseSlot = Map.update (\n -> if n <= 1 then Nothing else Just (n - 1)) peer
 
 -- | The single outbound ping stream to a peer, negotiated and ready.
 --
@@ -210,11 +265,16 @@ sendPing :: Switch -> Connection -> IO (Either PingError PingResult)
 sendPing sw conn = either Left id <$> withPingSession sw conn ping
 
 -- | Register the Ping handler on the Switch.
+--
+-- The installed handler shares one 'PingLimiter', so concurrent inbound
+-- ping streams are capped at 'maxPingStreamsPerPeer' per remote peer.
 registerPingHandler :: Switch -> IO ()
-registerPingHandler sw = atomically $ do
-  protos <- readTVar (swProtocols sw)
-  let handler conn stream = handlePing stream (connPeerId conn)
-  writeTVar (swProtocols sw) (Map.insert pingProtocolId handler protos)
+registerPingHandler sw = do
+  limiter <- newPingLimiter
+  atomically $ do
+    protos <- readTVar (swProtocols sw)
+    let handler conn stream = handlePingLimited limiter stream (connPeerId conn)
+    writeTVar (swProtocols sw) (Map.insert pingProtocolId handler protos)
 
 -- | Close a stream, swallowing any exception (best-effort EOF signal).
 closeQuietly :: StreamIO -> IO ()

--- a/test/LibP2P/Protocol/Ping/PingSpec.hs
+++ b/test/LibP2P/Protocol/Ping/PingSpec.hs
@@ -451,6 +451,150 @@ spec = do
       BS.length payload2 `shouldBe` pingSize
       payload2 `shouldNotBe` payload1
 
+  describe "Ping responder stream cap" $ do
+    -- ping.md: "The listening peer SHOULD accept at most two streams
+    -- per peer since cross-stream behavior is non-linear and stream
+    -- writes occur asynchronously."
+    it "accepts two concurrent ping streams from the same peer, both echo" $ do
+      limiter <- newPingLimiter
+      let peer = PeerId "capped-peer"
+      (dialer1, close1, listener1) <- mkClosableStreamPair
+      (dialer2, close2, listener2) <- mkClosableStreamPair
+      h1 <- async $ handlePingLimited limiter listener1 peer
+      h2 <- async $ handlePingLimited limiter listener2 peer
+      let payload1 = BS.pack [1..32]
+          payload2 = BS.pack [33..64]
+      streamWrite dialer1 payload1
+      resp1 <- readNBytes dialer1 pingSize
+      resp1 `shouldBe` payload1
+      streamWrite dialer2 payload2
+      resp2 <- readNBytes dialer2 pingSize
+      resp2 `shouldBe` payload2
+      close1
+      close2
+      wait h1
+      wait h2
+
+    it "resets the third concurrent ping stream from a peer while the first two stay usable" $ do
+      limiter <- newPingLimiter
+      let peer = PeerId "capped-peer"
+      (dialer1, close1, listener1) <- mkClosableStreamPair
+      (dialer2, close2, listener2) <- mkClosableStreamPair
+      (dialer3, _close3, listener3) <- mkClosableStreamPair
+      h1 <- async $ handlePingLimited limiter listener1 peer
+      h2 <- async $ handlePingLimited limiter listener2 peer
+      -- Prove both slots are held before opening the third stream.
+      streamWrite dialer1 (BS.pack [1..32])
+      _ <- readNBytes dialer1 pingSize
+      streamWrite dialer2 (BS.pack [33..64])
+      _ <- readNBytes dialer2 pingSize
+      -- The third stream must be refused: the handler returns without
+      -- serving the echo loop and closes its side of the stream.
+      h3 <- async $ handlePingLimited limiter listener3 peer
+      done3 <- timeout 1000000 (wait h3)
+      done3 `shouldBe` Just ()
+      streamWrite dialer3 (BS.pack [65..96])
+      echoed <- try (readNBytes dialer3 pingSize)
+      case echoed of
+        Left (_ :: IOError) -> pure ()  -- EOF from the reset
+        Right bs -> expectationFailure $
+          "third ping stream was served, echoed: " ++ show bs
+      -- The first two streams keep echoing after the refusal.
+      let payload1' = BS.pack [97..128]
+          payload2' = BS.pack [129..160]
+      streamWrite dialer1 payload1'
+      resp1 <- readNBytes dialer1 pingSize
+      resp1 `shouldBe` payload1'
+      streamWrite dialer2 payload2'
+      resp2 <- readNBytes dialer2 pingSize
+      resp2 `shouldBe` payload2'
+      close1
+      close2
+      wait h1
+      wait h2
+
+    it "closing a ping stream frees a slot for a new stream from the same peer" $ do
+      limiter <- newPingLimiter
+      let peer = PeerId "capped-peer"
+      (dialer1, close1, listener1) <- mkClosableStreamPair
+      (dialer2, close2, listener2) <- mkClosableStreamPair
+      h1 <- async $ handlePingLimited limiter listener1 peer
+      h2 <- async $ handlePingLimited limiter listener2 peer
+      streamWrite dialer1 (BS.pack [1..32])
+      _ <- readNBytes dialer1 pingSize
+      streamWrite dialer2 (BS.pack [33..64])
+      _ <- readNBytes dialer2 pingSize
+      -- Close the first stream; once its handler exits, the slot is free.
+      close1
+      wait h1
+      (dialer3, close3, listener3) <- mkClosableStreamPair
+      h3 <- async $ handlePingLimited limiter listener3 peer
+      let payload3 = BS.pack [65..96]
+      streamWrite dialer3 payload3
+      resp3 <- readNBytes dialer3 pingSize
+      resp3 `shouldBe` payload3
+      close2
+      close3
+      wait h2
+      wait h3
+
+    it "caps ping streams per peer, not globally" $ do
+      limiter <- newPingLimiter
+      let peerA = PeerId "peer-a"
+          peerB = PeerId "peer-b"
+      (dialerA1, closeA1, listenerA1) <- mkClosableStreamPair
+      (dialerA2, closeA2, listenerA2) <- mkClosableStreamPair
+      hA1 <- async $ handlePingLimited limiter listenerA1 peerA
+      hA2 <- async $ handlePingLimited limiter listenerA2 peerA
+      -- Peer A holds both of its slots.
+      streamWrite dialerA1 (BS.pack [1..32])
+      _ <- readNBytes dialerA1 pingSize
+      streamWrite dialerA2 (BS.pack [33..64])
+      _ <- readNBytes dialerA2 pingSize
+      -- A stream from peer B is still served.
+      (dialerB, closeB, listenerB) <- mkClosableStreamPair
+      hB <- async $ handlePingLimited limiter listenerB peerB
+      let payloadB = BS.pack [65..96]
+      streamWrite dialerB payloadB
+      respB <- readNBytes dialerB pingSize
+      respB `shouldBe` payloadB
+      closeA1
+      closeA2
+      closeB
+      wait hA1
+      wait hA2
+      wait hB
+
+    it "the handler registered by registerPingHandler enforces the per-peer cap" $ do
+      sw <- mkTestSwitch
+      registerPingHandler sw
+      protos <- atomically $ readTVar (swProtocols sw)
+      handler <- maybe (fail "ping handler not registered") pure
+        (Map.lookup pingProtocolId protos)
+      conn <- mkPingConnection (fail "test connection: no outbound streams")
+      (dialer1, close1, listener1) <- mkClosableStreamPair
+      (dialer2, close2, listener2) <- mkClosableStreamPair
+      (dialer3, _close3, listener3) <- mkClosableStreamPair
+      h1 <- async $ handler conn listener1
+      h2 <- async $ handler conn listener2
+      streamWrite dialer1 (BS.pack [1..32])
+      _ <- readNBytes dialer1 pingSize
+      streamWrite dialer2 (BS.pack [33..64])
+      _ <- readNBytes dialer2 pingSize
+      h3 <- async $ handler conn listener3
+      done3 <- timeout 1000000 (wait h3)
+      done3 `shouldBe` Just ()
+      streamWrite dialer3 (BS.pack [65..96])
+      echoed <- try (readNBytes dialer3 pingSize)
+      case echoed of
+        Left (_ :: IOError) -> pure ()
+        Right bs -> expectationFailure $
+          "third ping stream was served, echoed: " ++ show bs
+      close1
+      close2
+      wait h1
+      wait h2
+
   describe "Ping registration" $ do
     it "registerPingHandler adds handler to switch" $ do
       Right kp <- generateKeyPair


### PR DESCRIPTION
## Summary

Implements the listener side of the ping stream-limit clause pair (the dialer side landed in #163/#212).

ping.md: "The listening peer SHOULD accept at most two streams per peer since cross-stream behavior is non-linear and stream writes occur asynchronously."

Previously `handlePing` served every inbound ping stream the Switch dispatched, with no per-peer per-protocol cap, so a hostile dialer could hold up to the generic per-peer stream limit (256) in echo loops.

## Changes

- `src/LibP2P/Protocol/Ping.hs`
  - New `PingLimiter` (`TVar (Map PeerId Int)`) tracking live inbound ping streams per remote peer, with `newPingLimiter` / `handlePingLimited` / `maxPingStreamsPerPeer` (= 2) exported.
  - `handlePingLimited` atomically acquires a slot before serving; if the peer already holds two live ping streams the stream is reset (closed without serving the echo loop). The slot is released via `finally` when the served stream closes or errors.
  - `registerPingHandler` now creates one shared limiter and installs the capped handler, using `connPeerId` from the dispatched `Connection`.

## Tests (TDD, written first)

Five new conformance tests in `test/LibP2P/Protocol/Ping/PingSpec.hs` under "Ping responder stream cap", named after the spec clause:

- two concurrent inbound ping streams from one peer both echo
- the third concurrent stream is reset while the first two stay usable
- closing one stream frees a slot for a new stream from the same peer
- the cap is per peer, not global (a second peer's stream is unaffected)
- the handler installed by `registerPingHandler` enforces the cap end-to-end

`cabal test`: 1092 examples, 0 failures (GHC 9.10.3).

Closes #226