### PR TITLE
feat: implement RFC 0003 PeerRecord and wire signedPeerRecord into identify and gossipsub PX

### DIFF
--- a/libp2p-hs.cabal
+++ b/libp2p-hs.cabal
@@ -72,6 +72,7 @@ library
     LibP2P.NAT.AutoNAT.Message
     LibP2P.NAT.AutoNAT
     LibP2P.Crypto.SignedEnvelope
+    LibP2P.Crypto.PeerRecord
     LibP2P.NAT.Relay.Message
     LibP2P.NAT.Relay
     LibP2P.NAT.Relay.Client
@@ -177,6 +178,7 @@ test-suite libp2p-hs-test
     LibP2P.NAT.AutoNAT.MessageSpec
     LibP2P.NAT.AutoNAT.AutoNATSpec
     LibP2P.Crypto.SignedEnvelopeSpec
+    LibP2P.Crypto.PeerRecordSpec
     LibP2P.NAT.Relay.MessageSpec
     LibP2P.NAT.Relay.RelaySpec
     LibP2P.NAT.Relay.ClientSpec

--- a/src/LibP2P/Crypto/PeerRecord.hs
+++ b/src/LibP2P/Crypto/PeerRecord.hs
@@ -1,0 +1,142 @@
+-- | Peer routing records (RFC 0003).
+--
+-- A PeerRecord is a self-certified statement of a peer's dialable
+-- addresses, distributed inside a "LibP2P.Crypto.SignedEnvelope"
+-- (RFC 0002). Consumers verify the envelope signature and that the
+-- signing key derives the peer id named in the record, giving
+-- third-party-relayable address information that cannot be forged.
+--
+-- Wire format (go-libp2p @core/peer/pb/peer_record.proto@):
+--
+-- > message PeerRecord {
+-- >   message AddressInfo { bytes multiaddr = 1; }
+-- >   bytes peer_id = 1;
+-- >   uint64 seq = 2;
+-- >   repeated AddressInfo addresses = 3;
+-- > }
+--
+-- Envelope parameters (go-libp2p @core/peer/record.go@ — note the RFC
+-- 0003 draft text uses different strings; the deployed go-libp2p values
+-- are authoritative for interop):
+--
+--   * domain: @libp2p-peer-record@
+--   * payload type: the raw multicodec bytes @0x03 0x01@
+--     (multicodec table name @libp2p-peer-record@)
+module LibP2P.Crypto.PeerRecord
+  ( -- * Record type
+    PeerRecord (..)
+  , timestampSeq
+    -- * Protobuf codec
+  , encodePeerRecord
+  , decodePeerRecord
+    -- * Envelope integration
+  , peerRecordEnvelopeDomain
+  , peerRecordEnvelopePayloadType
+  , sealPeerRecord
+  , openPeerRecordEnvelope
+  ) where
+
+import Control.Monad (unless)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+import Data.IORef (IORef, atomicModifyIORef', newIORef)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Word (Word64)
+import LibP2P.Crypto.Key (KeyPair (..))
+import LibP2P.Crypto.PeerId (fromPublicKey, peerIdBytes)
+import LibP2P.Crypto.SignedEnvelope
+  ( SignedEnvelope (..)
+  , createEnvelope
+  , decodeSignedEnvelope
+  , verifyEnvelope
+  )
+import qualified Proto3.Wire.Decode as Decode
+import Proto3.Wire.Decode (Parser, RawMessage, at, embedded', one, parse, repeated)
+import qualified Proto3.Wire.Encode as Encode
+import Proto3.Wire.Types (FieldNumber (..))
+import System.IO.Unsafe (unsafePerformIO)
+
+-- | A routing record: which addresses a peer claims to be reachable at.
+data PeerRecord = PeerRecord
+  { prPeerId    :: !ByteString   -- ^ Peer id bytes (multihash of the public key)
+  , prSeq       :: !Word64       -- ^ Monotonic sequence number (see 'timestampSeq')
+  , prAddresses :: ![ByteString] -- ^ Binary multiaddrs (one per wrapped AddressInfo)
+  } deriving (Show, Eq)
+
+-- | Domain separation string for peer-record envelopes
+-- (go-libp2p @PeerRecordEnvelopeDomain@).
+peerRecordEnvelopeDomain :: ByteString
+peerRecordEnvelopeDomain = "libp2p-peer-record"
+
+-- | Envelope payload type: the @libp2p-peer-record@ multicodec bytes
+-- (go-libp2p @PeerRecordEnvelopePayloadType@).
+peerRecordEnvelopePayloadType :: ByteString
+peerRecordEnvelopePayloadType = BS.pack [0x03, 0x01]
+
+{-# NOINLINE lastSeqRef #-}
+lastSeqRef :: IORef Word64
+lastSeqRef = unsafePerformIO (newIORef 0)
+
+-- | A timestamp-based, strictly monotonic sequence number: the current
+-- Unix time in nanoseconds, bumped past the previous value if the clock
+-- has not advanced (mirrors go-libp2p @peer.TimestampSeq@).
+timestampSeq :: IO Word64
+timestampSeq = do
+  now <- floor . (* 1e9) . toRational <$> getPOSIXTime
+  atomicModifyIORef' lastSeqRef $ \prev ->
+    let next = max now (prev + 1) in (next, next)
+
+-- | Encode a PeerRecord to protobuf wire format. Proto3 default values
+-- (empty peer_id, zero seq) are omitted, matching go-libp2p's encoder.
+encodePeerRecord :: PeerRecord -> ByteString
+encodePeerRecord pr = BL.toStrict $ Encode.toLazyByteString $
+     (if BS.null (prPeerId pr)
+        then mempty
+        else Encode.byteString (FieldNumber 1) (prPeerId pr))
+  <> (if prSeq pr == 0
+        then mempty
+        else Encode.uint64 (FieldNumber 2) (prSeq pr))
+  <> foldMap
+       (Encode.embedded (FieldNumber 3) . Encode.byteString (FieldNumber 1))
+       (prAddresses pr)
+
+-- | Decode a PeerRecord from protobuf wire format.
+decodePeerRecord :: ByteString -> Either String PeerRecord
+decodePeerRecord bs = case parse peerRecordParser bs of
+  Left err     -> Left $ "PeerRecord decode error: " ++ show err
+  Right record -> Right record
+
+peerRecordParser :: Parser RawMessage PeerRecord
+peerRecordParser = PeerRecord
+  <$> at (one Decode.byteString BS.empty) (FieldNumber 1)
+  <*> at (one Decode.uint64 0) (FieldNumber 2)
+  <*> at (repeated (embedded' addressInfoParser)) (FieldNumber 3)
+
+addressInfoParser :: Parser RawMessage ByteString
+addressInfoParser = at (one Decode.byteString BS.empty) (FieldNumber 1)
+
+-- | Seal a PeerRecord into a SignedEnvelope with the given identity key.
+-- The caller is responsible for the record's peer id matching the key
+-- (a mismatched record still seals, but no verifier will accept it).
+sealPeerRecord :: KeyPair -> PeerRecord -> Either String SignedEnvelope
+sealPeerRecord kp record =
+  createEnvelope (kpPrivate kp) (kpPublic kp)
+    peerRecordEnvelopeDomain peerRecordEnvelopePayloadType
+    (encodePeerRecord record)
+
+-- | Open an encoded peer-record envelope: decode it, check the payload
+-- type, verify the signature under the peer-record domain, decode the
+-- record, and require that the envelope's key derives the peer id the
+-- record claims. Any failure rejects the envelope.
+openPeerRecordEnvelope :: ByteString -> Either String (SignedEnvelope, PeerRecord)
+openPeerRecordEnvelope bs = do
+  env <- decodeSignedEnvelope bs
+  unless (sePayloadType env == peerRecordEnvelopePayloadType) $
+    Left "peer record envelope: unexpected payload type"
+  unless (verifyEnvelope env peerRecordEnvelopeDomain) $
+    Left "peer record envelope: invalid signature"
+  record <- decodePeerRecord (sePayload env)
+  unless (peerIdBytes (fromPublicKey (sePublicKey env)) == prPeerId record) $
+    Left "peer record envelope: key does not derive the record's peer id"
+  Right (env, record)

--- a/src/LibP2P/Protocol/GossipSub/Handler.hs
+++ b/src/LibP2P/Protocol/GossipSub/Handler.hs
@@ -63,7 +63,9 @@ import LibP2P.Protocol.GossipSub.Router
   , publish
   , removePeer
   , setPeerIP
+  , setSignedPeerRecord
   )
+import LibP2P.Protocol.Identify.Message (IdentifyInfo (..))
 import qualified Data.Set as Set
 import LibP2P.Protocol.GossipSub.Types
   ( GossipSubParams
@@ -214,6 +216,7 @@ handleGossipSubStream node stream pid proto mIP = do
   now <- getCurrentTime
   addPeer (gsnRouter node) pid proto False now
   mapM_ (setPeerIP (gsnRouter node) pid) mIP
+  syncSignedPeerRecord node pid
   -- Read loop
   readLoop
   -- Cleanup on disconnect
@@ -227,6 +230,16 @@ handleGossipSubStream node stream pid proto mIP = do
         Right rpc -> do
           handleRPC (gsnRouter node) pid rpc
           readLoop
+
+-- | Feed the peer's signed peer record (obtained via identify, already
+-- verified against the authenticated peer id on receipt) from the
+-- Switch's peer store into the router, so PRUNE-with-PX can attach it
+-- when advertising this peer (#230).
+syncSignedPeerRecord :: GossipSubNode -> PeerId -> IO ()
+syncSignedPeerRecord node pid = do
+  store <- atomically $ readTVar (swPeerStore (gsnSwitch node))
+  mapM_ (setSignedPeerRecord (gsnRouter node) pid)
+    (Map.lookup pid store >>= idSignedPeerRecord)
 
 -- | Start the GossipSub node: register stream handler, notifier, and start heartbeat.
 startGossipSub :: GossipSubNode -> IO ()
@@ -263,6 +276,7 @@ onNewConnection node conn = do
       now <- getCurrentTime
       addPeer (gsnRouter node) pid proto True now
       mapM_ (setPeerIP (gsnRouter node) pid) (remoteIPBytes conn)
+      syncSignedPeerRecord node pid
       -- Send current subscriptions to the new peer
       sendCurrentSubscriptions node stream
       -- Start read loop on this stream to receive RPCs from the peer

--- a/src/LibP2P/Protocol/GossipSub/Router.hs
+++ b/src/LibP2P/Protocol/GossipSub/Router.hs
@@ -10,6 +10,7 @@ module LibP2P.Protocol.GossipSub.Router
   , addPeer
   , removePeer
   , setPeerIP
+  , setSignedPeerRecord
     -- * Topic subscription
   , join
   , leave
@@ -48,6 +49,7 @@ import Data.Word (Word64)
 import Crypto.Random (getRandomBytes)
 import List.Shuffle (sampleIO)
 import LibP2P.Crypto.PeerId (PeerId, peerIdBytes)
+import LibP2P.Crypto.PeerRecord (PeerRecord (..), openPeerRecordEnvelope)
 import LibP2P.Crypto.Key (KeyPair (..), sign)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Protocol.GossipSub.Types
@@ -88,6 +90,7 @@ newRouter params localPid sendRPC getTime = do
   iaskedCounts <- newTVarIO Map.empty
   iwantServed <- newTVarIO Map.empty
   onPX     <- newTVarIO (\_ _ -> pure ())
+  signedRecords <- newTVarIO Map.empty
   pure GossipSubRouter
     { gsParams         = params
     , gsLocalPeerId    = localPid
@@ -112,6 +115,7 @@ newRouter params localPid sendRPC getTime = do
     , gsOnMessage      = onMsg
     , gsValidators     = validators
     , gsOnPeerExchange = onPX
+    , gsSignedPeerRecords = signedRecords
     }
 
 -- Topic validation
@@ -159,6 +163,7 @@ removePeer router pid = atomically $ do
     Nothing -> pure ()
   modifyTVar' (gsPeers router) (Map.delete pid)
   modifyTVar' (gsMesh router) (Map.map (Set.delete pid))
+  modifyTVar' (gsSignedPeerRecords router) (Map.delete pid)
   modifyTVar' (gsFanout router) (Map.map (Set.delete pid))
   modifyTVar' (gsIWantPromises router) $
     Map.filterWithKey (\(p, _) _ -> p /= pid)
@@ -684,11 +689,27 @@ handleOnePrune router sender now prune = do
   -- Honour peer exchange, but only from peers whose score clears the
   -- PX acceptance threshold (gossipsub-v1.1.md: PX from low-scoring
   -- peers is an eclipse-attack vector)
+  -- Any attached signed peer record must verify (RFC 0003 envelope
+  -- opens and names the advertised peer) — a record that fails drops
+  -- its whole PX entry, matching go-libp2p's pxConnect. Entries without
+  -- a record are passed through unchanged.
   unless (null (prunePeers prune)) $ do
     score <- peerScore router sender
     when (score >= stAcceptPXThreshold (gsThresholds router)) $ do
-      onPX <- readTVarIO (gsOnPeerExchange router)
-      onPX topic (prunePeers prune)
+      let verified = filter validPXRecord (prunePeers prune)
+      unless (null verified) $ do
+        onPX <- readTVarIO (gsOnPeerExchange router)
+        onPX topic verified
+
+-- | A PX entry is acceptable if it carries no signed record, or a
+-- record whose envelope verifies and whose subject is the advertised
+-- peer id.
+validPXRecord :: PeerExchangeInfo -> Bool
+validPXRecord pxi = case pxSignedPeerRecord pxi of
+  Nothing -> True
+  Just envBytes -> case openPeerRecordEnvelope envBytes of
+    Right (_, record) -> prPeerId record == pxPeerId pxi
+    Left _ -> False
 
 -- | Handle IHAVE: request unseen messages via IWANT.
 --
@@ -808,14 +829,24 @@ peerScore router pid = do
 
 -- Peer exchange
 
+-- | Store the encoded signed peer record (RFC 0003 envelope bytes) for
+-- a peer, typically obtained via identify. It is attached to PX entries
+-- advertising that peer in outgoing PRUNEs (gossipsub-v1.1.md). Cleared
+-- by 'removePeer'.
+setSignedPeerRecord :: GossipSubRouter -> PeerId -> ByteString -> IO ()
+setSignedPeerRecord router pid recBytes = atomically $
+  modifyTVar' (gsSignedPeerRecords router) (Map.insert pid recBytes)
+
 -- | Select peer-exchange records for a PRUNE: up to 'paramPrunePeers'
 -- random peers subscribed to the topic with non-negative score,
 -- excluding the pruned peer itself (gossipsub-v1.1.md peer exchange).
+-- Peers whose signed peer record we hold get it attached.
 selectPXPeers :: GossipSubRouter -> Topic -> PeerId -> IO [PeerExchangeInfo]
 selectPXPeers router topic excluded = do
   now <- gsGetTime router
   peers <- readTVarIO (gsPeers router)
   ipMap <- readTVarIO (gsIPPeerCount router)
+  signedRecords <- readTVarIO (gsSignedPeerRecords router)
   let candidates =
         [ pid | (pid, ps) <- Map.toList peers
               , pid /= excluded
@@ -824,7 +855,8 @@ selectPXPeers router topic excluded = do
               , computeScore (gsScoreParams router) pid ps ipMap now >= 0 ]
   chosen <- sampleIO
     (min (paramPrunePeers (gsParams router)) (length candidates)) candidates
-  pure [ PeerExchangeInfo (peerIdBytes pid) Nothing | pid <- chosen ]
+  pure [ PeerExchangeInfo (peerIdBytes pid) (Map.lookup pid signedRecords)
+       | pid <- chosen ]
 
 -- Helper: construct a GRAFT RPC
 graftRPC :: Topic -> RPC

--- a/src/LibP2P/Protocol/GossipSub/Types.hs
+++ b/src/LibP2P/Protocol/GossipSub/Types.hs
@@ -500,7 +500,13 @@ data GossipSubRouter = GossipSubRouter
   , gsOnPeerExchange :: !(TVar (Topic -> [PeerExchangeInfo] -> IO ()))
     -- ^ Called with PX records from a PRUNE whose sender scores at or
     -- above 'stAcceptPXThreshold'. The application decides how to act
-    -- (e.g. resolve addresses and dial); default is a no-op.
+    -- (e.g. resolve addresses and dial); default is a no-op. Entries
+    -- carrying a signed peer record that fails verification are dropped
+    -- before the callback runs (gossipsub-v1.1.md, RFC 0003).
+  , gsSignedPeerRecords :: !(TVar (Map PeerId ByteString))
+    -- ^ Encoded RFC 0003 peer-record envelopes per peer, typically fed
+    -- from identify. Attached to PX entries in outgoing PRUNEs so the
+    -- receiver can verify the advertised addresses.
   }
 
 -- Defaults

--- a/src/LibP2P/Protocol/Identify.hs
+++ b/src/LibP2P/Protocol/Identify.hs
@@ -36,9 +36,16 @@ import Control.Exception (SomeException, catch)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
-import LibP2P.Crypto.PeerId (PeerId, fromPublicKey)
+import LibP2P.Crypto.PeerId (PeerId, fromPublicKey, peerIdBytes)
+import LibP2P.Crypto.PeerRecord
+  ( PeerRecord (..)
+  , openPeerRecordEnvelope
+  , sealPeerRecord
+  , timestampSeq
+  )
 import LibP2P.Crypto.Protobuf (decodePublicKey, encodePublicKey)
 import LibP2P.Crypto.Key (kpPublic)
+import LibP2P.Crypto.SignedEnvelope (SignedEnvelope (..), encodeSignedEnvelope)
 import LibP2P.Multiaddr.Codec (encodeProtocols)
 import LibP2P.Multiaddr (Multiaddr (..))
 import LibP2P.MultistreamSelect.Negotiation
@@ -93,7 +100,7 @@ requestIdentify conn = do
   result <- negotiateInitiator stream [identifyProtocolId]
   case result of
     Accepted _ ->
-      fmap (validatePublicKey (connPeerId conn))
+      fmap (validateIdentify (connPeerId conn))
         <$> readFramedIdentify stream maxIdentifySize
     NoProtocol -> pure (Left "remote does not support identify")
 
@@ -112,12 +119,18 @@ handleIdentifyPush sw conn stream = do
   case infoOrErr of
     Left _ -> pure ()
     Right rawInfo -> do
-      let info = validatePublicKey (connPeerId conn) rawInfo
+      let info = validateIdentify (connPeerId conn) rawInfo
       atomically $ do
         store <- readTVar (swPeerStore sw)
         let merged = maybe info (`mergeIdentify` info)
                        (Map.lookup (connPeerId conn) store)
         writeTVar (swPeerStore sw) (Map.insert (connPeerId conn) merged store)
+
+-- | Validate the identity-bound fields of a received Identify message
+-- against the peer id authenticated by the security handshake.
+validateIdentify :: PeerId -> IdentifyInfo -> IdentifyInfo
+validateIdentify remotePeer =
+  validateSignedPeerRecord remotePeer . validatePublicKey remotePeer
 
 -- | Enforce the identify spec's key/peer-id binding: the publicKey
 -- field must derive the sender's peer id, which the security handshake
@@ -136,6 +149,25 @@ validatePublicKey remotePeer info = case idPublicKey info of
     Right pk | fromPublicKey pk == remotePeer -> info
     _ -> info { idPublicKey = Nothing }
 
+-- | Verify a received signedPeerRecord (RFC 0003) against the
+-- authenticated peer id: the envelope must open (valid signature,
+-- payload type, key/record binding) and its signing key must derive
+-- the peer id the security handshake authenticated.
+--
+-- A verified record's addresses are authoritative and replace the
+-- unsigned listenAddrs (go-libp2p's certified addr book takes signed
+-- addresses over unsigned ones). A record that fails verification is
+-- dropped, keeping the unsigned listenAddrs as the fallback for peers
+-- whose record we cannot trust.
+validateSignedPeerRecord :: PeerId -> IdentifyInfo -> IdentifyInfo
+validateSignedPeerRecord remotePeer info = case idSignedPeerRecord info of
+  Nothing -> info
+  Just envBytes -> case openPeerRecordEnvelope envBytes of
+    Right (env, record)
+      | fromPublicKey (sePublicKey env) == remotePeer ->
+          info { idListenAddrs = prAddresses record }
+    _ -> info { idSignedPeerRecord = Nothing }
+
 -- | Merge a received (possibly partial) Identify update into the
 -- previously known info for a peer.
 --
@@ -153,6 +185,7 @@ mergeIdentify known update = IdentifyInfo
   , idListenAddrs     = replaceUnlessEmpty (idListenAddrs known) (idListenAddrs update)
   , idObservedAddr    = idObservedAddr update <|> idObservedAddr known
   , idProtocols       = replaceUnlessEmpty (idProtocols known) (idProtocols update)
+  , idSignedPeerRecord = idSignedPeerRecord update <|> idSignedPeerRecord known
   }
   where
     replaceUnlessEmpty old [] = old
@@ -181,20 +214,34 @@ pushIdentify sw = do
           streamClose stream
         NoProtocol -> streamClose stream
 
--- | Build our local IdentifyInfo from Switch state.
+-- | Build our local IdentifyInfo from Switch state, including a signed
+-- peer record (RFC 0003) over our listen addresses, sealed with the
+-- identity key.
 buildLocalIdentify :: Switch -> Maybe Connection -> IO IdentifyInfo
 buildLocalIdentify sw mConn = do
   (protocols, listenAddrs) <- atomically $ do
     protos <- Map.keys <$> readTVar (swProtocols sw)
     listeners <- readTVar (swListeners sw)
     pure (protos, map alAddress listeners)
+  seqNo <- timestampSeq
+  let addrBytes = map (\(Multiaddr ps) -> encodeProtocols ps) listenAddrs
+      record = PeerRecord
+        { prPeerId    = peerIdBytes (swLocalPeerId sw)
+        , prSeq       = seqNo
+        , prAddresses = addrBytes
+        }
+      -- Sealing our own record with our own identity key cannot fail;
+      -- if it somehow does, the optional field is omitted.
+      signedRecord = either (const Nothing) (Just . encodeSignedEnvelope)
+                       (sealPeerRecord (swIdentityKey sw) record)
   pure IdentifyInfo
     { idProtocolVersion = Just "ipfs/0.1.0"
     , idAgentVersion    = Just "libp2p-hs/0.1.0"
     , idPublicKey       = Just (encodePublicKey (kpPublic (swIdentityKey sw)))
-    , idListenAddrs     = map (\(Multiaddr ps) -> encodeProtocols ps) listenAddrs
+    , idListenAddrs     = addrBytes
     , idObservedAddr    = (\(Multiaddr ps) -> encodeProtocols ps) . connRemoteAddr <$> mConn
     , idProtocols       = protocols
+    , idSignedPeerRecord = signedRecord
     }
 
 -- | Register Identify protocol handlers on the Switch.

--- a/src/LibP2P/Protocol/Identify/Message.hs
+++ b/src/LibP2P/Protocol/Identify/Message.hs
@@ -1,12 +1,15 @@
 -- | Identify protocol message encoding/decoding (protobuf).
 --
--- Wire format from specs/identify/README.md:
---   Field 1: publicKey       (bytes, optional)
---   Field 2: listenAddrs     (repeated bytes)
---   Field 3: protocols       (repeated string)
---   Field 4: observedAddr    (bytes, optional)
---   Field 5: protocolVersion (string, optional)
---   Field 6: agentVersion    (string, optional)
+-- Wire format from specs/identify/README.md (field 8 from go-libp2p
+-- p2p/protocol/identify/pb/identify.proto — the vendored spec copy of
+-- identify is r1 and predates it):
+--   Field 1: publicKey        (bytes, optional)
+--   Field 2: listenAddrs      (repeated bytes)
+--   Field 3: protocols        (repeated string)
+--   Field 4: observedAddr     (bytes, optional)
+--   Field 5: protocolVersion  (string, optional)
+--   Field 6: agentVersion     (string, optional)
+--   Field 8: signedPeerRecord (bytes, optional; RFC 0003 peer-record envelope)
 --
 -- Uses proto3-wire for protobuf encoding/decoding. On the wire the
 -- message is varint-length-delimited; the framing lives in
@@ -36,6 +39,7 @@ data IdentifyInfo = IdentifyInfo
   , idListenAddrs     :: ![ByteString]       -- ^ Binary-encoded multiaddrs
   , idObservedAddr    :: !(Maybe ByteString) -- ^ Binary-encoded observed multiaddr
   , idProtocols       :: ![Text]             -- ^ Supported protocol IDs
+  , idSignedPeerRecord :: !(Maybe ByteString) -- ^ Encoded RFC 0003 peer-record envelope
   } deriving (Show, Eq)
 
 -- | Maximum Identify message size: 64 KiB.
@@ -51,6 +55,7 @@ encodeIdentify info = BL.toStrict $ Encode.toLazyByteString $
   <> optBytes 4 (idObservedAddr info)
   <> optText 5 (idProtocolVersion info)
   <> optText 6 (idAgentVersion info)
+  <> optBytes 8 (idSignedPeerRecord info)
   where
     optBytes :: Word -> Maybe ByteString -> MessageBuilder
     optBytes _ Nothing  = mempty
@@ -78,3 +83,4 @@ identifyParser = IdentifyInfo
   <*> at (repeated Decode.byteString)              (FieldNumber 2)  -- listenAddrs
   <*> at (optional Decode.byteString)              (FieldNumber 4)  -- observedAddr
   <*> at (repeated (TL.toStrict <$> Decode.text))  (FieldNumber 3)  -- protocols
+  <*> at (optional Decode.byteString)              (FieldNumber 8)  -- signedPeerRecord

--- a/test/LibP2P/Crypto/PeerRecordSpec.hs
+++ b/test/LibP2P/Crypto/PeerRecordSpec.hs
@@ -1,0 +1,131 @@
+module LibP2P.Crypto.PeerRecordSpec (spec) where
+
+import Test.Hspec
+
+import Control.Monad (replicateM)
+import qualified Data.ByteString as BS
+import LibP2P.Crypto.Ed25519 (generateKeyPair)
+import LibP2P.Crypto.Key (KeyPair (..))
+import LibP2P.Crypto.PeerId (fromPublicKey, peerIdBytes)
+import LibP2P.Crypto.PeerRecord
+import LibP2P.Crypto.SignedEnvelope
+  ( SignedEnvelope (..)
+  , createEnvelope
+  , encodeSignedEnvelope
+  )
+
+-- | A fresh Ed25519 identity.
+newKeyPair :: IO KeyPair
+newKeyPair = either (error . ("keygen failed: " <>)) id <$> generateKeyPair
+
+-- | A PeerRecord owned by the given key pair.
+recordFor :: KeyPair -> [BS.ByteString] -> PeerRecord
+recordFor kp addrs = PeerRecord
+  { prPeerId    = peerIdBytes (fromPublicKey (kpPublic kp))
+  , prSeq       = 42
+  , prAddresses = addrs
+  }
+
+-- | /ip4/127.0.0.1/tcp/4001 in binary multiaddr form.
+addr4001 :: BS.ByteString
+addr4001 = BS.pack [0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x0f, 0xa1]
+
+spec :: Spec
+spec = do
+  describe "PeerRecord protobuf (RFC 0003)" $ do
+    it "encode → decode round-trip preserves all fields" $ do
+      kp <- newKeyPair
+      let record = recordFor kp [addr4001, BS.pack [0x04, 10, 0, 0, 1, 0x06, 0x1f, 0x90]]
+      decodePeerRecord (encodePeerRecord record) `shouldBe` Right record
+
+    it "encodes go-libp2p field numbers at the byte level" $ do
+      -- core/peer/pb/peer_record.proto: peer_id = 1 (bytes), seq = 2
+      -- (uint64), addresses = 3 (repeated AddressInfo{multiaddr = 1}).
+      let record = PeerRecord (BS.pack [0xAA]) 5 [addr4001]
+      encodePeerRecord record `shouldBe` BS.concat
+        [ BS.pack [0x0A, 0x01, 0xAA]  -- peer_id = 1, length-delimited
+        , BS.pack [0x10, 0x05]        -- seq = 2, varint
+        , BS.pack [0x1A, 0x0A, 0x0A, 0x08], addr4001  -- addresses = 3, nested AddressInfo
+        ]
+
+    it "decodes a record with no addresses" $ do
+      let record = PeerRecord (BS.pack [0x01, 0x02]) 7 []
+      decodePeerRecord (encodePeerRecord record) `shouldBe` Right record
+
+    it "rejects malformed bytes" $ do
+      decodePeerRecord (BS.pack [0xFF, 0xFF, 0xFF]) `shouldSatisfy` \r ->
+        case r of
+          Left _  -> True
+          Right _ -> False
+
+  describe "envelope constants (go-libp2p core/peer)" $ do
+    it "payload type is the libp2p-peer-record multicodec bytes 0x03 0x01" $
+      peerRecordEnvelopePayloadType `shouldBe` BS.pack [0x03, 0x01]
+
+    it "domain string is libp2p-peer-record" $
+      peerRecordEnvelopeDomain `shouldBe` "libp2p-peer-record"
+
+  describe "timestampSeq" $ do
+    it "is strictly monotonic across calls" $ do
+      seqs <- replicateM 5 timestampSeq
+      and (zipWith (<) seqs (drop 1 seqs)) `shouldBe` True
+
+  describe "sealPeerRecord / openPeerRecordEnvelope" $ do
+    it "seal → encode → open round-trip recovers the record" $ do
+      kp <- newKeyPair
+      let record = recordFor kp [addr4001]
+      case sealPeerRecord kp record of
+        Left err -> expectationFailure $ "sealPeerRecord failed: " ++ err
+        Right env -> do
+          sePayloadType env `shouldBe` peerRecordEnvelopePayloadType
+          case openPeerRecordEnvelope (encodeSignedEnvelope env) of
+            Left err -> expectationFailure $ "open failed: " ++ err
+            Right (env', record') -> do
+              record' `shouldBe` record
+              sePublicKey env' `shouldBe` kpPublic kp
+
+    it "rejects an envelope signed under a different domain" $ do
+      kp <- newKeyPair
+      let record = recordFor kp [addr4001]
+      case createEnvelope (kpPrivate kp) (kpPublic kp) "some-other-domain"
+             peerRecordEnvelopePayloadType (encodePeerRecord record) of
+        Left err -> expectationFailure $ "createEnvelope failed: " ++ err
+        Right env ->
+          openPeerRecordEnvelope (encodeSignedEnvelope env)
+            `shouldSatisfy` isLeft
+
+    it "rejects an envelope with a tampered payload" $ do
+      kp <- newKeyPair
+      let record = recordFor kp [addr4001]
+      case sealPeerRecord kp record of
+        Left err -> expectationFailure $ "sealPeerRecord failed: " ++ err
+        Right env -> do
+          let tamperedRecord = record { prSeq = 43 }
+              tampered = env { sePayload = encodePeerRecord tamperedRecord }
+          openPeerRecordEnvelope (encodeSignedEnvelope tampered)
+            `shouldSatisfy` isLeft
+
+    it "rejects an envelope with the wrong payload type" $ do
+      kp <- newKeyPair
+      let record = recordFor kp [addr4001]
+      case createEnvelope (kpPrivate kp) (kpPublic kp) peerRecordEnvelopeDomain
+             (BS.pack [0x03, 0x02]) (encodePeerRecord record) of
+        Left err -> expectationFailure $ "createEnvelope failed: " ++ err
+        Right env ->
+          openPeerRecordEnvelope (encodeSignedEnvelope env)
+            `shouldSatisfy` isLeft
+
+    it "rejects a record whose peer id is not derived from the signing key" $ do
+      kpSigner <- newKeyPair
+      kpOther  <- newKeyPair
+      -- Valid signature by kpSigner over a record claiming kpOther's id
+      let record = recordFor kpOther [addr4001]
+      case sealPeerRecord kpSigner record of
+        Left err -> expectationFailure $ "sealPeerRecord failed: " ++ err
+        Right env ->
+          openPeerRecordEnvelope (encodeSignedEnvelope env)
+            `shouldSatisfy` isLeft
+  where
+    isLeft :: Either a b -> Bool
+    isLeft (Left _)  = True
+    isLeft (Right _) = False

--- a/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/HandlerSpec.hs
@@ -18,7 +18,9 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (KeyPair (..), publicKey, sign)
-import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey, peerIdBytes)
+import LibP2P.Crypto.PeerRecord (PeerRecord (..), sealPeerRecord)
+import LibP2P.Crypto.SignedEnvelope (encodeSignedEnvelope)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.MultistreamSelect.Negotiation
   ( NegotiationResult (..)
@@ -44,6 +46,7 @@ import LibP2P.Protocol.GossipSub.Message
   ( readRPCMessage
   , writeRPCMessage
   )
+import LibP2P.Protocol.Identify.Message (IdentifyInfo (..))
 import LibP2P.Protocol.GossipSub.Router (addPeer)
 import LibP2P.Protocol.GossipSub.Validation (signingBytes)
 import LibP2P.Protocol.GossipSub.Types
@@ -148,6 +151,33 @@ spec = do
       -- Verify peer is registered in router
       peers <- atomically $ readTVar (gsPeers (gsnRouter node))
       Map.member remotePid peers `shouldBe` True
+
+    it "feeds the peer's identify signed peer record into the router (#230)" $ do
+      (sw, _localPid) <- mkTestSwitch
+      node <- newGossipSubNode sw testParams
+      (remotePid, remoteKp) <- mkTestIdentity
+      -- Identify already stored a signed peer record for this peer
+      Right env <- pure (sealPeerRecord remoteKp
+        (PeerRecord (peerIdBytes remotePid) 1 []))
+      let envBytes = encodeSignedEnvelope env
+          storedInfo = IdentifyInfo
+            { idProtocolVersion  = Nothing
+            , idAgentVersion     = Nothing
+            , idPublicKey        = Nothing
+            , idListenAddrs      = []
+            , idObservedAddr     = Nothing
+            , idProtocols        = []
+            , idSignedPeerRecord = Just envBytes
+            }
+      atomically $ do
+        store <- readTVar (swPeerStore sw)
+        writeTVar (swPeerStore sw) (Map.insert remotePid storedInfo store)
+      (remoteStream, handlerStream) <- mkMemoryStreamPair
+      _ <- async $ handleGossipSubStream node handlerStream remotePid GossipSubPeer Nothing
+      writeRPCMessage remoteStream (subscribeRPC "test-topic")
+      threadDelay 200000
+      recs <- atomically $ readTVar (gsSignedPeerRecords (gsnRouter node))
+      Map.lookup remotePid recs `shouldBe` Just envBytes
 
     it "processes publish RPCs and delivers to onMessage callback" $ do
       (sw, _localPid) <- mkTestSwitch

--- a/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
+++ b/test/LibP2P/Protocol/GossipSub/RouterSpec.hs
@@ -13,7 +13,9 @@ import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Control.Exception (try)
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (KeyPair (..), sign)
-import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey, peerIdBytes)
+import LibP2P.Crypto.PeerRecord (PeerRecord (..), sealPeerRecord)
+import LibP2P.Crypto.SignedEnvelope (encodeSignedEnvelope)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Protocol.GossipSub.Types
 import LibP2P.Protocol.GossipSub.Router
@@ -1568,3 +1570,84 @@ spec = do
         handleIHave router fsPeer [IHave "t" [BS.pack [1]]]
         sent <- readIORef logRef
         iwantsSent sent `shouldBe` []
+
+    describe "PX signed peer records (#230)" $ do
+      it "selectPXPeers attaches the stored signed peer record" $ do
+        (router, _) <- mkTestRouter localPid
+        kp <- newKeyPair
+        let pxPeer = fromPublicKey (kpPublic kp)
+        addSubscribedPeer router pxPeer "blocks"
+        Right env <- pure (sealPeerRecord kp
+          (PeerRecord (peerIdBytes pxPeer) 1
+            [BS.pack [0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x0f, 0xa1]]))
+        let envBytes = encodeSignedEnvelope env
+        setSignedPeerRecord router pxPeer envBytes
+        px <- selectPXPeers router "blocks" (mkPeerId 9)
+        map pxPeerId px `shouldBe` [peerIdBytes pxPeer]
+        map pxSignedPeerRecord px `shouldBe` [Just envBytes]
+
+      it "selectPXPeers omits the record for peers without a stored one" $ do
+        (router, _) <- mkTestRouter localPid
+        let pxPeer = mkPeerId 1
+        addSubscribedPeer router pxPeer "blocks"
+        px <- selectPXPeers router "blocks" (mkPeerId 9)
+        map pxSignedPeerRecord px `shouldBe` [Nothing]
+
+      it "removePeer forgets the stored signed peer record" $ do
+        (router, _) <- mkTestRouter localPid
+        let pxPeer = mkPeerId 1
+        addSubscribedPeer router pxPeer "blocks"
+        setSignedPeerRecord router pxPeer (BS.pack [1, 2, 3])
+        removePeer router pxPeer
+        recs <- readTVarIO (gsSignedPeerRecords router)
+        Map.member pxPeer recs `shouldBe` False
+
+      it "handlePrune drops PX entries whose signed record fails verification" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            routerPx = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const 200 }  -- >= stAcceptPXThreshold (100)
+              }
+        addPeer routerPx sender GossipSubPeer False fixedTime
+        receivedRef <- newIORef ([] :: [(Topic, [PeerExchangeInfo])])
+        atomically $ writeTVar (gsOnPeerExchange routerPx) $ \t px ->
+          modifyIORef' receivedRef (++ [(t, px)])
+        kpGood <- newKeyPair
+        kpEvil <- newKeyPair
+        let goodPid = fromPublicKey (kpPublic kpGood)
+            evilPid = fromPublicKey (kpPublic kpEvil)
+        Right goodEnv <- pure (sealPeerRecord kpGood
+          (PeerRecord (peerIdBytes goodPid) 1 []))
+        -- Forged: signed by kpEvil over a record claiming goodPid's identity
+        Right forgedEnv <- pure (sealPeerRecord kpEvil
+          (PeerRecord (peerIdBytes goodPid) 1 []))
+        let validEntry    = PeerExchangeInfo (peerIdBytes goodPid)
+                              (Just (encodeSignedEnvelope goodEnv))
+            forgedEntry   = PeerExchangeInfo (peerIdBytes evilPid)
+                              (Just (encodeSignedEnvelope forgedEnv))
+            -- Valid envelope attached to an entry claiming a different peer
+            mismatchEntry = PeerExchangeInfo (BS.pack [9])
+                              (Just (encodeSignedEnvelope goodEnv))
+            garbageEntry  = PeerExchangeInfo (BS.pack [8])
+                              (Just (BS.pack [0x01, 0x02, 0x03]))
+            unsignedEntry = PeerExchangeInfo (BS.pack [7]) Nothing
+        handlePrune routerPx sender
+          [Prune "t" [validEntry, forgedEntry, mismatchEntry, garbageEntry, unsignedEntry]
+                 (Just 60)]
+        readIORef receivedRef `shouldReturn` [("t", [validEntry, unsignedEntry])]
+
+      it "handlePrune passes nothing to the PX callback when every record is forged" $ do
+        (router, _) <- mkTestRouter localPid
+        let sender = mkPeerId 1
+            routerPx = router
+              { gsScoreParams = defaultPeerScoreParams
+                  { pspAppSpecificScore = const 200 }
+              }
+        addPeer routerPx sender GossipSubPeer False fixedTime
+        receivedRef <- newIORef ([] :: [(Topic, [PeerExchangeInfo])])
+        atomically $ writeTVar (gsOnPeerExchange routerPx) $ \t px ->
+          modifyIORef' receivedRef (++ [(t, px)])
+        handlePrune routerPx sender
+          [Prune "t" [PeerExchangeInfo (BS.pack [9]) (Just (BS.pack [0xFF]))] (Just 60)]
+        readIORef receivedRef `shouldReturn` []

--- a/test/LibP2P/Protocol/Identify/IdentifySpec.hs
+++ b/test/LibP2P/Protocol/Identify/IdentifySpec.hs
@@ -22,7 +22,13 @@ import Data.List (sort)
 import qualified Data.Map.Strict as Map
 import LibP2P.Crypto.Ed25519 (generateKeyPair)
 import LibP2P.Crypto.Key (kpPublic)
-import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey)
+import LibP2P.Crypto.PeerId (PeerId (..), fromPublicKey, peerIdBytes)
+import LibP2P.Crypto.PeerRecord
+  ( PeerRecord (..)
+  , openPeerRecordEnvelope
+  , sealPeerRecord
+  )
+import LibP2P.Crypto.SignedEnvelope (encodeSignedEnvelope)
 import LibP2P.Crypto.Protobuf (encodePublicKey)
 import LibP2P.Core.Varint (decodeUvarint, encodeUvarint)
 import LibP2P.Multiaddr (Multiaddr (..))
@@ -123,6 +129,7 @@ emptyInfo = IdentifyInfo
   , idListenAddrs     = []
   , idObservedAddr    = Nothing
   , idProtocols       = []
+  , idSignedPeerRecord = Nothing
   }
 
 -- | Build an outbound Connection whose muxer hands out the given
@@ -287,6 +294,7 @@ spec = do
             , idListenAddrs     = []
             , idObservedAddr    = Nothing
             , idProtocols       = ["/test/proto"]
+            , idSignedPeerRecord = Nothing
             }
       -- Write varint-length-prefixed message then signal EOF
       let encoded = encodeIdentify testInfo
@@ -317,6 +325,7 @@ spec = do
             , idListenAddrs     = [encodeProtocols [IP4 0x7f000001, TCP 4001]]
             , idObservedAddr    = Nothing
             , idProtocols       = ["/ipfs/id/1.0.0", "/ipfs/ping/1.0.0"]
+            , idSignedPeerRecord = Nothing
             }
       atomically $ do
         store <- readTVar (swPeerStore sw)
@@ -330,6 +339,7 @@ spec = do
             , idListenAddrs     = newAddrs
             , idObservedAddr    = Nothing
             , idProtocols       = []
+            , idSignedPeerRecord = Nothing
             }
       (streamA, streamB) <- mkClosableStreamPair
       streamWrite streamA (frame (encodeIdentify partialPush))
@@ -501,6 +511,7 @@ spec = do
             , idListenAddrs     = [encodeProtocols [IP4 0x7f000001, TCP 4001]]
             , idObservedAddr    = Nothing
             , idProtocols       = ["/old/1.0.0", "/old/2.0.0"]
+            , idSignedPeerRecord = Nothing
             }
           update = IdentifyInfo
             { idProtocolVersion = Just "ipfs/0.2.0"
@@ -509,6 +520,7 @@ spec = do
             , idListenAddrs     = [encodeProtocols [IP4 0x7f000001, TCP 9999]]
             , idObservedAddr    = Just (encodeProtocols [IP4 0x7f000001, TCP 5555])
             , idProtocols       = ["/new/1.0.0"]
+            , idSignedPeerRecord = Nothing
             }
       -- Every field of the result comes from the update; in particular
       -- idProtocols is exactly the update's one-element list, not a
@@ -523,6 +535,7 @@ spec = do
             , idListenAddrs     = [encodeProtocols [IP4 0x7f000001, TCP 4001]]
             , idObservedAddr    = Just (encodeProtocols [IP4 0x7f000001, TCP 5555])
             , idProtocols       = ["/ipfs/id/1.0.0"]
+            , idSignedPeerRecord = Nothing
             }
       mergeIdentify known emptyInfo `shouldBe` known
 
@@ -539,6 +552,7 @@ spec = do
             , idListenAddrs     = [encodeProtocols [IP4 0x7f000001, TCP 4001]]
             , idObservedAddr    = Nothing
             , idProtocols       = ["/ipfs/id/1.0.0", "/ipfs/ping/1.0.0"]
+            , idSignedPeerRecord = Nothing
             }
       atomically $ do
         store <- readTVar (swPeerStore sw)
@@ -560,6 +574,7 @@ spec = do
             , idListenAddrs     = []
             , idObservedAddr    = Nothing
             , idProtocols       = ["/framed/1.0.0"]
+            , idSignedPeerRecord = Nothing
             }
       streamWrite streamA (frame (encodeIdentify testInfo))
       result <- readFramedIdentify streamB maxIdentifySize
@@ -574,6 +589,7 @@ spec = do
             , idListenAddrs     = [BS.pack [4, 7, 0, 0, 0, 1]]
             , idObservedAddr    = Nothing
             , idProtocols       = ["/a/1.0.0", "/b/1.0.0"]
+            , idSignedPeerRecord = Nothing
             }
       streamWrite streamA (encodeFramedIdentify testInfo)
       result <- readFramedIdentify streamB maxIdentifySize
@@ -722,3 +738,107 @@ spec = do
       protos <- atomically $ readTVar (swProtocols sw)
       Map.member identifyProtocolId protos `shouldBe` True
       Map.member identifyPushProtocolId protos `shouldBe` True
+
+  describe "Identify signedPeerRecord (RFC 0003, #230)" $ do
+    it "buildLocalIdentify seals a verifiable peer record over our listen addrs" $ do
+      sw <- mkTestSwitch
+      info <- buildLocalIdentify sw Nothing
+      case idSignedPeerRecord info of
+        Nothing -> expectationFailure "expected a signedPeerRecord in local identify"
+        Just envBytes -> case openPeerRecordEnvelope envBytes of
+          Left err -> expectationFailure $ "record failed to verify: " ++ err
+          Right (_, record) -> do
+            prPeerId record `shouldBe` peerIdBytes (swLocalPeerId sw)
+            prAddresses record `shouldBe` idListenAddrs info
+
+    it "handleIdentifyPush prefers verified signed-record addresses over listenAddrs" $ do
+      sw <- mkTestSwitch
+      Right remoteKp <- generateKeyPair
+      let remotePid = fromPublicKey (kpPublic remoteKp)
+          signedAddr   = encodeProtocols [IP4 0x7f000001, TCP 4001]
+          unsignedAddr = encodeProtocols [IP4 0x7f000001, TCP 9999]
+          record = PeerRecord
+            { prPeerId    = peerIdBytes remotePid
+            , prSeq       = 1
+            , prAddresses = [signedAddr]
+            }
+      Right env <- pure (sealPeerRecord remoteKp record)
+      let pushInfo = emptyInfo
+            { idListenAddrs      = [unsignedAddr]
+            , idSignedPeerRecord = Just (encodeSignedEnvelope env)
+            }
+      (streamA, streamB) <- mkClosableStreamPair
+      streamWrite streamA (frame (encodeIdentify pushInfo))
+      streamClose streamA
+      conn <- mkTestConnection remotePid (Multiaddr [IP4 0x7f000001, TCP 4001])
+      handleIdentifyPush sw conn streamB
+      store <- atomically $ readTVar (swPeerStore sw)
+      case Map.lookup remotePid store of
+        Nothing -> expectationFailure "Expected peer in store"
+        Just stored -> do
+          idListenAddrs stored `shouldBe` [signedAddr]
+          idSignedPeerRecord stored `shouldBe` Just (encodeSignedEnvelope env)
+
+    it "handleIdentifyPush drops a record not signed by the authenticated peer" $ do
+      -- A valid envelope signed by some other identity is a forged
+      -- routing record for this connection: the envelope key must match
+      -- the peer id authenticated by the security handshake.
+      sw <- mkTestSwitch
+      Right remoteKp   <- generateKeyPair
+      Right attackerKp <- generateKeyPair
+      let remotePid   = fromPublicKey (kpPublic remoteKp)
+          attackerPid = fromPublicKey (kpPublic attackerKp)
+          unsignedAddr = encodeProtocols [IP4 0x7f000001, TCP 9999]
+          forgedRecord = PeerRecord
+            { prPeerId    = peerIdBytes attackerPid
+            , prSeq       = 1
+            , prAddresses = [encodeProtocols [IP4 0x0a000001, TCP 4001]]
+            }
+      Right env <- pure (sealPeerRecord attackerKp forgedRecord)
+      let pushInfo = emptyInfo
+            { idListenAddrs      = [unsignedAddr]
+            , idSignedPeerRecord = Just (encodeSignedEnvelope env)
+            }
+      (streamA, streamB) <- mkClosableStreamPair
+      streamWrite streamA (frame (encodeIdentify pushInfo))
+      streamClose streamA
+      conn <- mkTestConnection remotePid (Multiaddr [IP4 0x7f000001, TCP 4001])
+      handleIdentifyPush sw conn streamB
+      store <- atomically $ readTVar (swPeerStore sw)
+      case Map.lookup remotePid store of
+        Nothing -> expectationFailure "Expected peer in store"
+        Just stored -> do
+          -- Unsigned fallback addresses are kept, forged record dropped
+          idListenAddrs stored `shouldBe` [unsignedAddr]
+          idSignedPeerRecord stored `shouldBe` Nothing
+
+    it "requestIdentify prefers verified signed-record addresses in the response" $ do
+      Right remoteKp <- generateKeyPair
+      let remotePid = fromPublicKey (kpPublic remoteKp)
+          signedAddr   = encodeProtocols [IP4 0x7f000001, TCP 4001]
+          unsignedAddr = encodeProtocols [IP4 0x7f000001, TCP 9999]
+          record = PeerRecord
+            { prPeerId    = peerIdBytes remotePid
+            , prSeq       = 1
+            , prAddresses = [signedAddr]
+            }
+      Right env <- pure (sealPeerRecord remoteKp record)
+      let responseInfo = emptyInfo
+            { idListenAddrs      = [unsignedAddr]
+            , idSignedPeerRecord = Just (encodeSignedEnvelope env)
+            }
+      (streamA, streamB) <- mkClosableStreamPair
+      conn <- mkPushConnection remotePid (Multiaddr [IP4 0x7f000001, TCP 4001])
+                (pure streamA)
+      remote <- async $ do
+        negResult <- negotiateResponder streamB [identifyProtocolId]
+        negResult `shouldBe` Accepted identifyProtocolId
+        streamWrite streamB (encodeFramedIdentify responseInfo)
+        streamClose streamB
+      result <- requestIdentify conn
+      wait remote
+      case result of
+        Left err -> expectationFailure $ "requestIdentify failed: " ++ err
+        Right info -> do
+          idListenAddrs info `shouldBe` [signedAddr]
+          idSignedPeerRecord info `shouldBe` Just (encodeSignedEnvelope env)

--- a/test/LibP2P/Protocol/Identify/MessageSpec.hs
+++ b/test/LibP2P/Protocol/Identify/MessageSpec.hs
@@ -14,6 +14,7 @@ fullInfo = IdentifyInfo
                           BS.pack [4, 10, 0, 0, 1, 6, 0x0F, 0xA1]]
   , idObservedAddr    = Just (BS.pack [4, 192, 168, 1, 1, 6, 0x1F, 0x90])
   , idProtocols       = ["/ipfs/id/1.0.0", "/ipfs/ping/1.0.0", "/noise"]
+  , idSignedPeerRecord = Just (BS.pack [0x0A, 0x02, 0x08, 0x01])
   }
 
 spec :: Spec
@@ -37,12 +38,13 @@ spec = do
         , idListenAddrs     = []
         , idObservedAddr    = Nothing
         , idProtocols       = []
+        , idSignedPeerRecord = Nothing
         }
 
     it "decode handles repeated listenAddrs correctly" $ do
       let info = IdentifyInfo Nothing Nothing Nothing
                    [BS.pack [1, 2], BS.pack [3, 4], BS.pack [5, 6]]
-                   Nothing []
+                   Nothing [] Nothing
           encoded = encodeIdentify info
           decoded = decodeIdentify encoded
       case decoded of
@@ -51,7 +53,7 @@ spec = do
 
     it "decode handles repeated protocols correctly" $ do
       let info = IdentifyInfo Nothing Nothing Nothing [] Nothing
-                   ["/noise", "/yamux/1.0.0", "/ipfs/id/1.0.0"]
+                   ["/noise", "/yamux/1.0.0", "/ipfs/id/1.0.0"] Nothing
           encoded = encodeIdentify info
           decoded = decodeIdentify encoded
       case decoded of
@@ -63,7 +65,7 @@ spec = do
       -- protocols = 3, observedAddr = 4, protocolVersion = 5,
       -- agentVersion = 6 — all length-delimited (wire type 2), so the
       -- first tag byte of a single-field message is (field << 3) | 2.
-      let empty = IdentifyInfo Nothing Nothing Nothing [] Nothing []
+      let empty = IdentifyInfo Nothing Nothing Nothing [] Nothing [] Nothing
           firstByte info = BS.head (encodeIdentify info)
       firstByte empty { idPublicKey = Just (BS.pack [1]) }   `shouldBe` 0x0a
       firstByte empty { idListenAddrs = [BS.pack [1]] }      `shouldBe` 0x12
@@ -71,6 +73,8 @@ spec = do
       firstByte empty { idObservedAddr = Just (BS.pack [1]) } `shouldBe` 0x22
       firstByte empty { idProtocolVersion = Just "v" }       `shouldBe` 0x2a
       firstByte empty { idAgentVersion = Just "v" }          `shouldBe` 0x32
+      -- signedPeerRecord = 8 (identify.proto, go-libp2p): tag (8 << 3) | 2
+      firstByte empty { idSignedPeerRecord = Just (BS.pack [1]) } `shouldBe` 0x42
 
     it "decodes a go-libp2p-shaped message (hand-written golden vector)" $ do
       -- Hand-constructed per the spec protobuf, deliberately NOT produced
@@ -99,7 +103,7 @@ spec = do
 
     it "decode skips unknown fields" $ do
       -- Encode known fields, then append unknown field bytes
-      let info = IdentifyInfo (Just "ipfs/0.1.0") Nothing Nothing [] Nothing []
+      let info = IdentifyInfo (Just "ipfs/0.1.0") Nothing Nothing [] Nothing [] Nothing
           encoded = encodeIdentify info
           -- Append unknown field 99 (wire type 0 = varint, tag = 99<<3|0 = 0x318)
           -- This is a varint-encoded tag + value: field 99, varint 42
@@ -110,7 +114,24 @@ spec = do
         Left err -> expectationFailure $ "Decode failed with unknown field: " ++ show err
 
     it "encode omits Nothing fields" $ do
-      let info = IdentifyInfo Nothing Nothing Nothing [] Nothing []
+      let info = IdentifyInfo Nothing Nothing Nothing [] Nothing [] Nothing
           encoded = encodeIdentify info
       -- Empty message should encode to empty bytes (no fields set)
       encoded `shouldBe` BS.empty
+
+    it "round-trips signedPeerRecord at the byte level (field 8)" $ do
+      -- Single-field message: tag 0x42 = (8 << 3) | 2, then length, then bytes
+      let recBytes = BS.pack [0xDE, 0xAD, 0xBE, 0xEF]
+          info = IdentifyInfo Nothing Nothing Nothing [] Nothing [] (Just recBytes)
+          encoded = encodeIdentify info
+      encoded `shouldBe` BS.pack [0x42, 0x04, 0xDE, 0xAD, 0xBE, 0xEF]
+      case decodeIdentify encoded of
+        Right result -> idSignedPeerRecord result `shouldBe` Just recBytes
+        Left err -> expectationFailure $ "Decode failed: " ++ show err
+
+    it "decodes a message without signedPeerRecord to Nothing" $ do
+      let info = IdentifyInfo Nothing Nothing Nothing [addr] Nothing [] Nothing
+          addr = BS.pack [1, 2]
+      case decodeIdentify (encodeIdentify info) of
+        Right result -> idSignedPeerRecord result `shouldBe` Nothing
+        Left err -> expectationFailure $ "Decode failed: " ++ show err

--- a/test/LibP2P/WireConformanceSpec.hs
+++ b/test/LibP2P/WireConformanceSpec.hs
@@ -169,6 +169,7 @@ spec = do
                 Just (BS.pack [0x04, 0x7f, 0x00, 0x00, 0x01, 0x06, 0x30, 0x39])
                 -- /ip4/127.0.0.1/tcp/12345
             , idProtocols       = ["/ipfs/id/1.0.0", "/ipfs/ping/1.0.0"]
+            , idSignedPeerRecord = Nothing
             }
           expected = BS.concat
             [ BS.singleton 0x57  -- varint frame length: 87-byte protobuf


### PR DESCRIPTION
## Summary

Implements the remaining RFC 0003 surface from #230: a `PeerRecord` type sealed in RFC 0002 signed envelopes, distributed via identify (field 8) and verified in gossipsub peer exchange.

### `LibP2P.Crypto.PeerRecord` (new)

- Protobuf codec matching go-libp2p `core/peer/pb/peer_record.proto`: `peer_id = 1` (bytes), `seq = 2` (uint64), `addresses = 3` (repeated `AddressInfo { multiaddr = 1 }`); proto3 defaults omitted on encode.
- `timestampSeq`: Unix-time-in-nanoseconds sequence number, strictly monotonic across calls (mirrors go-libp2p `peer.TimestampSeq`).
- `sealPeerRecord` / `openPeerRecordEnvelope` over the existing `SignedEnvelope`: open checks payload type, signature under the peer-record domain, record decode, and that the envelope key derives the record's peer id.

### identify

- `signedPeerRecord` (field 8, bytes) added to the Identify codec (byte-level tag test: `0x42`).
- `buildLocalIdentify` seals a record over our listen addresses with the identity key, so responses and pushes both carry it.
- On receive (`requestIdentify` and `handleIdentifyPush`), the envelope must open **and** its key must derive the connection's authenticated peer id. Verified record addresses replace the unsigned `listenAddrs`; a record that fails verification is dropped and the unsigned addresses are kept as fallback. `mergeIdentify` carries the field across partial pushes.

### gossipsub PX

- Router gains `gsSignedPeerRecords` + `setSignedPeerRecord` (cleared by `removePeer`); the Switch handler feeds it from the identify peer store when registering a peer.
- `selectPXPeers` attaches the stored record to PX entries in PRUNE-with-PX.
- `handlePrune` verifies any attached record before the peer-exchange callback: entries whose record fails to open or names a different peer than `pxPeerId` are dropped (matching go-libp2p `pxConnect`); unsigned entries keep the current behaviour.

## Notes

- **Envelope constants**: the issue text said domain `libp2p-routing-record`, but deployed go-libp2p (`core/peer/record.go`) uses domain **`libp2p-peer-record`** with payload type `0x03 0x01` (raw multicodec bytes); the RFC 0003 draft text differs again (`libp2p-routing-state`). go-libp2p is the interop authority, so its values are used and documented in the module header.
- **Vendored specs**: the repo does not vendor a `specs/` copy (no such directory or submodule), so there is no vendored identify spec to refresh; the field-8 provenance is documented in `LibP2P.Protocol.Identify.Message` instead.

## Testing

TDD (failing tests first): PeerRecord protobuf round-trip + byte-level field-number vector; envelope constants; monotonic seq; seal/open round-trip with rejection of wrong domain, tampered payload, wrong payload type, and key/peer-id mismatch; identify field-8 byte-level round-trip; identify receive-verify-store (prefer signed addresses, drop forged record, keep unsigned fallback) on both the request and push paths; PX emission carries the stored record and PX reception drops forged/mismatched/garbage records while keeping valid and unsigned entries; handler feeds identify records into the router.

`cabal build all` and `cabal test` (GHC 9.10.3): **1125 examples, 0 failures**.

Closes #230