### PR TITLE
fix: validate identify publicKey against peer id, serialize concurrent pings on a session

### DIFF
--- a/src/LibP2P/Protocol/Identify.hs
+++ b/src/LibP2P/Protocol/Identify.hs
@@ -36,7 +36,8 @@ import Control.Exception (SomeException, catch)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
-import LibP2P.Crypto.Protobuf (encodePublicKey)
+import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.Crypto.Protobuf (decodePublicKey, encodePublicKey)
 import LibP2P.Crypto.Key (kpPublic)
 import LibP2P.Multiaddr.Codec (encodeProtocols)
 import LibP2P.Multiaddr (Multiaddr (..))
@@ -83,13 +84,17 @@ handleIdentify sw conn stream = do
 -- | Request Identify from a remote peer (initiator side).
 --
 -- Opens a new stream, negotiates /ipfs/id/1.0.0, then reads one
--- varint-length-prefixed protobuf message.
+-- varint-length-prefixed protobuf message. The publicKey field is
+-- validated against the connection's authenticated peer id (see
+-- 'validatePublicKey').
 requestIdentify :: Connection -> IO (Either String IdentifyInfo)
 requestIdentify conn = do
   stream <- muxOpenStream (connSession conn)
   result <- negotiateInitiator stream [identifyProtocolId]
   case result of
-    Accepted _ -> readFramedIdentify stream maxIdentifySize
+    Accepted _ ->
+      fmap (validatePublicKey (connPeerId conn))
+        <$> readFramedIdentify stream maxIdentifySize
     NoProtocol -> pure (Left "remote does not support identify")
 
 -- | Handle an inbound Identify Push (responder side).
@@ -106,11 +111,30 @@ handleIdentifyPush sw conn stream = do
   infoOrErr <- readFramedIdentify stream maxIdentifySize
   case infoOrErr of
     Left _ -> pure ()
-    Right info -> atomically $ do
-      store <- readTVar (swPeerStore sw)
-      let merged = maybe info (`mergeIdentify` info)
-                     (Map.lookup (connPeerId conn) store)
-      writeTVar (swPeerStore sw) (Map.insert (connPeerId conn) merged store)
+    Right rawInfo -> do
+      let info = validatePublicKey (connPeerId conn) rawInfo
+      atomically $ do
+        store <- readTVar (swPeerStore sw)
+        let merged = maybe info (`mergeIdentify` info)
+                       (Map.lookup (connPeerId conn) store)
+        writeTVar (swPeerStore sw) (Map.insert (connPeerId conn) merged store)
+
+-- | Enforce the identify spec's key/peer-id binding: the publicKey
+-- field must derive the sender's peer id, which the security handshake
+-- has already authenticated.
+--
+-- A key that fails to decode or derives a different peer id is an
+-- identity claim the sender cannot back up, so it is dropped from the
+-- message (matching go-libp2p, which discards the key and keeps the
+-- connection — it is already authenticated). The rest of the message
+-- is untouched, and previously known good data stays intact because
+-- 'mergeIdentify' keeps the known key when the update carries none.
+validatePublicKey :: PeerId -> IdentifyInfo -> IdentifyInfo
+validatePublicKey remotePeer info = case idPublicKey info of
+  Nothing -> info
+  Just keyBytes -> case decodePublicKey keyBytes of
+    Right pk | fromPublicKey pk == remotePeer -> info
+    _ -> info { idPublicKey = Nothing }
 
 -- | Merge a received (possibly partial) Identify update into the
 -- previously known info for a peer.

--- a/src/LibP2P/Protocol/Ping.hs
+++ b/src/LibP2P/Protocol/Ping.hs
@@ -48,6 +48,7 @@ module LibP2P.Protocol.Ping
   , maxPingStreamsPerPeer
   ) where
 
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM
   ( TVar
   , atomically
@@ -58,7 +59,6 @@ import Control.Concurrent.STM
   )
 import Control.Exception (SomeException, catch, finally, try)
 import Control.Monad (unless)
-import qualified Data.ByteString as BS
 import Data.ByteString (ByteString)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import qualified Data.Map.Strict as Map
@@ -164,9 +164,15 @@ handlePingLimited (PingLimiter countsVar) stream peer = do
 -- pings with 'ping', and always release with 'closePingSession'. A
 -- session whose ping failed (timeout, mismatch, I/O error) closes its
 -- stream immediately and rejects further pings.
+--
+-- Concurrent 'ping' calls on one session are serialized on 'psLock':
+-- exactly one write/echo exchange runs on the stream at a time, so
+-- concurrent callers queue instead of interleaving their 32-byte
+-- payloads on the wire.
 data PingSession = PingSession
   { psStream :: !StreamIO
   , psClosed :: !(IORef Bool)
+  , psLock   :: !(MVar ())  -- ^ Held for the duration of one ping exchange
   }
 
 -- | Open a ping stream on the connection and negotiate the protocol.
@@ -186,7 +192,8 @@ openPingSession sw conn = do
       case negotiated of
         Right (Accepted _) -> do
           closedRef <- newIORef False
-          pure (Right (PingSession stream closedRef))
+          lock <- newMVar ()
+          pure (Right (PingSession stream closedRef lock))
         Right NoProtocol -> do
           closeQuietly stream
           pure (Left (PingStreamError "remote does not support ping"))
@@ -203,8 +210,13 @@ ping = pingWithTimeout pingTimeoutMicros
 -- microseconds for the echo. On failure the session is closed: a stream
 -- whose echo timed out or went wrong cannot be reused, because a late
 -- echo would corrupt the next ping.
+--
+-- The whole exchange runs under the session lock, so concurrent callers
+-- are queued one after another on the single stream. The closed check
+-- happens under the lock too: a caller queued behind a failed ping sees
+-- the session as closed instead of writing into a poisoned stream.
 pingWithTimeout :: Int -> PingSession -> IO (Either PingError PingResult)
-pingWithTimeout timeoutUs sess = do
+pingWithTimeout timeoutUs sess = withMVar (psLock sess) $ \() -> do
   closed <- readIORef (psClosed sess)
   if closed
     then pure (Left (PingStreamError "ping session is closed"))

--- a/test/LibP2P/IntegrationSpec.hs
+++ b/test/LibP2P/IntegrationSpec.hs
@@ -280,6 +280,36 @@ spec = do
         opens <- readIORef opensRef
         opens `shouldBe` 1
 
+    it "10 concurrent pings on one session share a single outbound stream" $ do
+      -- ping.md: "The dialing peer MUST NOT keep more than one outbound
+      -- stream for the ping protocol per peer" — even when callers ping
+      -- concurrently, the session serializes them on its one stream and
+      -- every ping still gets its own matching echo.
+      withConnectedPair $ \(swA, _pidA) _nodeB conn -> do
+        opensRef <- newIORef (0 :: Int)
+        let realSession = connSession conn
+            countingSession = realSession
+              { muxOpenStream = do
+                  modifyIORef' opensRef (+ 1)
+                  muxOpenStream realSession
+              }
+            countingConn = conn { connSession = countingSession }
+        result <- timeout 30000000 $ withPingSession swA countingConn $ \sess ->
+          forConcurrently [1 .. 10 :: Int] $ \_ -> ping sess
+        case result of
+          Nothing -> expectationFailure "concurrent ping session timed out"
+          Just (Left err) ->
+            expectationFailure $ "ping session failed to open: " ++ show err
+          Just (Right results) -> do
+            length results `shouldBe` 10
+            mapM_
+              (\r -> case r of
+                 Right (PingResult rtt) -> rtt `shouldSatisfy` (> 0)
+                 Left err -> expectationFailure $ "concurrent ping failed: " ++ show err)
+              results
+        opens <- readIORef opensRef
+        opens `shouldBe` 1
+
     it "unknown protocol gets na over real TCP and the connection stays usable" $ do
       withConnectedPair $ \(swA, _pidA) _nodeB conn -> do
         stream <- muxOpenStream (connSession conn)

--- a/test/LibP2P/Protocol/Identify/IdentifySpec.hs
+++ b/test/LibP2P/Protocol/Identify/IdentifySpec.hs
@@ -348,6 +348,148 @@ spec = do
           idAgentVersion merged `shouldBe` Just "go-libp2p/0.36.0"
           idProtocolVersion merged `shouldBe` Just "ipfs/0.1.0"
 
+    it "handleIdentifyPush stores a publicKey that derives the authenticated peer id" $ do
+      -- specs/identify: receivers must validate that the publicKey
+      -- derives the sender's peer id. A key that matches the peer id
+      -- authenticated by the security handshake is stored.
+      sw <- mkTestSwitch
+      Right remoteKp <- generateKeyPair
+      let remotePid = fromPublicKey (kpPublic remoteKp)
+          remoteKey = encodePublicKey (kpPublic remoteKp)
+          pushInfo = emptyInfo
+            { idPublicKey    = Just remoteKey
+            , idAgentVersion = Just "go-libp2p/0.36.0"
+            }
+      (streamA, streamB) <- mkClosableStreamPair
+      streamWrite streamA (frame (encodeIdentify pushInfo))
+      streamClose streamA
+      conn <- mkTestConnection remotePid (Multiaddr [IP4 0x7f000001, TCP 4001])
+      handleIdentifyPush sw conn streamB
+      store <- atomically $ readTVar (swPeerStore sw)
+      fmap idPublicKey (Map.lookup remotePid store) `shouldBe` Just (Just remoteKey)
+
+    it "handleIdentifyPush drops a publicKey that does not derive the authenticated peer id" $ do
+      -- A pushed key deriving some other peer id is an identity claim
+      -- the sender cannot back up: discard the key (go-libp2p behaviour;
+      -- the connection is already authenticated by Noise), keep the
+      -- known-good key, and still apply the rest of the update.
+      sw <- mkTestSwitch
+      Right remoteKp <- generateKeyPair
+      Right otherKp  <- generateKeyPair
+      let remotePid = fromPublicKey (kpPublic remoteKp)
+          knownKey  = encodePublicKey (kpPublic remoteKp)
+          wrongKey  = encodePublicKey (kpPublic otherKp)
+          knownInfo = emptyInfo
+            { idPublicKey    = Just knownKey
+            , idAgentVersion = Just "agent/1.0"
+            }
+      atomically $ do
+        store <- readTVar (swPeerStore sw)
+        writeTVar (swPeerStore sw) (Map.insert remotePid knownInfo store)
+      let update = emptyInfo
+            { idPublicKey    = Just wrongKey
+            , idAgentVersion = Just "agent/2.0"
+            }
+      (streamA, streamB) <- mkClosableStreamPair
+      streamWrite streamA (frame (encodeIdentify update))
+      streamClose streamA
+      conn <- mkTestConnection remotePid (Multiaddr [IP4 0x7f000001, TCP 4001])
+      handleIdentifyPush sw conn streamB
+      store <- atomically $ readTVar (swPeerStore sw)
+      case Map.lookup remotePid store of
+        Nothing -> expectationFailure "expected peer in store"
+        Just stored -> do
+          -- The mismatched key is not stored; the known-good key survives.
+          idPublicKey stored `shouldBe` Just knownKey
+          -- Validation only touches the key: the rest of the update merges.
+          idAgentVersion stored `shouldBe` Just "agent/2.0"
+
+    it "handleIdentifyPush does not store a mismatched publicKey for an unknown peer" $ do
+      sw <- mkTestSwitch
+      Right remoteKp <- generateKeyPair
+      Right otherKp  <- generateKeyPair
+      let remotePid = fromPublicKey (kpPublic remoteKp)
+          wrongKey  = encodePublicKey (kpPublic otherKp)
+          update = emptyInfo
+            { idPublicKey    = Just wrongKey
+            , idAgentVersion = Just "agent/2.0"
+            }
+      (streamA, streamB) <- mkClosableStreamPair
+      streamWrite streamA (frame (encodeIdentify update))
+      streamClose streamA
+      conn <- mkTestConnection remotePid (Multiaddr [IP4 0x7f000001, TCP 4001])
+      handleIdentifyPush sw conn streamB
+      store <- atomically $ readTVar (swPeerStore sw)
+      case Map.lookup remotePid store of
+        Nothing -> expectationFailure "expected peer in store"
+        Just stored -> do
+          idPublicKey stored `shouldBe` Nothing
+          idAgentVersion stored `shouldBe` Just "agent/2.0"
+
+    it "handleIdentifyPush drops a publicKey that cannot be decoded" $ do
+      -- A key that does not even parse as a PublicKey protobuf cannot be
+      -- validated against the peer id, so it must not be stored either.
+      sw <- mkTestSwitch
+      Right remoteKp <- generateKeyPair
+      let remotePid = fromPublicKey (kpPublic remoteKp)
+          update = emptyInfo { idPublicKey = Just (BS.pack [0xde, 0xad, 0xbe, 0xef]) }
+      (streamA, streamB) <- mkClosableStreamPair
+      streamWrite streamA (frame (encodeIdentify update))
+      streamClose streamA
+      conn <- mkTestConnection remotePid (Multiaddr [IP4 0x7f000001, TCP 4001])
+      handleIdentifyPush sw conn streamB
+      store <- atomically $ readTVar (swPeerStore sw)
+      fmap idPublicKey (Map.lookup remotePid store) `shouldBe` Just Nothing
+
+    it "requestIdentify drops a publicKey that does not derive the remote peer id" $ do
+      -- Response path of the same validation: the identify response is
+      -- returned with the mismatched key removed, other fields intact.
+      Right remoteKp <- generateKeyPair
+      Right otherKp  <- generateKeyPair
+      let remotePid = fromPublicKey (kpPublic remoteKp)
+          wrongKey  = encodePublicKey (kpPublic otherKp)
+          responseInfo = emptyInfo
+            { idPublicKey    = Just wrongKey
+            , idAgentVersion = Just "impostor/1.0"
+            }
+      (streamA, streamB) <- mkClosableStreamPair
+      conn <- mkPushConnection remotePid (Multiaddr [IP4 0x7f000001, TCP 4001])
+                (pure streamA)
+      remote <- async $ do
+        negResult <- negotiateResponder streamB [identifyProtocolId]
+        negResult `shouldBe` Accepted identifyProtocolId
+        streamWrite streamB (encodeFramedIdentify responseInfo)
+        streamClose streamB
+      result <- requestIdentify conn
+      wait remote
+      case result of
+        Left err -> expectationFailure $ "requestIdentify failed: " ++ err
+        Right info -> do
+          idPublicKey info `shouldBe` Nothing
+          idAgentVersion info `shouldBe` Just "impostor/1.0"
+
+    it "requestIdentify keeps a publicKey that derives the remote peer id" $ do
+      Right remoteKp <- generateKeyPair
+      let remotePid = fromPublicKey (kpPublic remoteKp)
+          remoteKey = encodePublicKey (kpPublic remoteKp)
+          responseInfo = emptyInfo
+            { idPublicKey    = Just remoteKey
+            , idAgentVersion = Just "honest/1.0"
+            }
+      (streamA, streamB) <- mkClosableStreamPair
+      conn <- mkPushConnection remotePid (Multiaddr [IP4 0x7f000001, TCP 4001])
+                (pure streamA)
+      remote <- async $ do
+        negResult <- negotiateResponder streamB [identifyProtocolId]
+        negResult `shouldBe` Accepted identifyProtocolId
+        streamWrite streamB (encodeFramedIdentify responseInfo)
+        streamClose streamB
+      result <- requestIdentify conn
+      wait remote
+      case result of
+        Left err -> expectationFailure $ "requestIdentify failed: " ++ err
+        Right info -> idPublicKey info `shouldBe` Just remoteKey
+
     it "mergeIdentify replaces present optional fields and non-empty repeated fields wholesale" $ do
       -- specs/identify: only *missing* fields are ignored. A field that
       -- is present in the update wins, and repeated fields are replaced

--- a/test/LibP2P/Protocol/Ping/PingSpec.hs
+++ b/test/LibP2P/Protocol/Ping/PingSpec.hs
@@ -1,6 +1,6 @@
 module LibP2P.Protocol.Ping.PingSpec (spec) where
 
-import Control.Concurrent.Async (async, cancel, wait)
+import Control.Concurrent.Async (async, cancel, forConcurrently, wait)
 import Control.Concurrent.STM
   ( TMVar
   , TQueue
@@ -253,6 +253,34 @@ spec = do
       opens `shouldBe` 1
       closed <- readIORef closedRef
       closed `shouldBe` True
+      done <- timeout 1000000 (wait responder)
+      done `shouldBe` Just ()
+
+    it "10 concurrent pings on one session serialize onto the single stream and all succeed" $ do
+      -- ping.md: the dialing peer MUST NOT keep more than one outbound
+      -- ping stream per peer. Concurrent callers must queue on the
+      -- session's one stream, one exchange at a time — without
+      -- serialization their 32-byte payloads interleave on the wire and
+      -- the echoes no longer match.
+      (streamA, _closeA, streamB) <- mkClosableStreamPair
+      opensRef <- newIORef (0 :: Int)
+      sw <- mkTestSwitch
+      conn <- mkPingConnection (countingOpen opensRef streamA)
+      responder <- async $ pingResponder streamB
+      result <- withPingSession sw conn $ \sess ->
+        forConcurrently [1 .. 10 :: Int] $ \_ -> ping sess
+      case result of
+        Left err -> expectationFailure $ "ping session failed to open: " ++ show err
+        Right results -> do
+          length results `shouldBe` 10
+          mapM_
+            (\r -> case r of
+               Right (PingResult rtt) -> rtt `shouldSatisfy` (>= 0)
+               Left err -> expectationFailure $ "concurrent ping failed: " ++ show err)
+            results
+      opens <- readIORef opensRef
+      opens `shouldBe` 1
+      -- withPingSession closed the stream, so the responder exits on EOF.
       done <- timeout 1000000 (wait responder)
       done `shouldBe` Just ()
 


### PR DESCRIPTION
Closes out the two implementation-dependent remainders of #170 that PRs #200/#219 could not cover as tests, because the behaviour itself was missing.

## Identify publicKey validation

Per specs/identify, receivers must validate that the `publicKey` field derives the sender's peer id. `mergeIdentify` previously stored any received key unchecked. Both receive paths now run the check against the connection's authenticated peer id (`connPeerId`, available since #195):

- `requestIdentify` (response path) and `handleIdentifyPush` (push path) pass the decoded message through `validatePublicKey`.
- A key that fails to decode or derives a different peer id is dropped from the message — matching go-libp2p, which discards the key without disconnecting (the connection is already authenticated by Noise). The rest of the update still applies, and the previously known good key survives the merge.

## PingSession concurrency

`psStream` was used without serialization, so concurrent `ping` calls on one session interleaved their 32-byte payloads on the wire. `PingSession` now carries a per-session `MVar` lock: the closed-check plus the whole write/echo exchange run under it, so concurrent callers queue for one exchange at a time on the single outbound stream (ping.md: the dialer MUST NOT keep more than one outbound ping stream per peer).

## Tests (TDD, red verified before the fixes)

| Test | Tier |
|---|---|
| `handleIdentifyPush stores a publicKey that derives the authenticated peer id` | stream |
| `handleIdentifyPush drops a publicKey that does not derive the authenticated peer id` (known key kept, rest of update applied) | stream |
| `handleIdentifyPush does not store a mismatched publicKey for an unknown peer` | stream |
| `handleIdentifyPush drops a publicKey that cannot be decoded` | stream |
| `requestIdentify drops a publicKey that does not derive the remote peer id` / `keeps a matching one` | stream |
| `10 concurrent pings on one session serialize onto the single stream and all succeed` (instrumented muxer; failed pre-fix with interleaving-induced stream errors) | unit |
| `10 concurrent pings on one session share a single outbound stream` (two-host, real TCP+Noise+Yamux; ran 3x extra without flakes) | E2E |

## Verification

`cabal build` + `cabal test` (GHC 9.10.3): 1100 examples, 0 failures.

## Out of scope

- The cross-implementation identify/ping rows from #170 are delegated to the unified-testing work in #129.
- Refreshing the vendored `specs/` snapshot (identify README r1 lacks `signedPeerRecord = 8`) is a separate chore.

Closes #170
