### PR TITLE
feat: migrate interop test app to unified-testing modern contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ cabal.project.local~
 .playwright-mcp/
 cabal.project.freeze
 go-libp2p/
+interop/rust-peer/target/

--- a/docker-compose.cross.yml
+++ b/docker-compose.cross.yml
@@ -3,6 +3,15 @@
 # Prerequisites:
 #   git clone --depth 1 --branch v0.48.0 https://github.com/libp2p/go-libp2p.git go-libp2p
 #
+# libp2p-hs speaks the unified-testing "modern" contract (uppercase env vars,
+# TEST_KEY-namespaced `<TEST_KEY>_listener_multiaddr` string key). The pinned
+# go-libp2p test app is a "legacy" test-plans app (lowercase env vars,
+# `listenerAddr` list). The shim-* services translate between the two key
+# schemes, mirroring the Redis proxy unified-testing runs for legacy images.
+# Each dialer pulls its shim in via depends_on, and a shim idles after
+# translating so it never triggers --exit-code-from's abort-on-exit before
+# the dialer finishes; the dialer's own timeout bounds the run.
+#
 # Test 1: go-libp2p listener, libp2p-hs dialer
 #   docker compose -f docker-compose.cross.yml up --build --exit-code-from hs-dialer redis go-listener hs-dialer
 #
@@ -11,10 +20,27 @@
 #
 # --exit-code-from <dialer> makes `up` return the dialer's exit code (0 on success),
 # so failures are not masked when another container exits 0 first.
+x-test-key: &test-key "cafe0129"
+
+x-hs-env: &hs-env
+  REDIS_ADDR: "redis:6379"
+  TEST_KEY: *test-key
+  TRANSPORT: tcp
+  SECURE_CHANNEL: noise
+  MUXER: yamux
+  LISTENER_IP: "0.0.0.0"
+
+x-go-env: &go-env
+  transport: tcp
+  security: noise
+  muxer: yamux
+  redis_addr: "redis:6379"
+  test_timeout_seconds: "180"
+
 services:
   redis:
     image: redis:7-alpine
-    # Disable persistence so a stale listenerAddr never survives across runs.
+    # Disable persistence so a stale listener address never survives across runs.
     command: ["redis-server", "--save", "", "--appendonly", "no"]
     ports:
       - "6379"
@@ -24,7 +50,7 @@ services:
       timeout: 3s
       retries: 30
 
-  # --- Test 1: go listener, hs dialer ---
+  # --- Test 1: go listener (legacy), hs dialer (modern) ---
   go-listener:
     build:
       context: ./go-libp2p
@@ -33,12 +59,25 @@ services:
       redis:
         condition: service_healthy
     environment:
-      transport: tcp
-      security: noise
-      muxer: yamux
+      <<: *go-env
       is_dialer: "false"
-      redis_addr: "redis:6379"
-      test_timeout_seconds: "180"
+
+  # Legacy -> modern: BLPOP the go listener's address off the legacy
+  # `listenerAddr` list and SET it under the modern namespaced key.
+  shim-go-to-hs:
+    image: redis:7-alpine
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      TEST_KEY: *test-key
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        ADDR=$$(redis-cli -h redis blpop listenerAddr 0 | tail -1)
+        if [ -z "$$ADDR" ]; then echo "shim: no listener address" >&2; exit 1; fi
+        redis-cli -h redis set "$${TEST_KEY}_listener_multiaddr" "$$ADDR"
+        exec tail -f /dev/null
 
   hs-dialer:
     build: .
@@ -48,15 +87,13 @@ services:
         condition: service_healthy
       go-listener:
         condition: service_started
+      shim-go-to-hs:
+        condition: service_started
     environment:
-      transport: tcp
-      security: noise
-      muxer: yamux
-      is_dialer: "true"
-      redis_addr: "redis:6379"
-      test_timeout_seconds: "180"
+      <<: *hs-env
+      IS_DIALER: "true"
 
-  # --- Test 2: hs listener, go dialer ---
+  # --- Test 2: hs listener (modern), go dialer (legacy) ---
   hs-listener:
     build: .
     image: libp2p-hs-interop:latest
@@ -64,12 +101,24 @@ services:
       redis:
         condition: service_healthy
     environment:
-      transport: tcp
-      security: noise
-      muxer: yamux
-      is_dialer: "false"
-      redis_addr: "redis:6379"
-      test_timeout_seconds: "180"
+      <<: *hs-env
+      IS_DIALER: "false"
+
+  # Modern -> legacy: poll the modern namespaced key and RPUSH it onto the
+  # legacy `listenerAddr` list for the go dialer's BLPOP.
+  shim-hs-to-go:
+    image: redis:7-alpine
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      TEST_KEY: *test-key
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        until ADDR=$$(redis-cli -h redis get "$${TEST_KEY}_listener_multiaddr"); [ -n "$$ADDR" ]; do sleep 0.2; done
+        redis-cli -h redis rpush listenerAddr "$$ADDR"
+        exec tail -f /dev/null
 
   go-dialer:
     build:
@@ -80,10 +129,8 @@ services:
         condition: service_healthy
       hs-listener:
         condition: service_started
+      shim-hs-to-go:
+        condition: service_started
     environment:
-      transport: tcp
-      security: noise
-      muxer: yamux
+      <<: *go-env
       is_dialer: "true"
-      redis_addr: "redis:6379"
-      test_timeout_seconds: "180"

--- a/docker-compose.gossipsub.yml
+++ b/docker-compose.gossipsub.yml
@@ -1,60 +1,79 @@
 # GossipSub cross-implementation interop test: libp2p-hs <-> rust-libp2p.
+# Both peers use the unified-testing "modern" env var and Redis key scheme
+# (the gossipsub mode itself is a local extension, not an upstream contract).
 #
 # Test 1 (Rust listener, HS dialer):
-#   docker compose -f docker-compose.gossipsub.yml up --build rust-listener hs-dialer redis --abort-on-container-exit
+#   docker compose -f docker-compose.gossipsub.yml up --build --exit-code-from hs-dialer redis rust-listener hs-dialer
 #
 # Test 2 (HS listener, Rust dialer):
-#   docker compose -f docker-compose.gossipsub.yml up --build hs-listener rust-dialer redis --abort-on-container-exit
+#   docker compose -f docker-compose.gossipsub.yml up --build --exit-code-from rust-dialer redis hs-listener rust-dialer
+x-test-key: &test-key "90551b29"
+
+x-hs-env: &hs-env
+  REDIS_ADDR: "redis:6379"
+  TEST_KEY: *test-key
+  TRANSPORT: tcp
+  SECURE_CHANNEL: noise
+  MUXER: yamux
+  LISTENER_IP: "0.0.0.0"
+  TEST_MODE: gossipsub
+
+x-rust-env: &rust-env
+  REDIS_ADDR: "redis:6379"
+  TEST_KEY: *test-key
+
 services:
   redis:
     image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
     ports:
       - "6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
 
   # --- Test 1: Rust listener, HS dialer ---
   rust-listener:
     build:
       context: ./interop/rust-peer
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     environment:
-      is_dialer: "false"
-      redis_addr: "redis:6379"
+      <<: *rust-env
+      IS_DIALER: "false"
 
   hs-dialer:
     build: .
     depends_on:
-      - redis
-      - rust-listener
+      redis:
+        condition: service_healthy
+      rust-listener:
+        condition: service_started
     environment:
-      transport: tcp
-      security: noise
-      muxer: yamux
-      is_dialer: "true"
-      redis_addr: "redis:6379"
-      test_timeout_seconds: "180"
-      test_mode: gossipsub
+      <<: *hs-env
+      IS_DIALER: "true"
 
   # --- Test 2: HS listener, Rust dialer ---
   hs-listener:
     build: .
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     environment:
-      transport: tcp
-      security: noise
-      muxer: yamux
-      is_dialer: "false"
-      redis_addr: "redis:6379"
-      test_timeout_seconds: "180"
-      test_mode: gossipsub
+      <<: *hs-env
+      IS_DIALER: "false"
 
   rust-dialer:
     build:
       context: ./interop/rust-peer
     depends_on:
-      - redis
-      - hs-listener
+      redis:
+        condition: service_healthy
+      hs-listener:
+        condition: service_started
     environment:
-      is_dialer: "true"
-      redis_addr: "redis:6379"
+      <<: *rust-env
+      IS_DIALER: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,43 @@
 # Self-to-self interop test: libp2p-hs listener + libp2p-hs dialer.
-# Usage: docker compose up --build --abort-on-container-exit
+# Both peers speak the unified-testing "modern" transport contract.
+# Usage: docker compose up --build --exit-code-from dialer
+x-hs-env: &hs-env
+  REDIS_ADDR: "redis:6379"
+  TEST_KEY: "cafe0129"
+  TRANSPORT: tcp
+  SECURE_CHANNEL: noise
+  MUXER: yamux
+  LISTENER_IP: "0.0.0.0"
+
 services:
   redis:
     image: redis:7-alpine
+    # Disable persistence so a stale listener address never survives across runs.
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
     ports:
       - "6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
 
   listener:
     build: .
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     environment:
-      transport: tcp
-      security: noise
-      muxer: yamux
-      is_dialer: "false"
-      redis_addr: "redis:6379"
-      test_timeout_seconds: "180"
+      <<: *hs-env
+      IS_DIALER: "false"
 
   dialer:
     build: .
     depends_on:
-      - redis
-      - listener
+      redis:
+        condition: service_healthy
+      listener:
+        condition: service_started
     environment:
-      transport: tcp
-      security: noise
-      muxer: yamux
-      is_dialer: "true"
-      redis_addr: "redis:6379"
-      test_timeout_seconds: "180"
+      <<: *hs-env
+      IS_DIALER: "true"

--- a/interop/Main.hs
+++ b/interop/Main.hs
@@ -1,21 +1,28 @@
--- | Interop test daemon for libp2p test-plans framework.
+-- | Interop test daemon for the libp2p/unified-testing framework.
 --
--- Reads configuration from environment variables, acts as either
--- a listener or dialer, coordinating via Redis.
+-- Implements the "modern" transport test-app contract
+-- (unified-testing docs/write-a-transport-test-app.md): reads uppercase
+-- environment variables, coordinates listener discovery through a shared
+-- Redis instance namespaced by TEST_KEY, and reports dialer measurements
+-- as YAML on stdout. All logging goes to stderr.
 --
--- Environment variables:
---   transport          - must be "tcp"
---   security           - must be "noise"
---   muxer              - must be "yamux"
---   is_dialer          - "true" or "false"
---   ip                 - bind address (default: "0.0.0.0")
---   redis_addr         - Redis host:port (default: "redis:6379")
---   test_timeout_seconds - timeout in seconds (default: "180")
---   test_mode          - "ping" (default) or "gossipsub"
+-- Environment variables (transport contract):
+--   IS_DIALER      - "true" or "false"
+--   REDIS_ADDR     - Redis host:port (default: "redis:6379")
+--   TEST_KEY       - hex key namespacing Redis coordination keys
+--   TRANSPORT      - must be "tcp"
+--   SECURE_CHANNEL - must be "noise"
+--   MUXER          - must be "yamux"
+--   LISTENER_IP    - bind address (default: "0.0.0.0")
+--   DEBUG          - accepted but ignored; all logging goes to stderr
+--
+-- Local extension (not part of the upstream contract):
+--   TEST_MODE      - "ping" (default) or "gossipsub"
 module Main (main) where
 
 import Control.Concurrent (threadDelay, forkIO, newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM (atomically, writeTVar)
+import Control.Monad (forever, join, void)
 import Data.Aeson (object, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Char8 as BS8
@@ -72,19 +79,23 @@ import System.Environment (lookupEnv)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (hFlush, hPutStrLn, stderr, stdout)
 import System.Timeout (timeout)
+import Text.Printf (printf)
+
+-- | The runner kills containers itself; this bounds Redis polling and
+-- local gossipsub waits.
+testTimeoutSeconds :: Int
+testTimeoutSeconds = 180
 
 main :: IO ()
 main = do
-  -- Read environment variables
-  transport <- getEnvRequired "transport"
-  security  <- getEnvRequired "security"
-  muxer     <- getEnvRequired "muxer"
-  isDialer  <- getEnvRequired "is_dialer"
-  ip        <- fromMaybe "0.0.0.0" <$> lookupEnv "ip"
-  redisAddr <- fromMaybe "redis:6379" <$> lookupEnv "redis_addr"
-  timeoutS  <- maybe 180 read <$> lookupEnv "test_timeout_seconds"
-
-  testMode  <- fromMaybe "ping" <$> lookupEnv "test_mode"
+  isDialer  <- getEnvRequired "IS_DIALER"
+  redisAddr <- fromMaybe "redis:6379" <$> lookupEnv "REDIS_ADDR"
+  testKey   <- getEnvRequired "TEST_KEY"
+  transport <- getEnvRequired "TRANSPORT"
+  security  <- lookupEnv "SECURE_CHANNEL"
+  muxer     <- lookupEnv "MUXER"
+  ip        <- fromMaybe "0.0.0.0" <$> lookupEnv "LISTENER_IP"
+  testMode  <- fromMaybe "ping" <$> lookupEnv "TEST_MODE"
 
   -- Validate supported protocols
   case validateProtocols transport security muxer of
@@ -92,6 +103,8 @@ main = do
       hPutStrLn stderr $ "Unsupported configuration: " ++ err
       exitFailure
     Right () -> pure ()
+
+  let addrKey = BS8.pack (testKey ++ "_listener_multiaddr")
 
   -- Generate identity
   ekp <- generateKeyPair
@@ -116,85 +129,44 @@ main = do
             }
       redisConn <- Redis.checkedConnect redisConnInfo
 
-      case testMode of
-        "gossipsub" -> case isDialer of
-          "false" -> runGossipSubListener sw pid ip redisConn timeoutS
-          "true"  -> runGossipSubDialer sw pid redisConn timeoutS
-          other   -> do
-            hPutStrLn stderr $ "Invalid is_dialer value: " ++ other
-            switchClose sw
-            exitFailure
-        _ -> do
-          registerPingHandler sw
-          case isDialer of
-            "false" -> runListener sw pid ip redisConn timeoutS
-            "true"  -> runDialer sw pid redisConn timeoutS
-            other   -> do
-              hPutStrLn stderr $ "Invalid is_dialer value: " ++ other
-              switchClose sw
-              exitFailure
-
--- | Listener mode: bind, publish address to Redis, wait.
-runListener :: Switch -> PeerId -> String -> Redis.Connection -> Int -> IO ()
-runListener sw pid ip redisConn timeoutS = do
-  let bindAddr = case fromText (T.pack ("/ip4/" ++ ip ++ "/tcp/0")) of
-        Right ma -> ma
-        Left err -> error $ "Invalid bind address: " ++ err
-
-  addrs <- switchListen sw defaultConnectionGater [bindAddr]
-  case addrs of
-    [] -> do
-      hPutStrLn stderr "switchListen returned no addresses"
-      switchClose sw
-      exitFailure
-    (listenAddr : _) -> do
-      -- Resolve actual IP if bound to 0.0.0.0
-      actualAddr <- resolveListenAddr listenAddr ip
-
-      -- Construct full multiaddr with /p2p/<peerId>
-      let peerIdMH = peerIdBytes pid
-      let fullAddr = encapsulateP2P actualAddr peerIdMH
-      let addrText = toText fullAddr
-
-      logInfo $ "Listening on: " ++ T.unpack addrText
-
-      -- Publish to Redis
-      let addrBS = TE.encodeUtf8 addrText
-      result <- Redis.runRedis redisConn $ Redis.rpush "listenerAddr" [addrBS]
-      case result of
-        Left err -> do
-          hPutStrLn stderr $ "Redis RPUSH failed: " ++ show err
-          switchClose sw
-          exitFailure
-        Right _ -> do
-          logInfo "Address published to Redis, waiting..."
-          -- The test runner kills this process once the dialer finishes.
-          -- Reaching the timeout means we were never successfully dialed,
-          -- which is a test failure (transport-interop README, Listener step 5).
-          threadDelay (timeoutS * 1000000)
-          hPutStrLn stderr "Listener timed out waiting to be dialed"
+      dialer <- case isDialer of
+        "true"  -> pure True
+        "false" -> pure False
+        other   -> do
+          hPutStrLn stderr $ "Invalid IS_DIALER value: " ++ other
           switchClose sw
           exitFailure
 
--- | Dialer mode: get address from Redis, dial, ping, output JSON.
-runDialer :: Switch -> PeerId -> Redis.Connection -> Int -> IO ()
-runDialer sw _pid redisConn timeoutS = do
-  logInfo "Waiting for listener address from Redis..."
+      case (testMode, dialer) of
+        ("gossipsub", False) -> runGossipSubListener sw pid ip redisConn addrKey
+        ("gossipsub", True)  -> runGossipSubDialer sw pid redisConn addrKey
+        (_, False) -> registerPingHandler sw >> runListener sw pid ip redisConn addrKey
+        (_, True)  -> registerPingHandler sw >> runDialer sw pid redisConn addrKey
 
-  -- BLPOP with timeout
-  result <- Redis.runRedis redisConn $
-    Redis.blpop ["listenerAddr"] (fromIntegral timeoutS)
+-- | Listener mode: bind, publish address to Redis, run until Docker
+-- shuts the container down (transport contract, Listener step 5).
+runListener :: Switch -> PeerId -> String -> Redis.Connection -> BS8.ByteString -> IO ()
+runListener sw pid ip redisConn addrKey = do
+  addrText <- listenAndResolve sw pid ip
 
-  case result of
-    Left err -> do
-      hPutStrLn stderr $ "Redis BLPOP failed: " ++ show err
-      switchClose sw
-      exitFailure
-    Right Nothing -> do
+  logInfo $ "Listening on: " ++ T.unpack addrText
+
+  publishListenerAddr redisConn addrKey addrText
+  logInfo "Address published to Redis, waiting to be dialed..."
+  forever $ threadDelay 3600000000
+
+-- | Dialer mode: get address from Redis, dial, ping, output YAML.
+runDialer :: Switch -> PeerId -> Redis.Connection -> BS8.ByteString -> IO ()
+runDialer sw _pid redisConn addrKey = do
+  logInfo "Polling Redis for listener address..."
+
+  mAddr <- pollListenerAddr redisConn addrKey
+  case mAddr of
+    Nothing -> do
       hPutStrLn stderr "Timed out waiting for listener address"
       switchClose sw
       exitFailure
-    Right (Just (_key, addrBS)) -> do
+    Just addrBS -> do
       let addrText = TE.decodeUtf8 addrBS
       logInfo $ "Got listener address: " ++ T.unpack addrText
 
@@ -212,7 +184,7 @@ runDialer sw _pid redisConn timeoutS = do
             logInfo $ "Dialing peer: " ++ T.unpack (toBase58 remotePeerId)
 
             -- handshakeStartInstant, recorded before connecting
-            -- (transport-interop README, Dialer step 4).
+            -- (transport contract, Dialer step 4).
             t0 <- getCurrentTime
 
             dialResult <- dial sw remotePeerId [transportAddr]
@@ -222,8 +194,9 @@ runDialer sw _pid redisConn timeoutS = do
                 switchClose sw
                 exitFailure
               Right conn -> do
-                -- A single ping (README steps 5-6): its round-trip time is
-                -- pingRTT, and the total elapsed since t0 is handshakePlusOneRTT.
+                -- A single ping (contract steps 4-5): its round-trip time
+                -- is ping_rtt, and the total elapsed since t0 is
+                -- handshake_plus_one_rtt.
                 pingResult <- sendPing sw conn
                 t1 <- getCurrentTime
 
@@ -236,20 +209,18 @@ runDialer sw _pid redisConn timeoutS = do
                     let handshakePlusOneRTT = realToFrac (diffUTCTime t1 t0) * 1000 :: Double
                         pingRTTMs = realToFrac (pingRTT pr) * 1000 :: Double
 
-                    -- Output JSON (pingRTTMilllis triple-L is the upstream spelling)
-                    let jsonOutput = object
-                          [ "handshakePlusOneRTTMillis" .= handshakePlusOneRTT
-                          , "pingRTTMilllis" .= pingRTTMs
-                          ]
-                    LBS8.putStrLn (Aeson.encode jsonOutput)
+                    -- Results schema: YAML on stdout, stdout is used for
+                    -- nothing else (transport contract, Results Schema).
+                    printf "latency:\n  handshake_plus_one_rtt: %.3f\n  ping_rtt: %.3f\n  unit: ms\n"
+                      handshakePlusOneRTT pingRTTMs
                     hFlush stdout
 
                     switchClose sw
                     exitSuccess
 
 -- | GossipSub listener: join topic, wait for message, reply, report to Redis.
-runGossipSubListener :: Switch -> PeerId -> String -> Redis.Connection -> Int -> IO ()
-runGossipSubListener sw pid ip redisConn timeoutS = do
+runGossipSubListener :: Switch -> PeerId -> String -> Redis.Connection -> BS8.ByteString -> IO ()
+runGossipSubListener sw pid ip redisConn addrKey = do
   let gsParams = defaultGossipSubParams { paramHeartbeatInterval = 60.0 }
   gsNode <- newGossipSubNode sw gsParams
   startGossipSub gsNode
@@ -259,84 +230,61 @@ runGossipSubListener sw pid ip redisConn timeoutS = do
   atomically $ writeTVar (gsOnMessage (gsnRouter gsNode))
     (\topic msg -> putMVar msgMVar (topic, msgData msg))
 
-  let bindAddr = case fromText (T.pack ("/ip4/" ++ ip ++ "/tcp/0")) of
-        Right ma -> ma
-        Left err -> error $ "Invalid bind address: " ++ err
+  addrText <- listenAndResolve sw pid ip
+  logInfo $ "GossipSub listener on: " ++ T.unpack addrText
 
-  addrs <- switchListen sw defaultConnectionGater [bindAddr]
-  case addrs of
-    [] -> do
-      hPutStrLn stderr "switchListen returned no addresses"
+  publishListenerAddr redisConn addrKey addrText
+  logInfo "Address published to Redis"
+
+  -- Join topic
+  gossipJoin gsNode "interop-gossipsub-test"
+  logInfo "Joined topic interop-gossipsub-test"
+
+  -- Re-announce subscriptions to peers that connect after join.
+  -- onNewConnection should handle this but cross-impl timing
+  -- can cause the announcement to be lost.
+  _ <- forkIO $ reannounceLoop gsNode "interop-gossipsub-test" 10
+
+  -- Wait for message
+  mResult <- timeout (testTimeoutSeconds * 1000000) $ takeMVar msgMVar
+  case mResult of
+    Nothing -> do
+      hPutStrLn stderr "Timeout waiting for GossipSub message"
+      let jsonOutput = object
+            [ "gossipSubInterop" .= False
+            , "role" .= ("listener" :: T.Text)
+            , "error" .= ("timeout" :: T.Text)
+            ]
+      void $ Redis.runRedis redisConn $
+        Redis.rpush "gossipResult" [LBS.toStrict (Aeson.encode jsonOutput)]
       stopGossipSub gsNode; switchClose sw
       exitFailure
-    (listenAddr : _) -> do
-      actualAddr <- resolveListenAddr listenAddr ip
-      let peerIdMH = peerIdBytes pid
-      let fullAddr = encapsulateP2P actualAddr peerIdMH
-      let addrText = toText fullAddr
+    Just (_topic, msgBytes) -> do
+      let received = BS8.unpack msgBytes
+      logInfo $ "Received message: " ++ received
 
-      logInfo $ "GossipSub listener on: " ++ T.unpack addrText
+      -- Publish reply
+      threadDelay 500000  -- 0.5s for stability
+      let replyMsg = "hs-reply-to-" ++ received
+      gossipPublish gsNode "interop-gossipsub-test" (BS8.pack replyMsg)
+      logInfo $ "Published reply: " ++ replyMsg
 
-      -- Publish address to Redis
-      let addrBS = TE.encodeUtf8 addrText
-      result <- Redis.runRedis redisConn $ Redis.rpush "listenerAddr" [addrBS]
-      case result of
-        Left err -> do
-          hPutStrLn stderr $ "Redis RPUSH failed: " ++ show err
-          stopGossipSub gsNode; switchClose sw
-          exitFailure
-        Right _ -> do
-          logInfo "Address published to Redis"
+      let jsonOutput = object
+            [ "gossipSubInterop" .= True
+            , "role" .= ("listener" :: T.Text)
+            , "messageReceived" .= received
+            , "messageSent" .= replyMsg
+            ]
+      void $ Redis.runRedis redisConn $
+        Redis.rpush "gossipResult" [LBS.toStrict (Aeson.encode jsonOutput)]
 
-          -- Join topic
-          gossipJoin gsNode "interop-gossipsub-test"
-          logInfo "Joined topic interop-gossipsub-test"
-
-          -- Re-announce subscriptions to peers that connect after join.
-          -- onNewConnection should handle this but cross-impl timing
-          -- can cause the announcement to be lost.
-          _ <- forkIO $ reannounceLoop gsNode "interop-gossipsub-test" 10
-
-          -- Wait for message
-          mResult <- timeout (timeoutS * 1000000) $ takeMVar msgMVar
-          case mResult of
-            Nothing -> do
-              hPutStrLn stderr "Timeout waiting for GossipSub message"
-              let jsonOutput = object
-                    [ "gossipSubInterop" .= False
-                    , "role" .= ("listener" :: T.Text)
-                    , "error" .= ("timeout" :: T.Text)
-                    ]
-              void $ Redis.runRedis redisConn $
-                Redis.rpush "gossipResult" [LBS.toStrict (Aeson.encode jsonOutput)]
-              stopGossipSub gsNode; switchClose sw
-              exitFailure
-            Just (_topic, msgBytes) -> do
-              let received = BS8.unpack msgBytes
-              logInfo $ "Received message: " ++ received
-
-              -- Publish reply
-              threadDelay 500000  -- 0.5s for stability
-              let replyMsg = "hs-reply-to-" ++ received
-              gossipPublish gsNode "interop-gossipsub-test" (BS8.pack replyMsg)
-              logInfo $ "Published reply: " ++ replyMsg
-
-              let jsonOutput = object
-                    [ "gossipSubInterop" .= True
-                    , "role" .= ("listener" :: T.Text)
-                    , "messageReceived" .= received
-                    , "messageSent" .= replyMsg
-                    ]
-              void $ Redis.runRedis redisConn $
-                Redis.rpush "gossipResult" [LBS.toStrict (Aeson.encode jsonOutput)]
-
-              -- Keep alive briefly for reply delivery
-              threadDelay 3000000
-              stopGossipSub gsNode; switchClose sw
+      -- Keep alive briefly for reply delivery
+      threadDelay 3000000
+      stopGossipSub gsNode; switchClose sw
 
 -- | GossipSub dialer: connect, publish message, wait for reply, report JSON.
-runGossipSubDialer :: Switch -> PeerId -> Redis.Connection -> Int -> IO ()
-runGossipSubDialer sw _pid redisConn timeoutS = do
+runGossipSubDialer :: Switch -> PeerId -> Redis.Connection -> BS8.ByteString -> IO ()
+runGossipSubDialer sw _pid redisConn addrKey = do
   let gsParams = defaultGossipSubParams { paramHeartbeatInterval = 60.0 }
   gsNode <- newGossipSubNode sw gsParams
   startGossipSub gsNode
@@ -353,21 +301,15 @@ runGossipSubDialer sw _pid redisConn timeoutS = do
         else pure ()
     )
 
-  logInfo "GossipSub dialer: waiting for listener address from Redis..."
+  logInfo "GossipSub dialer: polling Redis for listener address..."
 
-  result <- Redis.runRedis redisConn $
-    Redis.blpop ["listenerAddr"] (fromIntegral timeoutS)
-
-  case result of
-    Left err -> do
-      hPutStrLn stderr $ "Redis BLPOP failed: " ++ show err
-      stopGossipSub gsNode; switchClose sw
-      exitFailure
-    Right Nothing -> do
+  mAddr <- pollListenerAddr redisConn addrKey
+  case mAddr of
+    Nothing -> do
       hPutStrLn stderr "Timed out waiting for listener address"
       stopGossipSub gsNode; switchClose sw
       exitFailure
-    Right (Just (_key, addrBS)) -> do
+    Just addrBS -> do
       let addrText = TE.decodeUtf8 addrBS
       logInfo $ "Got listener address: " ++ T.unpack addrText
 
@@ -409,7 +351,7 @@ runGossipSubDialer sw _pid redisConn timeoutS = do
                 logInfo $ "Published: " ++ BS8.unpack testMsg
 
                 -- Wait for reply
-                mResult <- timeout (timeoutS * 1000000) $ takeMVar msgMVar
+                mResult <- timeout (testTimeoutSeconds * 1000000) $ takeMVar msgMVar
                 t1 <- getCurrentTime
                 let roundTripMs = realToFrac (diffUTCTime t1 t0) * 1000 :: Double
 
@@ -445,6 +387,52 @@ runGossipSubDialer sw _pid redisConn timeoutS = do
                     stopGossipSub gsNode; switchClose sw
                     exitSuccess
 
+-- | Bind, resolve the non-localhost address, and return the full
+-- multiaddr (with /p2p/ suffix) as text.
+listenAndResolve :: Switch -> PeerId -> String -> IO T.Text
+listenAndResolve sw pid ip = do
+  let bindAddr = case fromText (T.pack ("/ip4/" ++ ip ++ "/tcp/0")) of
+        Right ma -> ma
+        Left err -> error $ "Invalid bind address: " ++ err
+
+  addrs <- switchListen sw defaultConnectionGater [bindAddr]
+  case addrs of
+    [] -> do
+      hPutStrLn stderr "switchListen returned no addresses"
+      switchClose sw
+      exitFailure
+    (listenAddr : _) -> do
+      -- Resolve actual IP if bound to 0.0.0.0
+      actualAddr <- resolveListenAddr listenAddr ip
+      let peerIdMH = peerIdBytes pid
+      let fullAddr = encapsulateP2P actualAddr peerIdMH
+      pure (toText fullAddr)
+
+-- | SET the listener multiaddr under the TEST_KEY-namespaced key.
+publishListenerAddr :: Redis.Connection -> BS8.ByteString -> T.Text -> IO ()
+publishListenerAddr redisConn addrKey addrText = do
+  result <- Redis.runRedis redisConn $ Redis.set addrKey (TE.encodeUtf8 addrText)
+  case result of
+    Left err -> do
+      hPutStrLn stderr $ "Redis SET failed: " ++ show err
+      exitFailure
+    Right _ -> pure ()
+
+-- | Poll GET on the listener-multiaddr key until it appears (dialer
+-- contract step 2). Returns Nothing on timeout or Redis error.
+pollListenerAddr :: Redis.Connection -> BS8.ByteString -> IO (Maybe BS8.ByteString)
+pollListenerAddr redisConn addrKey =
+  join <$> timeout (testTimeoutSeconds * 1000000) loop
+  where
+    loop = do
+      result <- Redis.runRedis redisConn $ Redis.get addrKey
+      case result of
+        Left err -> do
+          hPutStrLn stderr $ "Redis GET failed: " ++ show err
+          pure Nothing
+        Right (Just v) -> pure (Just v)
+        Right Nothing -> threadDelay 200000 >> loop
+
 -- | Periodically re-announce our topic subscription to all connected peers.
 -- Ensures cross-implementation peers that connect after we've joined the topic
 -- learn about our subscription even if the initial announcement is lost.
@@ -458,22 +446,22 @@ reannounceLoop gsNode topic iterations = go iterations
       gossipJoin gsNode topic
       go (n - 1)
 
--- | Discard the result of an IO action.
-void :: IO a -> IO ()
-void action = action >> pure ()
-
 -- | Validate that we support the requested protocol combination.
-validateProtocols :: String -> String -> String -> Either String ()
+-- SECURE_CHANNEL and MUXER are only set for non-standalone transports,
+-- which tcp is, so both are required here.
+validateProtocols :: String -> Maybe String -> Maybe String -> Either String ()
 validateProtocols transport security muxer = do
   case transport of
     "tcp" -> pure ()
     other -> Left $ "transport " ++ other ++ " not supported (only tcp)"
   case security of
-    "noise" -> pure ()
-    other -> Left $ "security " ++ other ++ " not supported (only noise)"
+    Just "noise" -> pure ()
+    Just other -> Left $ "secure channel " ++ other ++ " not supported (only noise)"
+    Nothing -> Left "SECURE_CHANNEL not set (required for tcp)"
   case muxer of
-    "yamux" -> pure ()
-    other -> Left $ "muxer " ++ other ++ " not supported (only yamux)"
+    Just "yamux" -> pure ()
+    Just other -> Left $ "muxer " ++ other ++ " not supported (only yamux)"
+    Nothing -> Left "MUXER not set (required for tcp)"
 
 -- | Parse "host:port" string.
 parseHostPort :: String -> (String, Int)

--- a/interop/Makefile
+++ b/interop/Makefile
@@ -1,5 +1,7 @@
-# Makefile for libp2p/test-plans multidim-interop integration.
-# Convention: each implementation provides image-name and build targets.
+# Makefile for local interop test runs.
+# libp2p-hs speaks the libp2p/unified-testing "modern" transport contract;
+# the go-libp2p cross tests go through the legacy key-translation shims
+# defined in docker-compose.cross.yml.
 
 IMAGE_NAME := libp2p-hs-interop
 
@@ -13,23 +15,23 @@ build: image
 
 # Self-test: hs listener + hs dialer
 self-test:
-	cd .. && docker compose up --build --abort-on-container-exit
+	cd .. && docker compose up --build --exit-code-from dialer redis listener dialer
 
-# Cross-test: go listener, hs dialer
+# Cross-test: go listener, hs dialer (key-translation shim starts via depends_on)
 cross-test-go-listener:
-	cd .. && docker compose -f docker-compose.cross.yml up --build go-listener hs-dialer redis --abort-on-container-exit
+	cd .. && docker compose -f docker-compose.cross.yml up --build --exit-code-from hs-dialer redis go-listener hs-dialer
 
-# Cross-test: hs listener, go dialer
+# Cross-test: hs listener, go dialer (key-translation shim starts via depends_on)
 cross-test-hs-listener:
-	cd .. && docker compose -f docker-compose.cross.yml up --build hs-listener go-dialer redis --abort-on-container-exit
+	cd .. && docker compose -f docker-compose.cross.yml up --build --exit-code-from go-dialer redis hs-listener go-dialer
 
 # GossipSub cross-test: rust listener, hs dialer
 cross-gossipsub-rust-listener:
-	cd .. && docker compose -f docker-compose.gossipsub.yml up --build rust-listener hs-dialer redis --abort-on-container-exit
+	cd .. && docker compose -f docker-compose.gossipsub.yml up --build --exit-code-from hs-dialer redis rust-listener hs-dialer
 
 # GossipSub cross-test: hs listener, rust dialer
 cross-gossipsub-hs-listener:
-	cd .. && docker compose -f docker-compose.gossipsub.yml up --build hs-listener rust-dialer redis --abort-on-container-exit
+	cd .. && docker compose -f docker-compose.gossipsub.yml up --build --exit-code-from rust-dialer redis hs-listener rust-dialer
 
 # GossipSub cross-test: both directions
 cross-gossipsub: cross-gossipsub-rust-listener cross-gossipsub-hs-listener

--- a/interop/RESULTS.md
+++ b/interop/RESULTS.md
@@ -1,6 +1,6 @@
 ---
 title: Transport-Interop Results
-last_updated: 2026-05-27
+last_updated: 2026-08-06
 tags:
   - interop
   - transport
@@ -15,6 +15,13 @@ This document records reproducible evidence that the `libp2p-interop` binary
 [libp2p/test-plans](https://github.com/libp2p/test-plans/tree/master/transport-interop)
 **ping** contract against go-libp2p, in both dialer and listener roles, over
 **TCP + Noise + Yamux**.
+
+> **Update (2026-08-06, issue #129):** `interop/Main.hs` has since been migrated
+> to the [libp2p/unified-testing](https://github.com/libp2p/unified-testing)
+> "modern" transport contract (uppercase env vars, `TEST_KEY`-namespaced Redis
+> keys, YAML results on stdout). The legacy-contract details below are kept as
+> a historical record of the original test-plans runs; the go-libp2p cross
+> tests now go through the key-translation shims in `docker-compose.cross.yml`.
 
 ## Environment
 

--- a/interop/rust-peer/src/main.rs
+++ b/interop/rust-peer/src/main.rs
@@ -18,9 +18,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_target(false)
         .init();
 
-    let is_dialer = env::var("is_dialer").unwrap_or_else(|_| "false".to_string()) == "true";
-    let redis_addr = env::var("redis_addr").unwrap_or_else(|_| "redis:6379".to_string());
+    let is_dialer = env::var("IS_DIALER").unwrap_or_else(|_| "false".to_string()) == "true";
+    let redis_addr = env::var("REDIS_ADDR").unwrap_or_else(|_| "redis:6379".to_string());
+    let test_key = env::var("TEST_KEY")?;
     let redis_url = format!("redis://{}/", redis_addr);
+    let addr_key = format!("{}_listener_multiaddr", test_key);
 
     // Generate Ed25519 keypair
     let local_key = identity::Keypair::generate_ed25519();
@@ -54,9 +56,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     swarm.behaviour_mut().subscribe(&topic)?;
 
     if is_dialer {
-        run_dialer(&mut swarm, &topic, &redis_url).await
+        run_dialer(&mut swarm, &topic, &redis_url, &addr_key).await
     } else {
-        run_listener(&mut swarm, &topic, &redis_url).await
+        run_listener(&mut swarm, &topic, &redis_url, &addr_key).await
     }
 }
 
@@ -64,6 +66,7 @@ async fn run_listener(
     swarm: &mut Swarm<gossipsub::Behaviour>,
     topic: &gossipsub::IdentTopic,
     redis_url: &str,
+    addr_key: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     swarm.listen_on("/ip4/0.0.0.0/tcp/0".parse()?)?;
 
@@ -94,7 +97,7 @@ async fn run_listener(
 
     let client = redis::Client::open(redis_url)?;
     let mut redis_conn = client.get_connection()?;
-    redis_conn.rpush::<_, _, ()>("listenerAddr", &full_addr)?;
+    redis_conn.set::<_, _, ()>(addr_key, &full_addr)?;
 
     // Wait for incoming messages — log all events for debugging
     let result = timeout(Duration::from_secs(60), async {
@@ -163,15 +166,24 @@ async fn run_dialer(
     swarm: &mut Swarm<gossipsub::Behaviour>,
     topic: &gossipsub::IdentTopic,
     redis_url: &str,
+    addr_key: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    eprintln!("Waiting for listener address from Redis...");
+    eprintln!("Polling Redis for listener address...");
 
     let client = redis::Client::open(redis_url)?;
     let mut redis_conn = client.get_connection()?;
 
-    // BLPOP for listener address
-    let result: Option<(String, String)> = redis_conn.blpop("listenerAddr", 60.0)?;
-    let (_key, addr_str) = result.ok_or("timeout waiting for listener address")?;
+    // Poll GET until the listener publishes its address (60s timeout)
+    let addr_str = timeout(Duration::from_secs(60), async {
+        loop {
+            if let Some(addr) = redis_conn.get::<_, Option<String>>(addr_key)? {
+                return Ok::<_, redis::RedisError>(addr);
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    })
+    .await
+    .map_err(|_| "timeout waiting for listener address")??;
     eprintln!("Got listener address: {addr_str}");
 
     let remote_addr: Multiaddr = addr_str.parse()?;


### PR DESCRIPTION
## Summary
- Adapt `interop/Main.hs` to the [libp2p/unified-testing transport test-app contract](https://github.com/libp2p/unified-testing/blob/master/docs/write-a-transport-test-app.md) ("modern" scheme): uppercase env vars (`IS_DIALER`, `REDIS_ADDR`, `TEST_KEY`, `TRANSPORT`, `SECURE_CHANNEL`, `MUXER`, `LISTENER_IP`), `TEST_KEY`-namespaced `<TEST_KEY>_listener_multiaddr` Redis string key with GET polling, YAML results on stdout, listener runs until the runner shuts it down.
- Add legacy↔modern key-translation shim services to `docker-compose.cross.yml` (the pinned go-libp2p peer still speaks the legacy test-plans contract), mirroring the Redis proxy unified-testing runs for legacy images. Dialers pull the shims in via `depends_on`, so CI/Makefile invocations are unchanged.
- Migrate `interop/rust-peer` (local gossipsub peer) to the same modern env var and key scheme.
- Factor shared compose env blocks into YAML anchors with `TEST_KEY` as a single source of truth per file.

## Why
Part of #129 — the app must conform to the upstream contract before the test app can be registered in `libp2p/unified-testing`'s `transport/images.yaml` (nim reference: libp2p/unified-testing#77). The follow-up upstream PR will reference this repo + the merge commit of this PR + the root `Dockerfile`, declaring `transports: [tcp], secureChannels: [noise], muxers: [yamux]`.

## Test plan
- [x] `cabal build libp2p-interop` and `cargo check` (rust-peer) pass
- [x] hs↔hs self-test end to end in Docker: dialer prints the contract YAML (`latency: {handshake_plus_one_rtt: 4.938, ping_rtt: 0.558, unit: ms}`) and exits 0
- [x] Both shim directions exercised against a live Redis (legacy RPUSH → modern GET, modern SET → legacy BLPOP)
- [ ] CI `Interop` workflow: hs↔go cross test in both directions (runs on this PR)