### PR TITLE
fix: pipeline multistream header with first proposal in initiator

### DIFF
--- a/src/LibP2P/MultistreamSelect/Negotiation.hs
+++ b/src/LibP2P/MultistreamSelect/Negotiation.hs
@@ -152,26 +152,47 @@ writeMessage :: StreamIO -> Text -> IO ()
 writeMessage stream msg = streamWrite stream (encodeMessage msg)
 
 -- | Negotiate as the Initiator.
--- Sends header, then tries each protocol in order until one is accepted.
+--
+-- Pipelines the multistream header and the first protocol proposal in a
+-- single write before reading anything, as the multistream-select spec
+-- recommends ("the initiator SHOULD pipeline the multistream protocol
+-- id and the desired protocol id in the same packet"): this saves one
+-- round trip per negotiation. It then reads the header echo and the
+-- reply to the optimistic proposal; on @na@ it falls back to proposing
+-- the remaining protocols sequentially.
 negotiateInitiator :: StreamIO -> [ProtocolId] -> IO NegotiationResult
-negotiateInitiator stream protocols = do
+negotiateInitiator stream [] = do
+  -- Nothing to propose: announce the header only (as before pipelining)
+  -- and fail the negotiation after checking the peer's echo.
   writeMessage stream multistreamHeader
   result <- readMessage stream
   case result of
     Left _ -> pure NoProtocol
+    Right _ -> pure NoProtocol
+negotiateInitiator stream (firstProto : rest) = do
+  streamWrite stream (encodeMessage multistreamHeader <> encodeMessage firstProto)
+  headerReply <- readMessage stream
+  case headerReply of
+    Left _ -> pure NoProtocol
     Right header
       | header /= multistreamHeader -> pure NoProtocol
-      | otherwise -> tryProtocols protocols
+      | otherwise -> awaitReply firstProto (tryProtocols rest)
   where
     tryProtocols [] = pure NoProtocol
-    tryProtocols (proto : rest) = do
+    tryProtocols (proto : remaining) = do
       writeMessage stream proto
+      awaitReply proto (tryProtocols remaining)
+
+    -- Read the responder's answer to an already-sent proposal: an echo
+    -- accepts it, @na@ runs the fallback, anything else is a protocol
+    -- violation.
+    awaitReply proto onNa = do
       result <- readMessage stream
       case result of
         Left _ -> pure NoProtocol
         Right response
           | response == proto -> pure (Accepted proto)
-          | response == naMessage -> tryProtocols rest
+          | response == naMessage -> onNa
           | otherwise -> pure NoProtocol
 
 -- | Negotiate as the Responder.

--- a/test/LibP2P/ConformanceSpec.hs
+++ b/test/LibP2P/ConformanceSpec.hs
@@ -112,9 +112,11 @@ spec = do
       (stream, getWritten) <- mkScriptedStream mssWrongHeader
       result <- negotiateInitiator stream ["/noise"]
       result `shouldBe` NoProtocol
-      -- It must not go on to propose a protocol to an incompatible peer.
+      -- The first proposal is pipelined with the header (spec SHOULD),
+      -- so it is already on the wire when the mismatch is detected; the
+      -- initiator must abort there and propose nothing further.
       written <- getWritten
-      written `shouldBe` mssHeader
+      written `shouldBe` (mssHeader <> mssNoise)
 
     it "responder verifies the initiator's multistream header and stays silent on a mismatch" $ do
       (stream, getWritten) <- mkScriptedStream (mssWrongHeader <> mssNoise)

--- a/test/LibP2P/Protocol/Ping/PingSpec.hs
+++ b/test/LibP2P/Protocol/Ping/PingSpec.hs
@@ -438,9 +438,11 @@ spec = do
             wait responder
             readIORef writesRef
       chunks1 <- runRecordedPing
-      -- The initiator writes exactly three chunks: the multistream header,
-      -- the protocol proposal, and the ping payload (most recent first).
-      length chunks1 `shouldBe` 3
+      -- The initiator writes exactly two chunks: the pipelined
+      -- multistream header + protocol proposal (one write, per the
+      -- multistream-select SHOULD), and the ping payload (most recent
+      -- first).
+      length chunks1 `shouldBe` 2
       let payload1 = head chunks1
       -- ping.md: the payload is 32 raw bytes — no varint prefix, no
       -- framing. A length-prefixed write would be 33+ bytes here.

--- a/test/LibP2P/WireConformanceSpec.hs
+++ b/test/LibP2P/WireConformanceSpec.hs
@@ -55,6 +55,31 @@ mkScriptedStream canned = do
         }
   pure (stream, readIORef writtenRef)
 
+-- | Like 'mkScriptedStream', but additionally snapshots everything the
+-- code under test had written at the moment of its FIRST read. Lets a
+-- transcript assert pipelining: which bytes were already on the wire
+-- before the initiator started waiting for the peer's reply.
+mkScriptedStreamSnapshottingFirstRead
+  :: ByteString -> IO (StreamIO, IO (Maybe ByteString))
+mkScriptedStreamSnapshottingFirstRead canned = do
+  writtenRef <- newIORef BS.empty
+  readRef <- newIORef canned
+  firstReadRef <- newIORef Nothing
+  let stream = StreamIO
+        { streamWrite = \bs -> modifyIORef' writtenRef (`BS.append` bs)
+        , streamReadByte = do
+            snapshot <- readIORef firstReadRef
+            case snapshot of
+              Just _ -> pure ()
+              Nothing -> readIORef writtenRef >>= writeIORef firstReadRef . Just
+            buf <- readIORef readRef
+            case BS.uncons buf of
+              Nothing -> ioError (userError "scripted stream: EOF")
+              Just (b, rest) -> writeIORef readRef rest >> pure b
+        , streamClose = pure ()
+        }
+  pure (stream, readIORef firstReadRef)
+
 -- multistream-select vectors (multiformats/multistream-select README:
 -- every message is <varint-length><UTF-8 payload>\n, length includes \n).
 
@@ -93,6 +118,19 @@ spec = do
       result `shouldBe` Accepted "/noise"
       written <- getWritten
       written `shouldBe` mssHeader <> mssNoise
+
+    -- multistream-select README (select flow): "the initiator SHOULD
+    -- pipeline the multistream protocol id and the desired protocol id
+    -- in the same packet", saving one round trip per negotiation. Both
+    -- messages must already be on the wire when the initiator first
+    -- blocks on the responder's reply.
+    it "initiator pipelines header and first proposal before its first read" $ do
+      (stream, getWrittenAtFirstRead) <-
+        mkScriptedStreamSnapshottingFirstRead (mssHeader <> mssNoise)
+      result <- negotiateInitiator stream ["/noise"]
+      result `shouldBe` Accepted "/noise"
+      writtenAtFirstRead <- getWrittenAtFirstRead
+      writtenAtFirstRead `shouldBe` Just (mssHeader <> mssNoise)
 
     it "initiator falls back to its second protocol on na" $ do
       (stream, getWritten) <- mkScriptedStream (mssHeader <> mssNa <> mssYamux)


### PR DESCRIPTION
## Summary

Found during the #178 T3a MUST/SHOULD conformance sweep: `negotiateInitiator` wrote the multistream header, blocked on the header echo, and only then sent its first protocol proposal — costing one round trip on every stream negotiation (security, muxer, and each application stream).

The multistream-select README recommends pipelining: the initiator SHOULD send the multistream protocol id and the desired protocol id in the same packet. go-libp2p does this.

## Changes

- `src/LibP2P/MultistreamSelect/Negotiation.hs`: `negotiateInitiator` now writes the header and the first proposal in a single write before its first read. It then reads the header echo (mismatch → `NoProtocol`) and the reply to the optimistic proposal (echo → `Accepted`; `na` → the existing sequential try loop for the remaining protocols). `negotiateResponder` is unchanged — it already reads messages sequentially, which naturally tolerates pipelined input.
- `test/LibP2P/WireConformanceSpec.hs`: new transcript (written TDD-first, red against the sequential implementation) that snapshots the wire at the initiator's first read and asserts both messages are already there.
- `test/LibP2P/ConformanceSpec.hs`: the header-mismatch transcript now expects the pipelined proposal on the wire, while still requiring the initiator to abort without proposing anything further.
- `test/LibP2P/Protocol/Ping/PingSpec.hs`: the payload transcript counts two writes (pipelined negotiation + payload) instead of three.

## Testing

- Full suite: **1093 examples, 0 failures** (`cabal test`, GHC 9.10.3), including the #220 EOF tests (pre-header EOF, EOF after header, truncated varint at EOF all still return `NoProtocol` without throwing).
- The hs↔go transport-interop CI job on this PR is the live cross-implementation validation for this change: go-libp2p's responder must accept our pipelined header+proposal, and our initiator must handle go's (also pipelined) replies.

Closes #227