### PR TITLE
docs: add motivation and upstream collaboration sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 A Haskell implementation of the [libp2p](https://libp2p.io/) modular peer-to-peer networking stack.
 
+## Motivation
+
+Implementation diversity is a core resilience property of decentralized networks:
+a bug in one client must not be able to take down the whole network. Yet in the
+Ethereum ecosystem — whose consensus layer is built on libp2p — there are
+virtually no client implementations written in a pure functional language.
+libp2p-hs exists to widen that diversity: a complete, spec-conformant libp2p
+stack in Haskell, with the type-level guarantees and STM-based concurrency that
+purely functional programming brings to protocol implementation.
+
+## Upstream Collaboration
+
+The project is part of the [libp2p/unified-testing](https://github.com/libp2p/unified-testing)
+cross-implementation interop effort, joined at the invitation of a libp2p
+maintainer. The codebase receives code review from libp2p maintainers, and
+official integration into the unified testing suite is planned within 2027.
+Local interop evidence (hs ↔ go over tcp+noise+yamux) lives in `interop/RESULTS.md`.
+
 ## Quickstart
 
 ```haskell

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ cabal test --test-option="--match=Integration"
 
 **[API Reference](https://adust09.github.io/libp2p-hs/)** — Generated Haddock documentation.
 
-Interop test evidence lives in `interop/RESULTS.md`.
-
 ## Specification
 
 Based on the [libp2p specification](https://github.com/libp2p/specs).


### PR DESCRIPTION
## Summary

- Add a **Motivation** section: implementation diversity as a resilience property of decentralized networks, noting that the Ethereum ecosystem (whose consensus layer is built on libp2p) has virtually no client implementations in a pure functional language — libp2p-hs widens that diversity.
- Add an **Upstream Collaboration** section: participation in [libp2p/unified-testing](https://github.com/libp2p/unified-testing) at a maintainer's invitation, ongoing code review from libp2p maintainers, and planned official integration into the unified testing suite within 2027.
- Link local interop evidence (`interop/RESULTS.md`) from the new section.